### PR TITLE
[support] Fix creation of the NSAutoreleasePool

### DIFF
--- a/support/mono_embeddinator.c
+++ b/support/mono_embeddinator.c
@@ -68,7 +68,7 @@ id allocAndInitAutoreleasePool()
 {
     Class NSAutoreleasePoolClass = objc_getClass("NSAutoreleasePool");
     id pool = class_createInstance(NSAutoreleasePoolClass, 0);
-    return objc_msgSend(pool, sel_registerName("new"));
+    return objc_msgSend(pool, sel_registerName("init"));
 }
 
 void drainAutoreleasePool(id pool)


### PR DESCRIPTION
Current code crash like this:

2017-03-24 15:52:02.732 a.out[92593:125062863] -[NSAutoreleasePool new]: unrecognized selector sent to instance 0x7fa2d6512c50
2017-03-24 15:52:02.733 a.out[92593:125062863] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSAutoreleasePool new]: unrecognized selector sent to instance 0x7fa2d6512c50'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fffd1e10e7b __exceptionPreprocess + 171
	1   libobjc.A.dylib                     0x00007fffe6a0bcad objc_exception_throw + 48
	2   CoreFoundation                      0x00007fffd1e92cb4 -[NSObject(NSObject) doesNotRecognizeSelector:] + 132
	3   CoreFoundation                      0x00007fffd1d82fb5 ___forwarding___ + 1061
	4   CoreFoundation                      0x00007fffd1d82b08 _CF_forwarding_prep_0 + 120
	5   libproperties.dylib                 0x0000000106b6f5eb allocAndInitAutoreleasePool + 75
	6   libproperties.dylib                 0x0000000106b6f6b7 mono_m2n_init + 119
	7   a.out                               0x0000000106b64eb0 main + 64
	8   libdyld.dylib                       0x0000000107169255 start + 1
)
libc++abi.dylib: terminating with uncaught exception of type NSException
Stacktrace:

Native stacktrace:

	0   libmonosgen-2.0.1.dylib             0x0000000106c47d6a mono_handle_native_sigsegv + 282
	1   libsystem_platform.dylib            0x00007fffe74fcbba _sigtramp + 26
	2   ???                                 0x00000003f011f240 0x0 + 16912609856
	3   libsystem_c.dylib                   0x00007fffe7383420 abort + 129
	4   libc++abi.dylib                     0x00007fffe5ede85a __cxa_bad_cast + 0
	5   libc++abi.dylib                     0x00007fffe5f03c4f _ZL26default_unexpected_handlerv + 0
	6   libobjc.A.dylib                     0x00007fffe6a0df1e _ZL15_objc_terminatev + 103
	7   libc++abi.dylib                     0x00007fffe5f00d69 _ZSt11__terminatePFvvE + 8
	8   libc++abi.dylib                     0x00007fffe5f007de _ZN10__cxxabiv1L22exception_cleanup_funcE19_Unwind_Reason_CodeP17_Unwind_Exception + 0
	9   libobjc.A.dylib                     0x00007fffe6a0bdd6 objc_exception_throw + 345
	10  CoreFoundation                      0x00007fffd1e92cb4 -[NSObject(NSObject) doesNotRecognizeSelector:] + 132
	11  CoreFoundation                      0x00007fffd1d82fb5 ___forwarding___ + 1061
	12  CoreFoundation                      0x00007fffd1d82b08 _CF_forwarding_prep_0 + 120
	13  libproperties.dylib                 0x0000000106b6f5eb allocAndInitAutoreleasePool + 75
	14  libproperties.dylib                 0x0000000106b6f6b7 mono_m2n_init + 119
	15  a.out                               0x0000000106b64eb0 main + 64
	16  libdyld.dylib                       0x0000000107169255 start + 1

`new` is a static method, but the class is already [alloc]ated
by `class_createInstance`. Simply calling "init" is enough.