### PR TITLE
[tests][objc] Build debug tests into a subdirectory as well.

### DIFF
--- a/tests/objc-cli/.gitignore
+++ b/tests/objc-cli/.gitignore
@@ -1,11 +1,4 @@
-glib.c
-glib.h
-mono_embeddinator.c
-mono_embeddinator.h
-objc-support.m
-objc-support.h
-perf-cli
-test-cli
+debug
 release/
 # Xcode
 .DS_Store

--- a/tests/objc-cli/Makefile
+++ b/tests/objc-cli/Makefile
@@ -12,43 +12,42 @@ MANAGED_DLL=$(MANAGED_DLL_DIR)/bin/Debug/managed.dll
 $(MANAGED_DLL): $(wildcard $(MANAGED_DLL_DIR)/*.cs)
 	make -C $(MANAGED_DLL_DIR)
 
-managed.dll: $(MANAGED_DLL)
+%/managed.dll: $(MANAGED_DLL)
+	mkdir $(dir $@)
 	cp $< $@
-	mkdir release
-	cp $< release/
 
-libmanaged.dylib: managed.dll $(OBJC_GEN)
-	$(MONO) --debug $(OBJC_GEN) --debug managed.dll -c
+debug/libmanaged.dylib: debug/managed.dll $(OBJC_GEN)
+	$(MONO) --debug $(OBJC_GEN) --debug debug/managed.dll -c -o debug
 
-release/libmanaged.dylib: managed.dll $(OBJC_GEN)
-	$(MONO) --debug $(OBJC_GEN) managed.dll -c -o release
+release/libmanaged.dylib: release/managed.dll $(OBJC_GEN)
+	$(MONO) --debug $(OBJC_GEN) release/managed.dll -c -o release
 
-test-cli: test-managed.m libmanaged.dylib
-	clang -g -O0 $< -lmanaged -L. -framework Foundation -o $@ -rpath @executable_path -fobjc-arc
+debug/test-cli: test-managed.m debug/libmanaged.dylib
+	clang -g -O0 $< -lmanaged -Ldebug -Idebug -framework Foundation -o $@ -rpath @executable_path -fobjc-arc
 
 release/test-cli: test-managed.m release/libmanaged.dylib
-	clang -O2 $< -lmanaged -Lrelease -framework Foundation -o $@ -rpath @executable_path -fobjc-arc
+	clang -O2 $< -lmanaged -Lrelease -Irelease -framework Foundation -o $@ -rpath @executable_path -fobjc-arc
 
-perf-cli: perf-test.m libmanaged.dylib
-	clang -g -O0 $< -lmanaged -L. -framework Foundation -o $@ -rpath @executable_path -fobjc-arc
+debug/perf-cli: perf-test.m debug/libmanaged.dylib
+	clang -g -O0 $< -lmanaged -Ldebug -Idebug -framework Foundation -o $@ -rpath @executable_path -fobjc-arc
 
 release/perf-cli: perf-test.m release/libmanaged.dylib
-	clang -O2 $< -lmanaged -Lrelease -framework Foundation -o $@ -rpath @executable_path -fobjc-arc
+	clang -O2 $< -lmanaged -Lrelease -Irelease -framework Foundation -o $@ -rpath @executable_path -fobjc-arc
 
-run-test: test-cli release/test-cli
-	@echo "Test (Debug)"
-	./test-cli
-	@echo "Test (Release)"
-	./release/test-cli
+run-%-cli-test: %/test-cli
+	@echo "Test ($*)"
+	./$<
 
-perf: perf-cli release/perf-cli
-	@echo "Performance (Debug)"
-	time ./perf-cli
-	@echo "Performance (Release)"
-	time ./release/perf-cli
+run-%-perf-test: %/perf-cli
+	@echo "Performance ($*)"
+	time ./$<
+
+run-test: run-debug-cli-test run-release-cli-test
+
+perf: run-debug-perf-test run-release-perf-test
 
 clean:
-	@rm -rf *.h glib.c mono_embeddinator.c bindings.m *.dylib *.dll test-cli perf-cli release
+	@rm -rf debug release
 
 xctest:
 	xcodebuild test -project libmanaged/*.xcodeproj -scheme Tests
@@ -58,13 +57,13 @@ test-leaks: test-cli-leaks test-perf-leaks test-xctest-leaks
 ../leaktest/bin/Debug/leaktest.exe: $(wildcard ../leaktest/*.cs) libLeakCheckAtExit.dylib
 	/Library/Frameworks/Mono.framework/Versions/Current/Commands/xbuild /verbosity:quiet /nologo ../leaktest/leaktest.csproj
 
-test-cli-leaks: test-cli ../leaktest/bin/Debug/leaktest.exe
+test-cli-leaks: debug/test-cli ../leaktest/bin/Debug/leaktest.exe
 	mono --debug ../leaktest/bin/Debug/leaktest.exe $(abspath $<)
 
-test-perf-leaks: perf-cli ../leaktest/bin/Debug/leaktest.exe
+test-perf-leaks: debug/perf-cli ../leaktest/bin/Debug/leaktest.exe
 	mono --debug ../leaktest/bin/Debug/leaktest.exe $(abspath $<)
 
-test-xctest-leaks: ../leaktest/bin/Debug/leaktest.exe $(MANAGED_DLL) libmanaged.dylib
+test-xctest-leaks: ../leaktest/bin/Debug/leaktest.exe $(MANAGED_DLL) debug/libmanaged.dylib
 	rm -Rf libmanaged/Tests.xctest
 	xcodebuild -quiet build-for-testing -project libmanaged/*.xcodeproj -scheme Tests CONFIGURATION_BUILD_DIR=$(abspath libmanaged)
 	mono --debug ../leaktest/bin/Debug/leaktest.exe `xcrun -f xctest` -XCTest All $(abspath libmanaged/Tests.xctest)
@@ -74,10 +73,10 @@ libLeakCheckAtExit.dylib: leak-at-exit.c
 
 test-static: test-static-macos test-static-ios test-static-tvos test-static-watchos
 
-test-static-%: managed.dll $(OBJC_GEN)
-	/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono --debug $(OBJC_GEN) --debug managed.dll -c --outdir=build/$@-temp-dir --target=staticlibrary --platform=$*
+test-static-%: $(MANAGED_DLL) $(OBJC_GEN)
+	/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono --debug $(OBJC_GEN) --debug $(MANAGED_DLL) -c --outdir=build/$@-temp-dir --target=staticlibrary --platform=$*
 
 test-dynamic: test-dynamic-macos test-dynamic-ios test-dynamic-tvos test-dynamic-watchos
 
-test-dynamic-%: managed.dll $(OBJC_GEN)
-	/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono --debug $(OBJC_GEN) --debug managed.dll -c --outdir=build/$@-temp-dir --target=dylib --platform=$*
+test-dynamic-%: $(MANAGED_DLL) $(OBJC_GEN)
+	/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono --debug $(OBJC_GEN) --debug $(MANAGED_DLL) -c --outdir=build/$@-temp-dir --target=dylib --platform=$*

--- a/tests/objc-cli/Makefile
+++ b/tests/objc-cli/Makefile
@@ -13,7 +13,7 @@ $(MANAGED_DLL): $(wildcard $(MANAGED_DLL_DIR)/*.cs)
 	make -C $(MANAGED_DLL_DIR)
 
 %/managed.dll: $(MANAGED_DLL)
-	mkdir $(dir $@)
+	mkdir -p $(dir $@)
 	cp $< $@
 
 debug/libmanaged.dylib: debug/managed.dll $(OBJC_GEN)

--- a/tests/objc-cli/Makefile
+++ b/tests/objc-cli/Makefile
@@ -49,7 +49,7 @@ perf: run-debug-perf-test run-release-perf-test
 clean:
 	@rm -rf debug release
 
-xctest:
+xctest: debug/libmanaged.dylib
 	xcodebuild test -project libmanaged/*.xcodeproj -scheme Tests
 
 test-leaks: test-cli-leaks test-perf-leaks test-xctest-leaks

--- a/tests/objc-cli/libmanaged/libmanaged.xcodeproj/project.pbxproj
+++ b/tests/objc-cli/libmanaged/libmanaged.xcodeproj/project.pbxproj
@@ -29,8 +29,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		7E3455791E92B06100FCAD74 /* libmanaged.dylib.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = libmanaged.dylib.dSYM; path = ../libmanaged.dylib.dSYM; sourceTree = "<group>"; };
-		7E5081F01E928C24008125B5 /* libmanaged.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libmanaged.dylib; path = ../libmanaged.dylib; sourceTree = "<group>"; };
+		7E3455791E92B06100FCAD74 /* libmanaged.dylib.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = libmanaged.dylib.dSYM; path = ../debug/libmanaged.dylib.dSYM; sourceTree = "<group>"; };
+		7E5081F01E928C24008125B5 /* libmanaged.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libmanaged.dylib; path = ../debug/libmanaged.dylib; sourceTree = "<group>"; };
 		D1B0CD801E904EA6008FF17D /* managed.dll */ = {isa = PBXFileReference; lastKnownFileType = file; name = managed.dll; path = ../../../managed/bin/Debug/managed.dll; sourceTree = "<group>"; };
 		D1B0CD811E904EA6008FF17D /* managed.pdb */ = {isa = PBXFileReference; lastKnownFileType = file; name = managed.pdb; path = ../../../managed/bin/Debug/managed.pdb; sourceTree = "<group>"; };
 		D1E2B21F1E8F4FBB00846AF8 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -166,7 +166,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "make -C .. libmanaged.dylib\n";
+			shellScript = "make -C .. debug/libmanaged.dylib\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -276,11 +276,11 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				HEADER_SEARCH_PATHS = ..;
+				HEADER_SEARCH_PATHS = ../debug;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = (
-					..,
+					../debug,
 					"$(PROJECT_DIR)",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.xamarin.Tests;
@@ -294,11 +294,11 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				HEADER_SEARCH_PATHS = ..;
+				HEADER_SEARCH_PATHS = ../debug;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = (
-					..,
+					../debug,
 					"$(PROJECT_DIR)",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.xamarin.Tests;


### PR DESCRIPTION
This cleans up the current directory quite a bit.

Also modify the cli/perf tests a little bit to be able to run the
debug/release versions in parallel.