### PR TITLE
[objc] Initial support for methods

### DIFF
--- a/objcgen/generator.cs
+++ b/objcgen/generator.cs
@@ -35,6 +35,10 @@ namespace Embeddinator {
 		{
 		}
 
+		protected virtual void Generate (MethodInfo mi)
+		{
+		}
+
 		public virtual void Write (string outputDirectory)
 		{
 		}

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -16,8 +16,11 @@ namespace ObjC {
 		static TextWriter headers = new StringWriter ();
 		static TextWriter implementation = new StringWriter ();
 
+		static ParameterInfo [] NoParameters = new ParameterInfo [0];
+
 		List<Type> types = new List<Type> ();
 		Dictionary<Type, List<ConstructorInfo>> ctors = new Dictionary<Type, List<ConstructorInfo>> ();
+		Dictionary<Type, List<MethodInfo>> methods = new Dictionary<Type, List<MethodInfo>> ();
 		Dictionary<Type, List<PropertyInfo>> properties = new Dictionary<Type, List<PropertyInfo>> ();
 
 		public override void Process (IEnumerable<Assembly> assemblies)
@@ -41,10 +44,25 @@ namespace ObjC {
 					constructors = constructors.OrderBy ((arg) => arg.ParameterCount).ToList ();
 					ctors.Add (t, constructors);
 
+					var meths = new List<MethodInfo> ();
+					foreach (var mi in t.GetMethods (BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)) {
+						meths.Add (mi);
+					}
+					methods.Add (t, meths);
+
 					var props = new List<PropertyInfo> ();
 					foreach (var pi in t.GetProperties (BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)) {
+						var getter = pi.GetGetMethod ();
+						var setter = pi.GetSetMethod ();
+						// setter only property are valid in .NET and we need to generate a method in ObjC (there's no writeonly properties)
+						if (getter == null)
+							continue;
+						// we can do better than methods for the more common cases (readonly and readwrite)
+						meths.Remove (getter);
+						meths.Remove (setter);
 						props.Add (pi);
 					}
+					props = props.OrderBy ((arg) => arg.Name).ToList ();
 					properties.Add (t, props);
 				}
 			}
@@ -243,6 +261,15 @@ namespace ObjC {
 			if (properties.TryGetValue (t, out props)) {
 				foreach (var pi in props)
 					Generate (pi);
+				headers.WriteLine ();
+			}
+
+			headers.WriteLine ();
+			List<MethodInfo> meths;
+			if (methods.TryGetValue (t, out meths)) {
+				foreach (var mi in meths)
+					Generate (mi);
+				headers.WriteLine ();
 			}
 
 			headers.WriteLine ("@end");
@@ -256,11 +283,10 @@ namespace ObjC {
 		{
 			var getter = pi.GetGetMethod ();
 			var setter = pi.GetSetMethod ();
-			// FIXME: setter only is valid, even if discouraged, in .NET - we should create a SetX method
+			// setter-only properties are handled as methods (and should not reach this code)
 			if (getter == null && setter != null)
-				throw new NotImplementedException ("Write-only properties");
+				throw new EmbeddinatorException (99, "Internal error `setter only`. Please file a bug report with a test case (https://github.com/mono/Embeddinator-4000/issues");
 
-			// TODO override with attribute ? e.g. [ObjC.Selector ("foo")]
 			var name = CamelCase (pi.Name);
 
 			headers.Write ("@property (nonatomic");
@@ -274,53 +300,90 @@ namespace ObjC {
 			headers.WriteLine ($") {property_type} {name};");
 
 			var managed_type_name = pi.DeclaringType.Name;
-			implementation.Write (getter.IsStatic ? '+' : '-');
-			implementation.WriteLine ($" ({property_type}) {name}");
-			implementation.WriteLine ("{");
-			implementation.WriteLine ($"\tconst char __method_name [] = \"{managed_type_name}:{getter.Name}()\";");
-			implementation.WriteLine ("\tstatic MonoMethod* __method = nil;");
-			implementation.WriteLine ("\tif (!__method) {");
-			implementation.WriteLine ($"\t\t__lookup_class_{managed_type_name} ();");
-			implementation.WriteLine ($"\t\t__method = mono_embeddinator_lookup_method (__method_name, {managed_type_name}_class);");
-			implementation.WriteLine ("\t}");
-			implementation.WriteLine ("\tMonoObject* __exception = nil;");
-			var instance = "nil";
-			if (!getter.IsStatic) {
-				implementation.WriteLine ($"\t\tMonoObject* instance = mono_gchandle_get_target (_object->_handle);");
-				instance = "instance";
-			}
-			implementation.WriteLine ($"\tMonoObject* __result = mono_runtime_invoke (__method, {instance}, nil, &__exception);");
-			implementation.WriteLine ("\tif (__exception)");
-			implementation.WriteLine ("\t\tmono_embeddinator_throw_exception (__exception);");
-			ReturnValue (pi.PropertyType);
-			implementation.WriteLine ("}");
-			implementation.WriteLine ();
+
+			ImplementMethod (getter.IsStatic, getter.ReturnType, name, NoParameters, managed_type_name, getter.Name);
 			if (setter == null)
 				return;
-			
-			// TODO override with attribute ? e.g. [ObjC.Selector ("foo")]
-			implementation.Write (getter.IsStatic ? '+' : '-');
-			implementation.WriteLine ($" (void) set{pi.Name}:({property_type})value");
+
+			ImplementMethod (setter.IsStatic, setter.ReturnType, "set" + pi.Name, setter.GetParameters (), managed_type_name, setter.Name);
+		}
+
+		// TODO override with attribute ? e.g. [ObjC.Selector ("foo")]
+		void ImplementMethod (bool isStatic, Type returnType, string name, ParameterInfo [] parametersInfo, string managed_type_name, string managed_name)
+		{
+			var return_type = GetTypeName (returnType);
+			StringBuilder parameters = new StringBuilder ();
+			StringBuilder managed_parameters = new StringBuilder ();
+			foreach (var p in parametersInfo) {
+				if (parameters.Length > 0) {
+					parameters.Append (' ');
+					managed_parameters.Append (' ');
+				}
+				parameters.Append (":(").Append (GetTypeName (p.ParameterType)).Append (")").Append (p.Name);
+				managed_parameters.Append (GetMonoName (p.ParameterType));
+			}
+
+			implementation.Write (isStatic ? '+' : '-');
+			implementation.WriteLine ($" ({return_type}) {name}{parameters}");
 			implementation.WriteLine ("{");
-			implementation.WriteLine ($"\tconst char __method_name [] = \"{managed_type_name}:{setter.Name}({property_type})\";");
+			implementation.WriteLine ($"\tconst char __method_name [] = \"{managed_type_name}:{managed_name}({managed_parameters})\";");
 			implementation.WriteLine ("\tstatic MonoMethod* __method = nil;");
 			implementation.WriteLine ("\tif (!__method) {");
 			implementation.WriteLine ($"\t\t__lookup_class_{managed_type_name} ();");
 			implementation.WriteLine ($"\t\t__method = mono_embeddinator_lookup_method (__method_name, {managed_type_name}_class);");
 			implementation.WriteLine ("\t}");
-			implementation.WriteLine ("\tvoid* __args [1];");
-			implementation.WriteLine ("\t__args [0] = &value;");
+
+			var args = "nil";
+			if (parametersInfo.Length > 0) {
+				args = "__args";
+				implementation.WriteLine ($"\tvoid* __args [{parametersInfo.Length}];");
+				for (int i = 0; i < parametersInfo.Length; i++) {
+					implementation.WriteLine ($"\t__args [{i}] = &{parametersInfo [i].Name};");
+				}
+			}
+
 			implementation.WriteLine ("\tMonoObject* __exception = nil;");
-			instance = "nil";
-			if (!getter.IsStatic) {
-				implementation.WriteLine ($"\t\tMonoObject* instance = mono_gchandle_get_target (_object->_handle);");
+			var instance = "nil";
+			if (!isStatic) {
+				implementation.WriteLine ($"\tMonoObject* instance = mono_gchandle_get_target (_object->_handle);");
 				instance = "instance";
 			}
-			implementation.WriteLine ($"\tmono_runtime_invoke (__method, {instance}, __args, &__exception);");
+
+			implementation.Write ("\t");
+			if (!IsVoid (returnType))
+				implementation.Write ("MonoObject* __result = ");
+			implementation.WriteLine ($"mono_runtime_invoke (__method, {instance}, {args}, &__exception);");
+
 			implementation.WriteLine ("\tif (__exception)");
 			implementation.WriteLine ("\t\tmono_embeddinator_throw_exception (__exception);");
+			ReturnValue (returnType);
 			implementation.WriteLine ("}");
 			implementation.WriteLine ();
+		}
+
+		public static bool IsVoid (Type t)
+		{
+			if (t.Name != "Void")
+				return false;
+			return (t.Namespace == "System");
+		}
+
+		protected override void Generate (MethodInfo mi)
+		{
+			StringBuilder parameters = new StringBuilder ();
+			foreach (var p in mi.GetParameters ()) {
+				if (parameters.Length > 0)
+					parameters.Append (' ');
+				parameters.Append (":(").Append (GetTypeName (p.ParameterType)).Append (")").Append (p.Name);
+			}
+
+			var return_type = GetTypeName (mi.ReturnType);
+			var name = CamelCase (mi.Name);
+
+			headers.Write (mi.IsStatic ? '+' : '-');
+			headers.WriteLine ($" ({return_type}) {name}{parameters};");
+
+			ImplementMethod (mi.IsStatic, mi.ReturnType, name, mi.GetParameters (), mi.DeclaringType.Name, mi.Name);
 		}
 
 		void ReturnValue (Type t)
@@ -349,6 +412,10 @@ namespace ObjC {
 				implementation.WriteLine ("\tvoid* __unbox = mono_object_unbox (__result);");
 				implementation.WriteLine ($"\treturn *(({name}*)__unbox);");
 				break;
+			case TypeCode.Object:
+				if (t.Namespace == "System" && t.Name == "Void")
+					return;
+				goto default;
 			default:
 				throw new NotImplementedException ($"Returning type {t.Name} from native code");
 			}
@@ -372,7 +439,19 @@ namespace ObjC {
 		{
 			switch (Type.GetTypeCode (t)) {
 			case TypeCode.Object:
-				return (t.Namespace == "System" && t.Name == "Object") ? "NSObject" : t.FullName.Replace ('.', '_');
+				switch (t.Namespace) {
+				case "System":
+					switch (t.Name) {
+					case "Object":
+						return "NSObject";
+					case "Void":
+						return "void";
+					default:
+						return t.FullName.Replace ('.', '_');
+					}
+				default:
+					return t.FullName.Replace ('.', '_');
+				}
 			case TypeCode.Boolean:
 				return "bool";
 			case TypeCode.Char:
@@ -408,7 +487,19 @@ namespace ObjC {
 		{
 			switch (Type.GetTypeCode (t)) {
 			case TypeCode.Object:
-				throw new NotImplementedException ($"Converting type {t.Name} to a mono type name");
+				switch (t.Namespace) {
+				case "System":
+					switch (t.Name) {
+					case "Object":
+						return "object";
+					case "Void":
+						return "void";
+					default:
+						throw new NotImplementedException ($"Converting type {t.Name} to a mono type name");
+					}
+				default:
+					throw new NotImplementedException ($"Converting type {t.Name} to a mono type name");
+				}
 			case TypeCode.Boolean:
 				return "bool";
 			case TypeCode.Char:

--- a/tests/managed/properties.cs
+++ b/tests/managed/properties.cs
@@ -39,5 +39,16 @@ namespace Properties {
 		public bool IsBad { get; } = false;
 
 		public int Answer { get; set; } = UniversalAnswer;
+
+		int secret;
+
+		// setter only properties are valid (even if discouraged) in .net
+		public int Secret {
+			set { secret = value; }
+		}
+
+		public bool IsSecret {
+			get { return secret != 0; }
+		}
 	}
 }

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -38,17 +38,25 @@
 	XCTAssert ([query answer] == 42, "instance property getter");
 	query.answer = 911;
 	XCTAssert ([query answer] == 911, "instance property setter check");
+
+	XCTAssertFalse ([query isSecret], "instance property getter only 3");
+	// setter only property turned into method, so different syntax
+	[query set_Secret: 1];
+	XCTAssertTrue ([query isSecret], "instance property getter only 4");
 }
 
 - (void)testNamespaces {
 	id nonamespace = [[ClassWithoutNamespace alloc] init];
 	XCTAssertTrue ([[nonamespace description] containsString:@"<ClassWithoutNamespace:"], "nonamespace");
+	XCTAssertEqualObjects (@"ClassWithoutNamespace", [nonamespace toString], "nonamespace toString");
 	
 	id singlenamespace = [[First_ClassWithSingleNamespace alloc] init];
 	XCTAssertTrue ([[singlenamespace description] containsString:@"<First_ClassWithSingleNamespace:"], "singlenamespace");
+	XCTAssertEqualObjects (@"First.ClassWithSingleNamespace", [singlenamespace toString], "singlenamespace toString");
 	
 	id nestednamespaces = [[First_Second_ClassWithNestedNamespace alloc] init];
 	XCTAssertTrue ([[nestednamespaces description] containsString:@"<First_Second_ClassWithNestedNamespace:"], "nestednamespaces");
+	XCTAssertEqualObjects (@"First.Second.ClassWithNestedNamespace", [nestednamespaces toString], "nestednamespaces toString");
 }
 
 - (void)testExceptions {

--- a/tests/objcgentest/ObjCGeneratorTest.cs
+++ b/tests/objcgentest/ObjCGeneratorTest.cs
@@ -9,7 +9,11 @@ namespace ObjCGeneratorTest {
 	
 	[TestFixture]
 	public class Helpers {
-		
+
+		public static Universe Universe { get; } = new Universe (UniverseOptions.None);
+
+		public static Assembly mscorlib { get; } = Universe.Load ("mscorlib.dll");
+
 		[Test]
 		public void CamelCase ()
 		{
@@ -31,53 +35,54 @@ namespace ObjCGeneratorTest {
 		[Test]
 		public void TypeMatch ()
 		{
-			var universe = new Universe (UniverseOptions.None);
-			var asm = universe.Load ("mscorlib.dll");
-
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.Boolean")), Is.EqualTo ("bool"), "bool");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.Char")), Is.EqualTo ("unsigned short"), "char");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.SByte")), Is.EqualTo ("signed char"), "sbyte");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.Int16")), Is.EqualTo ("short"), "short");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.Int32")), Is.EqualTo ("int"), "int");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.Int64")), Is.EqualTo ("long long"), "long");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.Byte")), Is.EqualTo ("unsigned char"), "byte");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.UInt16")), Is.EqualTo ("unsigned short"), "ushort");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.UInt32")), Is.EqualTo ("unsigned int"), "uint");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.UInt64")), Is.EqualTo ("unsigned long long"), "ulong");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.Single")), Is.EqualTo ("float"), "float");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.Double")), Is.EqualTo ("double"), "double");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.String")), Is.EqualTo ("NSString*"), "string");
-			Assert.That (ObjCGenerator.GetTypeName (asm.GetType ("System.Object")), Is.EqualTo ("NSObject"), "object");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Boolean")), Is.EqualTo ("bool"), "bool");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Char")), Is.EqualTo ("unsigned short"), "char");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.SByte")), Is.EqualTo ("signed char"), "sbyte");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Int16")), Is.EqualTo ("short"), "short");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Int32")), Is.EqualTo ("int"), "int");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Int64")), Is.EqualTo ("long long"), "long");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Byte")), Is.EqualTo ("unsigned char"), "byte");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.UInt16")), Is.EqualTo ("unsigned short"), "ushort");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.UInt32")), Is.EqualTo ("unsigned int"), "uint");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.UInt64")), Is.EqualTo ("unsigned long long"), "ulong");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Single")), Is.EqualTo ("float"), "float");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Double")), Is.EqualTo ("double"), "double");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.String")), Is.EqualTo ("NSString*"), "string");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Object")), Is.EqualTo ("NSObject"), "object");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Void")), Is.EqualTo ("void"), "void");
 		}
 
 		[Test]
 		public void TypeMatchFailure ()
 		{
-			var universe = new Universe (UniverseOptions.None);
-			var asm = universe.Load ("mscorlib.dll");
-
-			Assert.Throws<NotImplementedException> (() => ObjCGenerator.GetTypeName (asm.GetType ("System.DateTime")), "DateTime");
+			Assert.Throws<NotImplementedException> (() => ObjCGenerator.GetTypeName (mscorlib.GetType ("System.DateTime")), "DateTime");
 		}
 
 		[Test]
 		public void MonoMatch ()
 		{
-			var universe = new Universe (UniverseOptions.None);
-			var asm = universe.Load ("mscorlib.dll");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.Boolean")), Is.EqualTo ("bool"), "bool");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.Char")), Is.EqualTo ("char"), "char");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.SByte")), Is.EqualTo ("sbyte"), "sbyte");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.Int16")), Is.EqualTo ("int16"), "short");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.Int32")), Is.EqualTo ("int"), "int");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.Int64")), Is.EqualTo ("long"), "long");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.Byte")), Is.EqualTo ("byte"), "byte");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.UInt16")), Is.EqualTo ("uint16"), "ushort");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.UInt32")), Is.EqualTo ("uint"), "uint");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.UInt64")), Is.EqualTo ("ulong"), "ulong");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.Single")), Is.EqualTo ("single"), "float");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.Double")), Is.EqualTo ("double"), "double");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.String")), Is.EqualTo ("string"), "string");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.Void")), Is.EqualTo ("void"), "void");
+			Assert.That (ObjCGenerator.GetMonoName (mscorlib.GetType ("System.Object")), Is.EqualTo ("object"), "object");
+		}
 
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.Boolean")), Is.EqualTo ("bool"), "bool");
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.Char")), Is.EqualTo ("char"), "char");
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.SByte")), Is.EqualTo ("sbyte"), "sbyte");
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.Int16")), Is.EqualTo ("int16"), "short");
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.Int32")), Is.EqualTo ("int"), "int");
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.Int64")), Is.EqualTo ("long"), "long");
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.Byte")), Is.EqualTo ("byte"), "byte");
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.UInt16")), Is.EqualTo ("uint16"), "ushort");
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.UInt32")), Is.EqualTo ("uint"), "uint");
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.UInt64")), Is.EqualTo ("ulong"), "ulong");
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.Single")), Is.EqualTo ("single"), "float");
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.Double")), Is.EqualTo ("double"), "double");
-			Assert.That (ObjCGenerator.GetMonoName (asm.GetType ("System.String")), Is.EqualTo ("string"), "string");
+		[Test]
+		public void IsVoid ()
+		{
+			Assert.True (ObjCGenerator.IsVoid (mscorlib.GetType ("System.Void")), "void");
+			Assert.False (ObjCGenerator.IsVoid (mscorlib.GetType ("System.Object")), "object");
 		}
 	}
 }


### PR DESCRIPTION
This also handle the case of setter-only properties (generated as a
set* method).

Unit tests added for existing methods (previously not generated)

Replace PR https://github.com/mono/Embeddinator-4000/pull/63