### PR TITLE
[objc] Enforce ARC.

### DIFF
--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -146,6 +146,7 @@ namespace Embeddinator {
 			StringBuilder options = new StringBuilder ("clang ");
 			if (debug)
 				options.Append ("-g -O0 ");
+			options.Append ("-fobjc-arc ");
 			options.Append ("-DMONO_EMBEDDINATOR_DLL_EXPORT ");
 			options.Append ("-framework CoreFoundation ");
 			options.Append ("-framework Foundation ");

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -50,6 +50,11 @@ namespace ObjC {
 			headers.WriteLine ("#include \"mono_embeddinator.h\"");
 			headers.WriteLine ("#import <Foundation/Foundation.h>");
 			headers.WriteLine ();
+			headers.WriteLine ();
+			headers.WriteLine ("#if !__has_feature(objc_arc)");
+			headers.WriteLine ("#error Embeddinator code must be built with ARC.");
+			headers.WriteLine ("#endif");
+			headers.WriteLine ();
 			headers.WriteLine ("MONO_EMBEDDINATOR_BEGIN_DECLS");
 			headers.WriteLine ();
 
@@ -314,7 +319,7 @@ namespace ObjC {
 				implementation.WriteLine ("\t\treturn NULL;");
 				implementation.WriteLine ("\tint length = mono_string_length ((MonoString *) __result);");
 				implementation.WriteLine ("\tgunichar2 *str = mono_string_chars ((MonoString *) __result);");
-				implementation.WriteLine ("\treturn [[[NSString alloc] initWithBytes: str length: length * 2 encoding: NSUTF16LittleEndianStringEncoding] autorelease];");
+				implementation.WriteLine ("\treturn [[NSString alloc] initWithBytes: str length: length * 2 encoding: NSUTF16LittleEndianStringEncoding];");
 				break;
 			case TypeCode.Boolean:
 			case TypeCode.Char:

--- a/support/mono_embeddinator.c
+++ b/support/mono_embeddinator.c
@@ -66,23 +66,6 @@ void mono_embeddinator_set_context(mono_embeddinator_context_t* ctx)
     _current_context = ctx;
 }
 
-#if defined(__OBJC__)
-static id alloc_and_init_autorelease_pool()
-{
-    Class NSAutoreleasePoolClass = objc_getClass("NSAutoreleasePool");
-    id pool = class_createInstance(NSAutoreleasePoolClass, 0);
-    return objc_msgSend(pool, sel_registerName("init"));
-}
-
-static void drain_autorelease_pool(id pool)
-{
-    (void)objc_msgSend(pool, sel_registerName("drain"));
-}
-
-#define AUTORELEASE_POOL_DEFAULT_VALUE ((id)-1)
-static id _autorelease_pool = AUTORELEASE_POOL_DEFAULT_VALUE;
-#endif
-
 int mono_embeddinator_init(mono_embeddinator_context_t* ctx, const char* domain)
 {
     if (ctx == 0 || ctx->domain != 0)
@@ -93,11 +76,6 @@ int mono_embeddinator_init(mono_embeddinator_context_t* ctx, const char* domain)
 
     mono_embeddinator_set_context(ctx);
 
-#if defined(__OBJC__)
-    if (_autorelease_pool == AUTORELEASE_POOL_DEFAULT_VALUE)
-        _autorelease_pool = alloc_and_init_autorelease_pool();
-#endif
-
     return true;
 }
 
@@ -107,14 +85,6 @@ int mono_embeddinator_destroy(mono_embeddinator_context_t* ctx)
         return false;
 
     mono_jit_cleanup (ctx->domain);
-
-#if defined(__OBJC__)
-    if (_autorelease_pool != AUTORELEASE_POOL_DEFAULT_VALUE)
-    {
-        drain_autorelease_pool(_autorelease_pool);
-        _autorelease_pool = AUTORELEASE_POOL_DEFAULT_VALUE;
-    }
-#endif
 
     return true;
 }

--- a/tests/objc-cli/Makefile
+++ b/tests/objc-cli/Makefile
@@ -11,13 +11,13 @@ libmanaged.dylib: managed.dll
 	/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono --debug ../../objcgen/bin/Debug/objcgen.exe --debug managed.dll -c
 
 test: libmanaged.dylib
-	clang test-managed.m -lmanaged -L. -framework Foundation -o test-cli -rpath @executable_path
+	clang test-managed.m -lmanaged -L. -framework Foundation -o test-cli -rpath @executable_path -fobjc-arc
 
 run-test: test
 	./test-cli
 	
 perf: libmanaged.dylib
-	clang perf-test.m -lmanaged -L. -framework Foundation -o perf-cli -rpath @executable_path
+	clang perf-test.m -lmanaged -L. -framework Foundation -o perf-cli -rpath @executable_path -fobjc-arc
 	time ./perf-cli
 
 clean:


### PR DESCRIPTION
Also remove the NSAutoreleasePool code, the current code doesn't build with ARC,
and in any case it's the consumer's responsibility to ensure there's an
NSAutoreleasePool on the stack.