### PR TITLE
[objc] Add a header (embeddinator.h) that's meant to be included by generated headers.

### DIFF
--- a/objcgen/objcgen.csproj
+++ b/objcgen/objcgen.csproj
@@ -311,6 +311,10 @@
     <Folder Include="support\" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="..\support\embeddinator.h">
+      <Link>support\embeddinator.h</Link>
+      <LogicalName>embeddinator.h</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\support\glib.c">
       <Link>support\glib.c</Link>
       <LogicalName>glib.c</LogicalName>

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -72,15 +72,13 @@ namespace ObjC {
 
 		public override void Generate (IEnumerable<Assembly> assemblies)
 		{
-			headers.WriteLine ("#include \"mono_embeddinator.h\"");
+			headers.WriteLine ("#include \"embeddinator.h\"");
 			headers.WriteLine ("#import <Foundation/Foundation.h>");
 			headers.WriteLine ();
 			headers.WriteLine ();
 			headers.WriteLine ("#if !__has_feature(objc_arc)");
 			headers.WriteLine ("#error Embeddinator code must be built with ARC.");
 			headers.WriteLine ("#endif");
-			headers.WriteLine ();
-			headers.WriteLine ("MONO_EMBEDDINATOR_BEGIN_DECLS");
 			headers.WriteLine ();
 
 			headers.WriteLine ("// forward declarations");
@@ -91,6 +89,7 @@ namespace ObjC {
 			implementation.WriteLine ("#include \"bindings.h\"");
 			implementation.WriteLine ("#include \"glib.h\"");
 			implementation.WriteLine ("#include \"objc-support.h\"");
+			implementation.WriteLine ("#include \"mono_embeddinator.h\"");
 			implementation.WriteLine ("#include <mono/jit/jit.h>");
 			implementation.WriteLine ("#include <mono/metadata/assembly.h>");
 			implementation.WriteLine ("#include <mono/metadata/object.h>");
@@ -118,9 +117,6 @@ namespace ObjC {
 			implementation.WriteLine ();
 
 			base.Generate (assemblies);
-
-			headers.WriteLine ();
-			headers.WriteLine ("MONO_EMBEDDINATOR_END_DECLS");
 		}
 
 		protected override void Generate (Assembly a)

--- a/support/embeddinator.h
+++ b/support/embeddinator.h
@@ -1,0 +1,36 @@
+/*
+ * Definitions needed for the generated header files.
+ *
+ * (C) 2017 Microsoft, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * Arrays
+ */
+
+typedef struct MonoEmbedArray MonoEmbedArray;
+
+/**
+ * Objects
+ */
+
+typedef struct MonoEmbedObject MonoEmbedObject;

--- a/support/mono_embeddinator.h
+++ b/support/mono_embeddinator.h
@@ -58,6 +58,7 @@
     #define MONO_EMBEDDINATOR_API MONO_EMBEDDINATOR_API_IMPORT
 #endif
 
+#include "embeddinator.h"
 typedef uint16_t gunichar2;
 
 typedef struct _GArray GArray;
@@ -194,24 +195,17 @@ typedef void (*mono_embeddinator_error_report_hook_t)(mono_embeddinator_error_t)
 MONO_EMBEDDINATOR_API
 void* mono_embeddinator_install_error_report_hook(mono_embeddinator_error_report_hook_t hook);
 
-/** 
- * Arrays
- */
 
-typedef struct
+struct MonoEmbedArray
 {
     GArray* array;
-} MonoEmbedArray;
+};
 
-/**
- * Objects
- */
-
-typedef struct
+struct MonoEmbedObject
 {
     MonoClass* _class;
     uint32_t _handle;
-} MonoEmbedObject;
+};
 
 /**
  * Creates a MonoEmbedObject support object from a Mono object instance.

--- a/tests/objc-cli/.gitignore
+++ b/tests/objc-cli/.gitignore
@@ -2,6 +2,7 @@ glib.c
 glib.h
 mono_embeddinator.c
 mono_embeddinator.h
+embeddinator.h
 objc-support.m
 objc-support.h
 perf-cli


### PR DESCRIPTION
This way we can limit the API surface of the generated code.