### PR TITLE
[objc] `mono_embeddinator_create_object` now calls `mono_gchandle_new`

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -255,7 +255,6 @@ namespace ObjC {
 					implementation.WriteLine ("\t\t\treturn nil;");
 					//implementation.WriteLine ("\t\t\tmono_embeddinator_throw_exception (__exception);");
 					implementation.WriteLine ("\t\t_object = mono_embeddinator_create_object (__instance);");
-					implementation.WriteLine ("\t\t_object->_handle = mono_gchandle_new (__instance, /*pinned=*/false);");
 					implementation.WriteLine ("\t}");
 					implementation.WriteLine ("\treturn self = [super init];");
 					implementation.WriteLine ("}");


### PR DESCRIPTION
So we need to remove our own call, which overwrites the original one.