### PR TITLE
[test][objc] Fix Makefile not to delete leak-at-exit.c

### DIFF
--- a/tests/objc-cli/Makefile
+++ b/tests/objc-cli/Makefile
@@ -29,7 +29,7 @@ perf: perf-cli
 	time ./perf-cli
 
 clean:
-	@rm -f *.h *.c bindings.m *.dylib *.dll test-cli perf-cli
+	@rm -f *.h glib.c mono_embeddinator.c bindings.m *.dylib *.dll test-cli perf-cli
 
 xctest:
 	xcodebuild test -project libmanaged/*.xcodeproj -scheme Tests


### PR DESCRIPTION
That one is not a generated file