### PR TITLE
[generator][perf] Cache MonoMethod for 3-4x faster calls. Fixes issue #27

### DIFF
--- a/binder/Generators/C/CSources.cs
+++ b/binder/Generators/C/CSources.cs
@@ -54,10 +54,17 @@ namespace MonoEmbeddinator4000.Generators
 
             GenerateObjectDeclarations();
 
-            GenerateMonoInitialization();
-            GenerateAssemblyLoad();
+            GenerateGlobalMethods ();
 
             VisitDeclContext(Unit);
+        }
+
+        public virtual void GenerateGlobalMethods ()
+        {
+            GenerateMonoInitialization ();
+            GenerateAssemblyLoad ();
+            GenerateMethodLookup ();
+            GenerateMethodExceptionThrown ();
         }
 
         public override bool VisitEnumDecl(Enumeration @enum)
@@ -130,6 +137,44 @@ namespace MonoEmbeddinator4000.Generators
             PopBlock(NewLineKind.BeforeNextBlock);
         }
 
+        public void GenerateMethodLookup ()
+        {
+            PushBlock ();
+            WriteLine ("static MonoMethod* __method_lookup (const char* method_name, MonoClass *klass)");
+            WriteStartBraceIndent ();
+
+            WriteLine ("MonoMethodDesc* desc = mono_method_desc_new (method_name, /*include_namespace=*/true);");
+            WriteLine ("MonoMethod* method = mono_method_desc_search_in_class (desc, klass);");
+            WriteLine ("mono_method_desc_free (desc);");
+
+            WriteLine ("if (!method)");
+            WriteStartBraceIndent ();
+            WriteLine ("mono_m2n_error_t error;");
+            WriteLine ("error.type = MONO_M2N_METHOD_LOOKUP_FAILED;");
+            WriteLine ("error.string = method_name;");
+            WriteLine ("mono_m2n_error (error);");
+            WriteCloseBraceIndent ();
+
+            WriteLine ("return method;");
+            WriteCloseBraceIndent ();
+            PopBlock (NewLineKind.BeforeNextBlock);
+        }
+
+        public void GenerateMethodExceptionThrown ()
+        {
+            PushBlock ();
+            WriteLine ("static void __method_exception_thrown (MonoObject *exception)");
+            WriteStartBraceIndent ();
+
+            WriteLine ("mono_m2n_error_t error;");
+            WriteLine ("error.type = MONO_M2N_EXCEPTION_THROWN;");
+            WriteLine ("error.exception = (MonoException*) exception;");
+            WriteLine ("mono_m2n_error (error);");
+
+            WriteCloseBraceIndent ();
+            PopBlock (NewLineKind.BeforeNextBlock);
+        }
+
         public void GenerateClassLookup(Class @class)
         {
             PushBlock();
@@ -172,33 +217,16 @@ namespace MonoEmbeddinator4000.Generators
         {
             var methodNameId = GeneratedIdentifier("method_name");
             WriteLine("const char {0}[] = \"{1}\";", methodNameId, method.OriginalName);
-            var descId = GeneratedIdentifier("desc");
-
-            WriteLine("MonoMethodDesc* {0} = mono_method_desc_new({1}, /*include_namespace=*/true);",
-                descId, methodNameId);
 
             var methodId = GeneratedIdentifier("method");
+            WriteLine ($"static MonoMethod *{methodId} = 0;");
 
             var @class = method.Namespace as Class;
             var classId = string.Format("{0}_class", @class.QualifiedName);
-
-            WriteLine("MonoMethod* {0} = mono_method_desc_search_in_class({1}, {2});",
-                methodId, descId, classId);
-
-            WriteLine("mono_method_desc_free({0});", descId);
-
             var retType = method.ReturnType;
 
             WriteLine("if ({0} == 0)", methodId);
-            WriteStartBraceIndent();
-
-            var errorId = GeneratedIdentifier("error");
-            WriteLine("mono_m2n_error_t {0};", errorId);
-            WriteLine("{0}.type = MONO_M2N_METHOD_LOOKUP_FAILED;", errorId);
-            WriteLine("{0}.string = {1};", errorId, methodNameId);
-            WriteLine("mono_m2n_error({0});", errorId);
-
-            WriteCloseBraceIndent();
+            WriteLineIndent ($"{methodId} = __method_lookup ({methodNameId}, {classId});");
         }
 
         public static string GetMonoObjectField(DriverOptions options, string @object, string field)
@@ -285,13 +313,7 @@ namespace MonoEmbeddinator4000.Generators
                 methodId, instanceId, argsId, exceptionId);
 
             WriteLine("if ({0} != 0)", exceptionId);
-            WriteStartBraceIndent();
-            var errorId = GeneratedIdentifier("error");
-            WriteLine("mono_m2n_error_t {0};", errorId);
-            WriteLine("{0}.type = MONO_M2N_EXCEPTION_THROWN;", errorId);
-            WriteLine("{0}.exception = (MonoException*) {1};", errorId, exceptionId);
-            WriteLine("mono_m2n_error({0});", errorId);
-            WriteCloseBraceIndent();
+            WriteLineIndent ($"__method_exception_thrown ({exceptionId});");
 
             foreach (var marshalContext in contexts)
             {


### PR DESCRIPTION
* Reduce generated code duplication to handle error condition (size);
* Cache MonoMethod for reuse (performance)

reference:
https://github.com/mono/Embeddinator-4000/issues/27

Running this

```

int main (int argc, const char * argv[])
{
	@autoreleasepool {
		int counter = argc == 1 ? 1000000 : atoi (argv [0]);

		for (int i = 0; i < counter; i++) {
			assert (![Platform isWindows]);
		}
	}
	return 0;
}
```

is very slow:

```
clang perf-test.m -lproperties -L. -framework Foundation
time ./a.out
        0.93 real         0.87 user         0.04 sys
```

due to the fact that the `MonoMethod` is not cached, see generated code:

```
+ (bool)isWindows
{
    __lookup_class_Platform();
    const char __method_name[] = "Platform:get_IsWindows()";
    MonoMethodDesc* __desc = mono_method_desc_new(__method_name, /*include_namespace=*/true);
    MonoMethod* __method = mono_method_desc_search_in_class(__desc, Platform_class);
    mono_method_desc_free(__desc);
    if (__method == 0)
    {
        mono_m2n_error_t __error;
        __error.type = MONO_M2N_METHOD_LOOKUP_FAILED;
        __error.string = __method_name;
        mono_m2n_error(__error);
    }
    MonoObject* __exception = 0;
    MonoObject* __result;
    __result = mono_runtime_invoke(__method, 0, 0, &__exception);
    if (__exception != 0)
    {
        mono_m2n_error_t __error;
        __error.type = MONO_M2N_EXCEPTION_THROWN;
        __error.exception = (MonoException*) __exception;
        mono_m2n_error(__error);
    }
    void* __unbox = mono_object_unbox(__result);
    return *((bool*)__unbox);
}

@end
```

Moving (sharing) the initialization code (less code) and caching the `MonoMethod` like this:

```
+ (bool)isWindows
{
    const char __method_name[] = "Platform:get_IsWindows()";
    static MonoMethod* __method = nil;

    if (!__method)
    {
        __lookup_class_Platform();
        __method = __method_lookup (__method_name, Platform_class);

    }
    MonoObject* __exception = 0;
    MonoObject* __result;
    __result = mono_runtime_invoke (__method, 0, 0, &__exception);
    if (__exception)
        __method_exception_thrown (__exception);
    void* __unbox = mono_object_unbox(__result);
    return *((bool*)__unbox);
}
```

is a lot faster.

```
clang perf-test.m -lproperties -L. -framework Foundation
time ./a.out
        0.23 real         0.19 user         0.02 sys
```