### PR TITLE
[objc][generator] Update type/pointer spacing to follow ObjC conventions

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -523,7 +523,7 @@ namespace ObjC {
 			case TypeCode.UInt64:
 				return "unsigned long long";
 			case TypeCode.String:
-				return "NSString*";
+				return "NSString *";
 			default:
 				throw new NotImplementedException ($"Converting type {t.Name} to a native type name");
 			}

--- a/tests/objcgentest/ObjCGeneratorTest.cs
+++ b/tests/objcgentest/ObjCGeneratorTest.cs
@@ -47,7 +47,7 @@ namespace ObjCGeneratorTest {
 			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.UInt64")), Is.EqualTo ("unsigned long long"), "ulong");
 			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Single")), Is.EqualTo ("float"), "float");
 			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Double")), Is.EqualTo ("double"), "double");
-			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.String")), Is.EqualTo ("NSString*"), "string");
+			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.String")), Is.EqualTo ("NSString *"), "string");
 			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Object")), Is.EqualTo ("NSObject"), "object");
 			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Void")), Is.EqualTo ("void"), "void");
 		}


### PR DESCRIPTION
The convention is that there's a space between the type and the pointer character (*) in Objective-C.
See: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingMethods.html#//apple_ref/doc/uid/20001282-BCIGIJJF
_Note: Apple's frameworks are using this convention too._