### PR TITLE
taking latest visual studio version, not oldest

### DIFF
--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -398,7 +398,7 @@ namespace MonoEmbeddinator4000
             if (vsSdks.Count == 0)
                 throw new Exception("Visual Studio SDK was not found on your system.");
 
-            var vsSdk = vsSdks.FirstOrDefault();
+            var vsSdk = vsSdks.LastOrDefault();
             var clBin = Path.GetFullPath(
                 Path.Combine(vsSdk.Directory, "..", "..", "VC", "bin", "cl.exe"));
 


### PR DESCRIPTION
Currently the oldest VS version is used for compilation instead of newest (latest).