### PR TITLE
[objc] Generate better code for class properties

### DIFF
--- a/binder/Generators/ObjC/ObjCHeaders.cs
+++ b/binder/Generators/ObjC/ObjCHeaders.cs
@@ -44,7 +44,7 @@ namespace MonoEmbeddinator4000.Generators
         public override void GenerateMethodSignature(Method method,
             bool isSource)
         {
-            this.GenerateObjCMethodSignature(method);
+            this.GenerateObjCMethodSignature(method, headers: true);
         }
 
         public override bool VisitClassDecl(Class @class)

--- a/binder/Generators/ObjC/ObjCSources.cs
+++ b/binder/Generators/ObjC/ObjCSources.cs
@@ -21,7 +21,7 @@ namespace MonoEmbeddinator4000.Generators
         public override void GenerateMethodSignature(Method method,
             bool isSource)
         {
-            this.GenerateObjCMethodSignature(method);
+            this.GenerateObjCMethodSignature(method, headers: false);
         }
 
         public override string GenerateClassObjectAlloc(string type)


### PR DESCRIPTION
The following C# code

```
public static class Platform {
	public static bool IsWindows { get { ... } }
}
```

is presently generated (headers) as

```
@interface Platform : NSObject {
    @public MonoEmbedObject* _object;
}

+ (bool)get_IsWindows;
@end
```

which is valid, but awkward looking for objc developers. It is not a class property (like it is in C#) and the `get_` prefix is not expected (nor pretty) for the caller, e.g.

```
NSLog (@"%s", [Platform get_IsWindows] ? "[FAIL]" : "[PASS]");
```

With this PR we generate:

```
@interface Platform : NSObject {
    @public MonoEmbedObject* _object;
}

@property (nonatomic, class, readonly) bool isWindows;
@end
```

which can be called with

```
NSLog (@"%s", [Platform isWindows] ? "[FAIL]" : "[PASS]");
```