### PR TITLE
[objc] Avoid objc ctor inheritance. Fixes issue #72

### DIFF
--- a/docs/ObjC.md
+++ b/docs/ObjC.md
@@ -11,3 +11,46 @@ The use of Automatic Reference Counting (ARC) is **required** to call the genera
 ### NSString support
 
 API that expose `System.String` types are converted into `NSString`. This makes memory management easier than dealing with `char*`.
+
+## Main differences with .NET
+
+### Constructors v.s. Initializers
+
+In Objective-C, you can call any of the initializer prototypes of any of the parent classes in the inheritance chain unless it is marked as unavailable (NS_UNAVAILABLE).
+
+In C# you must explicitly declare a constructor member inside a class, this means constructors are not inherited.
+
+In order to expose the right representation of the C# API to Objective-C, we add `NS_UNAVAILABLE` to any initializer that is not present in the child class from the parent class.
+
+C# API:
+
+```csharp
+public class Unique {
+	public Unique () : this (1)
+	{
+	}
+
+	public Unique (int id)
+	{
+	}
+}
+
+public class SuperUnique : Unique {
+	public SuperUnique () : base (911)
+	{
+	}
+}
+```
+
+Objective-C surfaced API:
+
+```objectivec
+@interface SuperUnique : Unique
+
+- (instancetype)initWithId:(int)id NS_UNAVAILABLE;
+- (instancetype)init;
+
+@end
+```
+
+Here we can see that `initWithId:` has been marked as unavailable.

--- a/objcgen/objcgen.csproj
+++ b/objcgen/objcgen.csproj
@@ -306,6 +306,7 @@
     <Compile Include="error.cs" />
     <Compile Include="ErrorHelper.cs" />
     <Compile Include="Version.generated.cs" />
+    <Compile Include="objcgenerator-helpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="support\" />

--- a/objcgen/objcgenerator-helpers.cs
+++ b/objcgen/objcgenerator-helpers.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using IKVM.Reflection;
+using Type = IKVM.Reflection.Type;
+
+using Embeddinator;
+namespace ObjC {
+	public partial class ObjCGenerator {
+
+		// get a name that is safe to use from ObjC code
+		public static string GetObjCName (Type t)
+		{
+			return t.FullName.Replace ('.', '_');
+		}
+
+		void GetSignatures (string objName, string monoName, MemberInfo info, ParameterInfo [] parameters, out string objcSignature, out string monoSignature)
+		{
+			var method = (info as MethodBase); // else it's a PropertyInfo
+			// special case for setter-only - the underscore looks ugly
+			if ((method != null) && method.IsSpecialName)
+				objName = objName.Replace ("_", String.Empty);
+			StringBuilder objc = new StringBuilder (objName);
+			var mono = new StringBuilder (monoName);
+			mono.Append ('(');
+			int n = 0;
+			foreach (var p in parameters) {
+				if (objc.Length > objName.Length) {
+					objc.Append (' ');
+					mono.Append (',');
+				}
+				if (method != null) {
+					if (n == 0) {
+						if (method.IsConstructor || !method.IsSpecialName)
+							objc.Append (PascalCase (p.Name));
+					} else
+						objc.Append (p.Name.ToLowerInvariant ());
+				}
+				objc.Append (":(").Append (GetTypeName (p.ParameterType)).Append (") ").Append (p.Name);
+				mono.Append (GetMonoName (p.ParameterType));
+				n++;
+			}
+			mono.Append (')');
+
+			objcSignature = objc.ToString ();
+			monoSignature = mono.ToString ();
+		}
+
+		public IEnumerable<ConstructorInfo> GetUnavailableParentCtors (Type type, List<ConstructorInfo> typeCtors)
+		{
+			var baseType = type.BaseType;
+			if (baseType.Namespace == "System" && baseType.Name == "Object")
+				return Enumerable.Empty<ConstructorInfo> ();
+
+			List<ConstructorInfo> parentCtors;
+			if (!ctors.TryGetValue (baseType, out parentCtors))
+				return Enumerable.Empty<ConstructorInfo> ();
+
+			var finalList = new List<ConstructorInfo> ();
+			foreach (var pctor in parentCtors) {
+				var pctorParams = pctor.GetParameters ();
+				foreach (var ctor in typeCtors) {
+					var ctorParams = ctor.GetParameters ();
+					if (pctorParams.Any (pc => !ctorParams.Any (p => p.Position == pc.Position && pc.ParameterType == p.ParameterType))) {
+						finalList.Add (pctor);
+						break;
+					}
+				}
+			}
+
+			return finalList;
+		}
+	}
+}

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -90,10 +90,6 @@
 
 	id super_unique_default_init = [[Constructors_SuperUnique alloc] init];
 	XCTAssert ([super_unique_default_init id] == 411, "super id");
-
-	// FIXME - this should not be allowed, that .ctor is not available to call in .NET as it is not re-declared in SuperUnique
-	id super_unique_init_id = [[Constructors_SuperUnique alloc] initWithId:42];
-	XCTAssert ([super_unique_init_id id] == 42, "id");
 	
 	Constructors_Implicit* implicit = [[Constructors_Implicit alloc] init];
 	XCTAssertEqualObjects (@"OK", [implicit testResult], "implicit");


### PR DESCRIPTION
.NET .ctor are not inherited but `init*` methods are in ObjC, we now
mark as `NS_UNAVAILABLE` the ctors that are not available.

Also this commit introduces `objcgenerator-helpers.cs` which its main
intention is to move the small ObjC related functions like
`GetObjCConstructorName` or `GetUnavailableParentCtors` to avoid
polluting `objcgenerator.cs`

## Test failure on objc-cli tests was expected

```
Testing failed:
	'initWithId:' is unavailable
```

Will fix/remove the assert once bot confirms, I am still not sure how to properly test a `NS_UNAVAILABLE` feature in XCT ...