### PR TITLE
[objc] Disable the `new` selector when no `init` is available

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -281,6 +281,7 @@ namespace ObjC {
 				if (static_type)
 					headers.WriteLine ("// a .net static type cannot be initialized");
 				headers.WriteLine ("- (instancetype)init NS_UNAVAILABLE;");
+				headers.WriteLine ("+ (instancetype)new NS_UNAVAILABLE;");
 			}
 
 			// TODO we should re-use the base `init` when it exists


### PR DESCRIPTION
We currently disable the `init` ctor when is not needed i.e. static
classes in .NET but we should also disable the `new` static selector
since you could do `[foo new]` and get an instance.