### PR TITLE
[objc][generator] Fix subclassing when both types are bound

### DIFF
--- a/tests/managed/constructors.cs
+++ b/tests/managed/constructors.cs
@@ -26,6 +26,18 @@ namespace Constructors {
 		public int Id { get; private set; }
 	}
 
+	public class SuperUnique : Unique {
+
+		public SuperUnique () : base (411)
+		{
+		}
+
+		// note: SuperUnique (int id) {} is NOT exposed on purpose - which means it's not available in C#
+		// objc: `init*` are inherited, so it's legal to call `new SuperUnique (42)` because `Unique` as such a .ctor
+
+		// note: `public int Id { get; } should be usable on this type (by inheritance)
+	}
+
 	public class Implicit {
 
 		// default ctor is implicit (in C#) and must be generated

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -67,6 +67,13 @@
 
 	id unique_init_id = [[Constructors_Unique alloc] initWithId:911];
 	XCTAssert ([unique_init_id id] == 911, "id");
+
+	id super_unique_default_init = [[Constructors_SuperUnique alloc] init];
+	XCTAssert ([super_unique_default_init id] == 411, "super id");
+
+	// FIXME - this should not be allowed, that .ctor is not available to call in .NET as it is not re-declared in SuperUnique
+	id super_unique_init_id = [[Constructors_SuperUnique alloc] initWithId:42];
+	XCTAssert ([super_unique_init_id id] == 42, "id");
 	
 	Constructors_Implicit* implicit = [[Constructors_Implicit alloc] init];
 	XCTAssertEqualObjects (@"OK", [implicit testResult], "implicit");


### PR DESCRIPTION
E.g. `public class SuperUnique : Unique {}`

This raise an interesting issue (to be solved later) since ObjC and .NET
semantics differs for init*/.ctor. A test case (with a FIXME) is added.

and I now recall why headers were a bad idea:

./bindings.h:75:39: error: attempting to use the forward class 'Constructors_Unique' as superclass of 'Constructors_SuperUnique'

so the ordering of forwarders had to be altered a bit.