### PR TITLE
[objc][README] Recommend usage of objcgen.exe instead of MonoEmbeddinator4000.exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Open the solution in `build/MonoEmbeddinator4000.sln` with Visual Studio or Xama
 
 To generate bindings for a managed library you invoke the `MonoEmbeddinator4000.exe` command line tool.
 
+_Important: please follow the instructions in `objcgen`'s [README](https://github.com/mono/Embeddinator-4000/blob/objc/objcgen/README.md) to use the new and improved Objective-C generator (will eventually fusion with `MonoEmbeddinator4000.exe`._
+
 If you do not pass any arguments, you will get a list of the tool options:
 
 ```

--- a/objcgen/README.md
+++ b/objcgen/README.md
@@ -1,5 +1,15 @@
 # ObjC generator
 
+## Build
+
+Simply run `make` in `Embeddinator-4000/objcgen`.
+
+## Run
+
+Don't use `MonoEmbeddinator4000.exe`.
+
+Use `mono ./bin/Debug/objcgen.exe --gen=Obj-C -o ./Output ManagedAssembly1.dll`.
+
 ## Generated API of questionable usability
 
 Whenever we generate a working API that is not optimal (in ObjC) we should update the `docs/BestPracticesObjC.md` document to explain the situation and provide guidance to get the best ObjC API output.


### PR DESCRIPTION
objcgen.exe has to be used in order to try the new generator (with the latest fixes).