### PR TITLE
[generators] Rework namespaces support

### DIFF
--- a/binder/Generators/C/CSources.cs
+++ b/binder/Generators/C/CSources.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using CppSharp;
 using CppSharp.AST;
 using CppSharp.AST.Extensions;
@@ -151,11 +152,15 @@ namespace MonoEmbeddinator4000.Generators
                 assemblyName.Replace('.', '_')));
             WriteLine("{0}();", assemblyLookupId);
 
-            var namespaces = Declaration.GatherNamespaces(@class.Namespace).ToList();
-            namespaces.Reverse();
-            namespaces.Remove(namespaces.First());
+            StringBuilder @namespace = new StringBuilder ();
+            foreach (var ns in Declaration.GatherNamespaces (@class.Namespace)) {
+                if (ns is TranslationUnit)
+                    continue;
+                if (@namespace.Length > 0)
+                    @namespace.Append ('.');
+                @namespace.Append (ns.LogicalName);
+            }
 
-            var @namespace = string.Join(".", namespaces);
             var ids = string.Join(", ",
                 @class.QualifiedName.Split('.').Select(n => string.Format("\"{0}\"", n)));
 


### PR DESCRIPTION
It seems the order of the elements returned from `Declaration.
GatherNamespaces` can vary, so removing the `First` element can
be wrong (leading to an incorrect.missing namespace), crashing
the app (since the class won't be found).

Replace this with a loop that exclude the `TranslationUnit` (a
subclass of `Namespace`) and use a `StringBuilder` to minimize
allocations.