### PR TITLE
removed Xamarin.Android.Tools references to files in obj directory

### DIFF
--- a/build/projects/Xamarin.Android.Tools.csproj
+++ b/build/projects/Xamarin.Android.Tools.csproj
@@ -20,7 +20,8 @@
     <OutputPath>../lib/Debug\</OutputPath>
     <BaseIntermediateOutputPath>../obj/Debug/Xamarin.Android.Tools\</BaseIntermediateOutputPath>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -32,7 +33,8 @@
     <OutputPath>../lib/Release\</OutputPath>
     <BaseIntermediateOutputPath>../obj/Release/Xamarin.Android.Tools\</BaseIntermediateOutputPath>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -83,15 +85,6 @@
     </Compile>
     <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkWindows.cs">
       <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkWindows.cs</Link>
-    </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/obj/Debug/TemporaryGeneratedFile_036C0B5B-1481-4323-8D20-8F5ADCB23D92.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/obj/Debug/TemporaryGeneratedFile_036C0B5B-1481-4323-8D20-8F5ADCB23D92.cs</Link>
-    </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/obj/Debug/TemporaryGeneratedFile_5937a670-0e60-4077-877b-f7221da3dda1.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/obj/Debug/TemporaryGeneratedFile_5937a670-0e60-4077-877b-f7221da3dda1.cs</Link>
-    </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/obj/Debug/TemporaryGeneratedFile_E7A71F73-0F8D-4B9B-B56E-8E70B10BC5D3.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/obj/Debug/TemporaryGeneratedFile_E7A71F73-0F8D-4B9B-B56E-8E70B10BC5D3.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Xamarin.Android.Tools was contained files from obj directory. That prevented compilation thus I removed them. They were there by mistake anyway, I assume.