### PR TITLE
[objc] Fix subclassing when `init` is not available

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -257,7 +257,10 @@ namespace ObjC {
 					implementation.WriteLine ("\t\t_object = mono_embeddinator_create_object (__instance);");
 					implementation.WriteLine ("\t\t_object->_handle = mono_gchandle_new (__instance, /*pinned=*/false);");
 					implementation.WriteLine ("\t}");
-					implementation.WriteLine ("\treturn self = [super init];");
+					if (types.Contains (t.BaseType))
+						implementation.WriteLine ("\treturn self = [super initForSuper];");
+					else
+						implementation.WriteLine ("\treturn self = [super init];");
 					implementation.WriteLine ("}");
 					implementation.WriteLine ();
 				}
@@ -268,6 +271,21 @@ namespace ObjC {
 				if (static_type)
 					headers.WriteLine ("// a .net static type cannot be initialized");
 				headers.WriteLine ("- (instancetype)init NS_UNAVAILABLE;");
+			}
+
+			// TODO we should re-use the base `init` when it exists
+			if (!static_type) {
+				headers.WriteLine ("- (instancetype)initForSuper;");
+
+				implementation.WriteLine ("// only when `init` is not generated and we have subclasses");
+				implementation.WriteLine ("- (instancetype) initForSuper {");
+				// calls super's initForSuper until we reach a non-generated type
+				if (types.Contains (t.BaseType))
+					implementation.WriteLine ("\treturn self = [super initForSuper];");
+				else
+					implementation.WriteLine ("\treturn self = [super init];");
+				implementation.WriteLine ("}");
+				implementation.WriteLine ();
 			}
 
 			headers.WriteLine ();
@@ -320,11 +338,22 @@ namespace ObjC {
 			ImplementMethod (setter.IsStatic, setter.ReturnType, "set" + pi.Name, setter.GetParameters (), pi.DeclaringType, setter.Name);
 		}
 
+		public string GetReturnType (Type declaringType, Type returnType)
+		{
+			if (declaringType == returnType)
+				return "instancetype";
+
+			var return_type = GetTypeName (returnType);
+			if (types.Contains (returnType))
+				return_type += "*";
+			return return_type;
+		}
+
 		// TODO override with attribute ? e.g. [ObjC.Selector ("foo")]
 		void ImplementMethod (bool isStatic, Type returnType, string name, ParameterInfo [] parametersInfo, Type type, string managed_name)
 		{
 			var managed_type_name = GetObjCName (type);
-			var return_type = GetTypeName (returnType);
+			var return_type = GetReturnType (type, returnType);
 			StringBuilder parameters = new StringBuilder ();
 			StringBuilder managed_parameters = new StringBuilder ();
 			foreach (var p in parametersInfo) {
@@ -390,7 +419,7 @@ namespace ObjC {
 				parameters.Append (":(").Append (GetTypeName (p.ParameterType)).Append (")").Append (p.Name);
 			}
 
-			var return_type = GetTypeName (mi.ReturnType);
+			var return_type = GetReturnType (mi.DeclaringType, mi.ReturnType);
 			var name = CamelCase (mi.Name);
 
 			headers.Write (mi.IsStatic ? '+' : '-');
@@ -428,7 +457,13 @@ namespace ObjC {
 			case TypeCode.Object:
 				if (t.Namespace == "System" && t.Name == "Void")
 					return;
-				goto default;
+				if (!types.Contains (t))
+					goto default;
+				// TODO: cheating by reusing `initForSuper` - maybe a better name is needed
+				implementation.WriteLine ($"\t{GetTypeName (t)}* __peer = [[{GetTypeName (t)} alloc] initForSuper];");
+				implementation.WriteLine ("\t__peer->_object = mono_embeddinator_create_object (__result);");
+				implementation.WriteLine ("\treturn __peer;");
+				break;
 			default:
 				throw new NotImplementedException ($"Returning type {t.Name} from native code");
 			}

--- a/tests/managed/exceptions.cs
+++ b/tests/managed/exceptions.cs
@@ -25,4 +25,23 @@ namespace Exceptions {
 			Console.WriteLine ("Should not be printed");
 		}
 	}
+
+	public class Base {
+
+		// no default .ctor
+		// objc: so no `init`
+
+		public Base (bool broken)
+		{
+			if (broken)
+				throw new Exception ();
+		}
+	}
+
+	public class Super : Base {
+		// some case won't work - we must take care not to leak in such cases
+		public Super (bool broken) : base (broken)
+		{
+		}
+	}
 }

--- a/tests/managed/managed.csproj
+++ b/tests/managed/managed.csproj
@@ -35,6 +35,7 @@
     <Compile Include="types.cs" />
     <Compile Include="exceptions.cs" />
     <Compile Include="constructors.cs" />
+    <Compile Include="methods.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/managed/methods.cs
+++ b/tests/managed/methods.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Methods {
+	
+	public class Static  {
+
+		// not exposed
+		private Static (int id)
+		{
+			Id = id;
+		}
+
+		public static Static Create (int id)
+		{
+			return new Static (id);
+		}
+
+		// to help test the method call was successful
+		// only getter will be generated
+		public int Id { get; private set; }
+	}
+}

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -71,6 +71,14 @@
 	// .cctor that throw - can't be called directly but it makes the type unusable
 	id static_thrower = [[Exceptions_ThrowInStaticCtor alloc] init];
 	XCTAssertNil (static_thrower, "Exceptions_ThrowInStaticCtor init");
+	
+	// .ctor chaining
+	id sup1 = [[Exceptions_Super alloc] initWithBroken:false];
+	XCTAssertNotNil (sup1, "not broken (as expected)");
+
+	// beside chaining this can detect (possible, it's fine) leaks (e.g. of CGHandle)
+	id sup2 = [[Exceptions_Super alloc] initWithBroken:true];
+	XCTAssertNil (sup2, "broken (exception thrown in managed code)");
 }
 
 - (void)testConstructors {
@@ -101,6 +109,11 @@
 
 	Constructors_AllTypeCode* all4 = [[Constructors_AllTypeCode alloc] initWithF32:FLT_MAX F64:DBL_MAX];
 	XCTAssertTrue ([all4 testResult], "all4");
+}
+
+- (void)testMethods {
+	id static_method = [Methods_Static create: 1];
+	XCTAssert ([static_method id] == 1, "create id");
 }
 
 - (void)testStaticCallPerformance {


### PR DESCRIPTION
It's similar to XI/XM NSObjectFlag - we need a different road to call
the base classes without calling managed code twice (e.g. the Super
and Base tests for exceptions).

Note: `init` is not always exposed, so we cannot trust it blindly.

This allow the same "internal" `initWithSuper` to be re-used to return
instance of types being bound (e.g. a `+create` without a `-init`).