### PR TITLE
[objc] Remove non-public information from header files and simplify runtime initialization

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -129,6 +129,7 @@ namespace ObjC {
 			implementation.WriteLine ("{");
 			implementation.WriteLine ($"\tif (__{name}_image)");
 			implementation.WriteLine ("\t\treturn;");
+			implementation.WriteLine ("\t__initialize_mono ();");
 			implementation.WriteLine ($"\t__{name}_image = mono_embeddinator_load_assembly (&__mono_context, \"{name}.dll\");");
 			implementation.WriteLine ($"\tassert (__{name}_image && \"Could not load the assembly '{name}.dll'.\");");
 			implementation.WriteLine ("}");
@@ -144,31 +145,30 @@ namespace ObjC {
 			var has_bound_base_class = types.Contains (t.BaseType);
 
 			var managed_name = GetObjCName (t);
-			implementation.WriteLine ($"static void __lookup_class_{managed_name} ()");
-			implementation.WriteLine ("{");
-			implementation.WriteLine ($"\tif (!{managed_name}_class) {{");
-			implementation.WriteLine ("\t\t__initialize_mono ();");
-			implementation.WriteLine ("\t\t__lookup_assembly_managed ();");
-			implementation.WriteLine ($"\t\t{managed_name}_class = mono_class_from_name (__{t.Assembly.GetName ().Name}_image, \"{t.Namespace}\", \"{t.Name}\");");
-			implementation.WriteLine ("\t}");
-			implementation.WriteLine ("}");
-			implementation.WriteLine ();
 
 			var native_name = GetTypeName (t);
 			headers.WriteLine ();
 			headers.WriteLine ($"// {t.AssemblyQualifiedName}");
-			headers.WriteLine ($"@interface {native_name} : {GetTypeName (t.BaseType)} {{");
-			// our internal field is only needed once in the type hierarchy
-			if (!types.Contains (t.BaseType))
-				headers.WriteLine ("\tMonoEmbedObject* _object;");
-			headers.WriteLine ("}");
-			if (!has_bound_base_class)
-				headers.WriteLine ("-(void) dealloc;");
+			headers.WriteLine ($"@interface {native_name} : {GetTypeName (t.BaseType)}");
 			headers.WriteLine ();
 
 			implementation.WriteLine ();
 			implementation.WriteLine ($"// {t.AssemblyQualifiedName}");
-			implementation.WriteLine ($"@implementation {native_name}");
+			implementation.WriteLine ($"@implementation {native_name} {{");
+			// our internal field is only needed once in the type hierarchy
+			if (!types.Contains (t.BaseType))
+				implementation.WriteLine ("\t@public MonoEmbedObject* _object;");
+			implementation.WriteLine ("}");
+			implementation.WriteLine ();
+
+			implementation.WriteLine ("+ (void) initialize");
+			implementation.WriteLine ("{");
+			implementation.WriteLine ($"\tif (self != [{managed_name} class])");
+			implementation.WriteLine ("\t\treturn;");
+			var aname = t.Assembly.GetName ().Name;
+			implementation.WriteLine ($"\t__lookup_assembly_{aname} ();");
+			implementation.WriteLine ($"\t{managed_name}_class = mono_class_from_name (__{aname}_image, \"{t.Namespace}\", \"{t.Name}\");");
+			implementation.WriteLine ("}");
 			implementation.WriteLine ();
 
 			if (!has_bound_base_class) {
@@ -213,7 +213,6 @@ namespace ObjC {
 					implementation.WriteLine ($"\tconst char __method_name [] = \"{t.FullName}:{signature}\";");
 					implementation.WriteLine ("\tstatic MonoMethod* __method = nil;");
 					implementation.WriteLine ("\tif (!__method) {");
-					implementation.WriteLine ($"\t\t__lookup_class_{managed_name} ();");
 					implementation.WriteLine ($"\t\t__method = mono_embeddinator_lookup_method (__method_name, {managed_name}_class);");
 					implementation.WriteLine ("\t}");
 					// TODO: this logic will need to be update for managed NSObject types (e.g. from XI / XM) not to call [super init]
@@ -342,7 +341,7 @@ namespace ObjC {
 			implementation.WriteLine ($"\tconst char __method_name [] = \"{type.FullName}:{managed_name}({managed_parameters})\";");
 			implementation.WriteLine ("\tstatic MonoMethod* __method = nil;");
 			implementation.WriteLine ("\tif (!__method) {");
-			implementation.WriteLine ($"\t\t__lookup_class_{managed_type_name} ();");
+			//implementation.WriteLine ($"\t\t__lookup_class_{managed_type_name} ();");
 			implementation.WriteLine ($"\t\t__method = mono_embeddinator_lookup_method (__method_name, {managed_type_name}_class);");
 			implementation.WriteLine ("\t}");
 


### PR DESCRIPTION
- Don't expose `MonoEmbedObject* _object;` in the public headers - it's
  not meant to be used outside the generated code (but make it @public);

- Don't expose `dealloc` in the headers - it's not meant to be called
  from public code;

- Call `__initialize_mono` when loading assembly image, not class - the
  later happens way more often;

- Drop `__lookup_class_*` functions in favor of `+initialize`;

- That makes it possible to remove the `__lookup_class_*` call from methods;