### PR TITLE
[objc] Add xcode support for objc-cli to build the libmanaged.dylib and it's unit tests

### DIFF
--- a/support/mono_embeddinator.c
+++ b/support/mono_embeddinator.c
@@ -119,8 +119,17 @@ int mono_embeddinator_destroy(mono_embeddinator_context_t* ctx)
     return true;
 }
 
+static GString* path_override = NULL;
+
+void mono_embeddinator_set_assembly_path (const char *path)
+{
+	path_override = g_string_new (path);
+}
+
 static GString* get_current_executable_path()
 {
+    if (path_override)
+        return path_override;
 #if defined(__APPLE__)
     int ret;
     pid_t pid; 

--- a/support/mono_embeddinator.h
+++ b/support/mono_embeddinator.h
@@ -100,6 +100,12 @@ int mono_embeddinator_destroy(mono_embeddinator_context_t* ctx);
 MONO_EMBEDDINATOR_API
 mono_embeddinator_context_t* mono_embeddinator_get_context();
 
+/**
+ * Override the default path (current executable) where assemblies will be loaded.
+ */
+MONO_EMBEDDINATOR_API
+void mono_embeddinator_set_assembly_path (const char *path);
+
 /** 
  * Sets the current context.
  */

--- a/tests/objc-cli/.gitignore
+++ b/tests/objc-cli/.gitignore
@@ -1,0 +1,24 @@
+glib.c
+glib.h
+mono_embeddinator.c
+mono_embeddinator.h
+perf-cli
+test-cli
+# Xcode
+.DS_Store
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
+xcuserdata
+profile
+*.moved-aside
+DerivedData
+.idea/

--- a/tests/objc-cli/libmanaged/Tests/Info.plist
+++ b/tests/objc-cli/libmanaged/Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -1,0 +1,55 @@
+#import <XCTest/XCTest.h>
+#include "bindings.h"
+#include "mono_embeddinator.h"
+
+@interface Tests : XCTestCase
+
+@end
+
+@implementation Tests
+
++ (void)setUp {
+	[super setUp];
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"managed" ofType:@"dll"];
+	mono_embeddinator_set_assembly_path ([path UTF8String]);
+}
+
+- (void)setUp {
+	[super setUp];
+}
+
+- (void)tearDown {
+	[super tearDown];
+}
+
+- (void)testProperties {
+	XCTAssertFalse ([Platform isWindows], "static class property getter only");
+	XCTAssert ([Platform exitCode] == 0, "static class property getter");
+
+	Platform.exitCode = 255;
+	XCTAssert ([Platform exitCode] == 255, "static class property setter check");
+	
+/*	XCTAssert ([Properties_Query universalAnswer] == 42, "static property getter only");
+	
+	Properties_Query* query = [[Properties_Query alloc] init];
+	XCTAssertTrue ([query isGood], "instance property getter only 1");
+	XCTAssertFalse ([query isBad], "instance property getter only 2");
+	XCTAssert ([query answer] == 42, "instance property getter");
+	query.answer = 911;
+	XCTAssert ([query answer] == 911, "instance property setter check");*/
+}
+
+- (void)testStaticCallPerformance {
+	const int iterations = 1000000;
+	[self measureBlock:^{
+		int n = 0;
+		for (int i = 0; i < iterations; i++) {
+			if ([Platform isWindows])
+				++n;
+		}
+		XCTAssert (n == 0);
+	}];
+}
+
+@end

--- a/tests/objc-cli/libmanaged/libmanaged.xcodeproj/project.pbxproj
+++ b/tests/objc-cli/libmanaged/libmanaged.xcodeproj/project.pbxproj
@@ -1,0 +1,422 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D1B0CD821E904EA6008FF17D /* managed.dll in Resources */ = {isa = PBXBuildFile; fileRef = D1B0CD801E904EA6008FF17D /* managed.dll */; };
+		D1B0CD831E904EA6008FF17D /* managed.pdb in Resources */ = {isa = PBXBuildFile; fileRef = D1B0CD811E904EA6008FF17D /* managed.pdb */; };
+		D1E2B2221E8F4FBB00846AF8 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = D1E2B2211E8F4FBB00846AF8 /* Tests.m */; };
+		D1E2B2241E8F4FBB00846AF8 /* liblibmanaged.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D1E2B20F1E8F4F9100846AF8 /* liblibmanaged.dylib */; };
+		D1E2B2301E8F509E00846AF8 /* bindings.h in Headers */ = {isa = PBXBuildFile; fileRef = D1E2B22A1E8F509E00846AF8 /* bindings.h */; };
+		D1E2B2311E8F509E00846AF8 /* bindings.m in Sources */ = {isa = PBXBuildFile; fileRef = D1E2B22B1E8F509E00846AF8 /* bindings.m */; };
+		D1E2B2321E8F509E00846AF8 /* glib.c in Sources */ = {isa = PBXBuildFile; fileRef = D1E2B22C1E8F509E00846AF8 /* glib.c */; };
+		D1E2B2331E8F509E00846AF8 /* glib.h in Headers */ = {isa = PBXBuildFile; fileRef = D1E2B22D1E8F509E00846AF8 /* glib.h */; };
+		D1E2B2341E8F509E00846AF8 /* mono_embeddinator.c in Sources */ = {isa = PBXBuildFile; fileRef = D1E2B22E1E8F509E00846AF8 /* mono_embeddinator.c */; };
+		D1E2B2351E8F509E00846AF8 /* mono_embeddinator.h in Headers */ = {isa = PBXBuildFile; fileRef = D1E2B22F1E8F509E00846AF8 /* mono_embeddinator.h */; };
+		D1E2B2371E8F510700846AF8 /* libmonosgen-2.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D1E2B2361E8F510700846AF8 /* libmonosgen-2.0.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		D1E2B2251E8F4FBB00846AF8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D1E2B2071E8F4F9100846AF8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D1E2B20E1E8F4F9100846AF8;
+			remoteInfo = libmanaged;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		D1B0CD801E904EA6008FF17D /* managed.dll */ = {isa = PBXFileReference; lastKnownFileType = file; name = managed.dll; path = ../../../managed/bin/Debug/managed.dll; sourceTree = "<group>"; };
+		D1B0CD811E904EA6008FF17D /* managed.pdb */ = {isa = PBXFileReference; lastKnownFileType = file; name = managed.pdb; path = ../../../managed/bin/Debug/managed.pdb; sourceTree = "<group>"; };
+		D1E2B20F1E8F4F9100846AF8 /* liblibmanaged.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = liblibmanaged.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		D1E2B21F1E8F4FBB00846AF8 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D1E2B2211E8F4FBB00846AF8 /* Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
+		D1E2B2231E8F4FBB00846AF8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D1E2B22A1E8F509E00846AF8 /* bindings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bindings.h; path = ../../bindings.h; sourceTree = "<group>"; };
+		D1E2B22B1E8F509E00846AF8 /* bindings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = bindings.m; path = ../../bindings.m; sourceTree = "<group>"; };
+		D1E2B22C1E8F509E00846AF8 /* glib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = glib.c; path = ../../glib.c; sourceTree = "<group>"; };
+		D1E2B22D1E8F509E00846AF8 /* glib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = glib.h; path = ../../glib.h; sourceTree = "<group>"; };
+		D1E2B22E1E8F509E00846AF8 /* mono_embeddinator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = mono_embeddinator.c; path = ../../mono_embeddinator.c; sourceTree = "<group>"; };
+		D1E2B22F1E8F509E00846AF8 /* mono_embeddinator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mono_embeddinator.h; path = ../../mono_embeddinator.h; sourceTree = "<group>"; };
+		D1E2B2361E8F510700846AF8 /* libmonosgen-2.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmonosgen-2.0.a"; path = "/Library/Frameworks/Mono.framework/Versions/5.0.0/lib/libmonosgen-2.0.a"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D1E2B20C1E8F4F9100846AF8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1E2B2371E8F510700846AF8 /* libmonosgen-2.0.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1E2B21C1E8F4FBB00846AF8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1E2B2241E8F4FBB00846AF8 /* liblibmanaged.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D1E2B2061E8F4F9100846AF8 = {
+			isa = PBXGroup;
+			children = (
+				D1E2B2111E8F4F9100846AF8 /* libmanaged */,
+				D1E2B2201E8F4FBB00846AF8 /* Tests */,
+				D1E2B2101E8F4F9100846AF8 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		D1E2B2101E8F4F9100846AF8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D1E2B20F1E8F4F9100846AF8 /* liblibmanaged.dylib */,
+				D1E2B21F1E8F4FBB00846AF8 /* Tests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D1E2B2111E8F4F9100846AF8 /* libmanaged */ = {
+			isa = PBXGroup;
+			children = (
+				D1E2B2361E8F510700846AF8 /* libmonosgen-2.0.a */,
+				D1E2B22A1E8F509E00846AF8 /* bindings.h */,
+				D1E2B22B1E8F509E00846AF8 /* bindings.m */,
+				D1E2B22C1E8F509E00846AF8 /* glib.c */,
+				D1E2B22D1E8F509E00846AF8 /* glib.h */,
+				D1E2B22E1E8F509E00846AF8 /* mono_embeddinator.c */,
+				D1E2B22F1E8F509E00846AF8 /* mono_embeddinator.h */,
+			);
+			path = libmanaged;
+			sourceTree = "<group>";
+		};
+		D1E2B2201E8F4FBB00846AF8 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				D1B0CD801E904EA6008FF17D /* managed.dll */,
+				D1B0CD811E904EA6008FF17D /* managed.pdb */,
+				D1E2B2211E8F4FBB00846AF8 /* Tests.m */,
+				D1E2B2231E8F4FBB00846AF8 /* Info.plist */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		D1E2B20D1E8F4F9100846AF8 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1E2B2301E8F509E00846AF8 /* bindings.h in Headers */,
+				D1E2B2331E8F509E00846AF8 /* glib.h in Headers */,
+				D1E2B2351E8F509E00846AF8 /* mono_embeddinator.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		D1E2B20E1E8F4F9100846AF8 /* libmanaged */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D1E2B2181E8F4F9100846AF8 /* Build configuration list for PBXNativeTarget "libmanaged" */;
+			buildPhases = (
+				D1E2B20B1E8F4F9100846AF8 /* Sources */,
+				D1E2B20C1E8F4F9100846AF8 /* Frameworks */,
+				D1E2B20D1E8F4F9100846AF8 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = libmanaged;
+			productName = libmanaged;
+			productReference = D1E2B20F1E8F4F9100846AF8 /* liblibmanaged.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		D1E2B21E1E8F4FBB00846AF8 /* Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D1E2B2271E8F4FBB00846AF8 /* Build configuration list for PBXNativeTarget "Tests" */;
+			buildPhases = (
+				D1E2B21B1E8F4FBB00846AF8 /* Sources */,
+				D1E2B21C1E8F4FBB00846AF8 /* Frameworks */,
+				D1E2B21D1E8F4FBB00846AF8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D1E2B2261E8F4FBB00846AF8 /* PBXTargetDependency */,
+			);
+			name = Tests;
+			productName = Tests;
+			productReference = D1E2B21F1E8F4FBB00846AF8 /* Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D1E2B2071E8F4F9100846AF8 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0830;
+				ORGANIZATIONNAME = "Sebastien Pouliot";
+				TargetAttributes = {
+					D1E2B20E1E8F4F9100846AF8 = {
+						CreatedOnToolsVersion = 8.3;
+						ProvisioningStyle = Automatic;
+					};
+					D1E2B21E1E8F4FBB00846AF8 = {
+						CreatedOnToolsVersion = 8.3;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = D1E2B20A1E8F4F9100846AF8 /* Build configuration list for PBXProject "libmanaged" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = D1E2B2061E8F4F9100846AF8;
+			productRefGroup = D1E2B2101E8F4F9100846AF8 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D1E2B20E1E8F4F9100846AF8 /* libmanaged */,
+				D1E2B21E1E8F4FBB00846AF8 /* Tests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D1E2B21D1E8F4FBB00846AF8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1B0CD831E904EA6008FF17D /* managed.pdb in Resources */,
+				D1B0CD821E904EA6008FF17D /* managed.dll in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D1E2B20B1E8F4F9100846AF8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1E2B2321E8F509E00846AF8 /* glib.c in Sources */,
+				D1E2B2341E8F509E00846AF8 /* mono_embeddinator.c in Sources */,
+				D1E2B2311E8F509E00846AF8 /* bindings.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1E2B21B1E8F4FBB00846AF8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1E2B2221E8F4FBB00846AF8 /* Tests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		D1E2B2261E8F4FBB00846AF8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D1E2B20E1E8F4F9100846AF8 /* libmanaged */;
+			targetProxy = D1E2B2251E8F4FBB00846AF8 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		D1E2B2161E8F4F9100846AF8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		D1E2B2171E8F4F9100846AF8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		D1E2B2191E8F4F9100846AF8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				EXECUTABLE_PREFIX = lib;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks/Mono.framework/Versions/5.0.0/lib",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_HEADER_SEARCH_PATHS = "/Library/Frameworks/Mono.framework/Versions/Current/include/mono-2.0";
+				USER_HEADER_SEARCH_PATHS = "";
+			};
+			name = Debug;
+		};
+		D1E2B21A1E8F4F9100846AF8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				EXECUTABLE_PREFIX = lib;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks/Mono.framework/Versions/5.0.0/lib",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_HEADER_SEARCH_PATHS = "/Library/Frameworks/Mono.framework/Versions/Current/include/mono-2.0";
+				USER_HEADER_SEARCH_PATHS = "";
+			};
+			name = Release;
+		};
+		D1E2B2281E8F4FBB00846AF8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.xamarin.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				USER_HEADER_SEARCH_PATHS = "/Library/Frameworks/Mono.framework/Versions/Current/include/mono-2.0/**";
+			};
+			name = Debug;
+		};
+		D1E2B2291E8F4FBB00846AF8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.xamarin.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				USER_HEADER_SEARCH_PATHS = "/Library/Frameworks/Mono.framework/Versions/Current/include/mono-2.0/**";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D1E2B20A1E8F4F9100846AF8 /* Build configuration list for PBXProject "libmanaged" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D1E2B2161E8F4F9100846AF8 /* Debug */,
+				D1E2B2171E8F4F9100846AF8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D1E2B2181E8F4F9100846AF8 /* Build configuration list for PBXNativeTarget "libmanaged" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D1E2B2191E8F4F9100846AF8 /* Debug */,
+				D1E2B21A1E8F4F9100846AF8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D1E2B2271E8F4FBB00846AF8 /* Build configuration list for PBXNativeTarget "Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D1E2B2281E8F4FBB00846AF8 /* Debug */,
+				D1E2B2291E8F4FBB00846AF8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D1E2B2071E8F4F9100846AF8 /* Project object */;
+}


### PR DESCRIPTION
This allows debugging the generated code with Xcode as well as
running the native unit tests with XCTest (which might not be the
best tool but it's good to support).

This commit requires a addition to mono_embeddinator so we can
override where the assemblies are loaded from - we cannot assume
they will be with the executable (e.g. plugin) and we hit this
case with Xcode unit tests.