### PR TITLE
[objc] Use msbuild instead of xbuild.

### DIFF
--- a/objcgen/Makefile
+++ b/objcgen/Makefile
@@ -6,4 +6,4 @@ OBJCGEN_FILES := \
 
 bin/Debug/objcgen.exe: $(OBJCGEN_FILES)
 	nuget restore ../generator.sln
-	xbuild objcgen.csproj
+	msbuild objcgen.csproj

--- a/tests/managed/Makefile
+++ b/tests/managed/Makefile
@@ -1,5 +1,5 @@
 bin/Debug/managed.dll: $(wildcard *.cs) managed.csproj
-	/Library/Frameworks/Mono.framework/Versions/Current/Commands/xbuild managed.csproj
+	/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild managed.csproj
 	
 all: managed.dll
 

--- a/tests/objc-cli/Makefile
+++ b/tests/objc-cli/Makefile
@@ -56,7 +56,7 @@ xctest:
 test-leaks: test-cli-leaks test-perf-leaks test-xctest-leaks
 
 ../leaktest/bin/Debug/leaktest.exe: $(wildcard ../leaktest/*.cs) libLeakCheckAtExit.dylib
-	/Library/Frameworks/Mono.framework/Versions/Current/Commands/xbuild /verbosity:quiet /nologo ../leaktest/leaktest.csproj
+	/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild /verbosity:quiet /nologo ../leaktest/leaktest.csproj
 
 test-cli-leaks: test-cli ../leaktest/bin/Debug/leaktest.exe
 	mono --debug ../leaktest/bin/Debug/leaktest.exe $(abspath $<)


### PR DESCRIPTION
This prevents fleeting visions of red text in the terminal.