### PR TITLE
[objcgen] Create an embedder class that contains the state required to run the embeddinator.

### DIFF
--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -42,6 +42,7 @@ namespace Embeddinator {
 
 	public static class Driver
 	{
+		public static Embedder CurrentEmbedder { get; private set; }
 		static int Main (string [] args)
 		{
 			try {
@@ -52,23 +53,26 @@ namespace Embeddinator {
 			}
 		}
 
-		public static int Main2 (string [] args)
+		public static int Main2 (params string [] args)
 		{
 			var action = Action.None;
+			var embedder = new Embedder ();
+
+			CurrentEmbedder = embedder;
 
 			var os = new OptionSet {
-				{ "c|compile", "Compiles the generated output", v => CompileCode = true },
-				{ "d|debug", "Build the native library with debug information.", v => Debug = true },
-				{ "gen=", $"Target generator (default {TargetLanguage})", v => SetTarget (v) },
-				{ "o|out|outdir=", "Output directory", v => OutputDirectory = v },
-				{ "p|platform=", $"Target platform (iOS, macOS [default], watchOS, tvOS)", v => SetPlatform (v) },
-				{ "dll|shared", "Compiles as a shared library (default)", v => CompilationTarget = CompilationTarget.SharedLibrary },
-				{ "static", "Compiles as a static library (unsupported)", v => CompilationTarget = CompilationTarget.StaticLibrary },
+				{ "c|compile", "Compiles the generated output", v => embedder.CompileCode = true },
+				{ "d|debug", "Build the native library with debug information.", v => embedder.Debug = true },
+				{ "gen=", $"Target generator (default {embedder.TargetLanguage})", v => embedder.SetTarget (v) },
+				{ "o|out|outdir=", "Output directory", v => embedder.OutputDirectory = v },
+				{ "p|platform=", $"Target platform (iOS, macOS [default], watchOS, tvOS)", v => embedder.SetPlatform (v) },
+				{ "dll|shared", "Compiles as a shared library (default)", v => embedder.CompilationTarget = CompilationTarget.SharedLibrary },
+				{ "static", "Compiles as a static library (unsupported)", v => embedder.CompilationTarget = CompilationTarget.StaticLibrary },
 				{ "vs=", $"Visual Studio version for compilation (unsupported)", v => { throw new EmbeddinatorException (2, $"Option `--vs` is not supported"); } },
 				{ "h|?|help", "Displays the help", v => action = Action.Help },
 				{ "v|verbose", "generates diagnostic verbose output", v => ErrorHelper.Verbosity++ },
 				{ "version", "Display the version information.", v => action = Action.Version },
-				{ "target=", "The compilation target (static, shared, framework).", v => SetCompilationTarget (v) },
+				{ "target=", "The compilation target (static, shared, framework).", v => embedder.SetCompilationTarget (v) },
 			};
 
 			var assemblies = os.Parse (args);
@@ -91,9 +95,9 @@ namespace Embeddinator {
 				return 0;
 			case Action.Generate:
 				try {
-					var result = Generate (assemblies);
-					if (CompileCode && (result == 0))
-						result = Compile ();
+					var result = embedder.Generate (assemblies);
+					if (embedder.CompileCode && (result == 0))
+						result = embedder.Compile ();
 					Console.WriteLine ("Done");
 					return result;
 				} catch (NotImplementedException e) {
@@ -103,10 +107,13 @@ namespace Embeddinator {
 				throw ErrorHelper.CreateError (99, "Internal error: invalid action {0}. Please file a bug report with a test case (https://github.com/mono/Embeddinator-4000/issues)", action);
 			}
 		}
+	}
 
-		static string outputDirectory = ".";
+	public class Embedder {
 
-		public static string OutputDirectory {
+		string outputDirectory = ".";
+
+		public string OutputDirectory {
 			get { return outputDirectory; }
 			set {
 				if (!Directory.Exists (value)) {
@@ -121,15 +128,15 @@ namespace Embeddinator {
 			}
 		}
 
-		static bool CompileCode { get; set; }
+		public bool CompileCode { get; set; }
 
-		static bool Debug { get; set; }
+		public bool Debug { get; set; }
 
-		static bool Shared { get { return CompilationTarget == CompilationTarget.SharedLibrary; } }
+		public bool Shared { get { return CompilationTarget == CompilationTarget.SharedLibrary; } }
 
-		static string LibraryName { get; set; }
+		public string LibraryName { get; set; }
 
-		public static void SetPlatform (string platform)
+		public void SetPlatform (string platform)
 		{
 			switch (platform.ToLowerInvariant ()) {
 			case "osx":
@@ -152,7 +159,7 @@ namespace Embeddinator {
 			}
 		}
 
-		public static void SetTarget (string value)
+		public void SetTarget (string value)
 		{
 			switch (value.ToLowerInvariant ()) {
 			case "objc":
@@ -166,7 +173,7 @@ namespace Embeddinator {
 			}
 		}
 
-		public static void SetCompilationTarget (string value)
+		public void SetCompilationTarget (string value)
 		{
 			switch (value.ToLowerInvariant ()) {
 			case "library":
@@ -186,11 +193,11 @@ namespace Embeddinator {
 			}
 		}
 
-		public static Platform Platform { get; set; } = Platform.macOS;
-		public static TargetLanguage TargetLanguage { get; private set; } = TargetLanguage.ObjectiveC;
-		public static CompilationTarget CompilationTarget { get; set; } = CompilationTarget.SharedLibrary;
+		public Platform Platform { get; set; } = Platform.macOS;
+		public TargetLanguage TargetLanguage { get; private set; } = TargetLanguage.ObjectiveC;
+		public CompilationTarget CompilationTarget { get; set; } = CompilationTarget.SharedLibrary;
 
-		static int Generate (List<string> args)
+		public int Generate (List<string> args)
 		{
 			Console.WriteLine ("Parsing assemblies...");
 
@@ -259,7 +266,7 @@ namespace Embeddinator {
 			public string LinkerFlags;
 		}
 
-		static int Compile ()
+		public int Compile ()
 		{
 			Console.WriteLine ("Compiling binding code...");
 
@@ -413,7 +420,7 @@ namespace Embeddinator {
 			return 0;
 		}
 
-		static string GetTargetFramework ()
+		string GetTargetFramework ()
 		{
 			switch (Platform) {
 			case Platform.macOS:
@@ -429,7 +436,7 @@ namespace Embeddinator {
 			}
 		}
 
-		static int RunProcess (string filename, string arguments)
+		public static int RunProcess (string filename, string arguments)
 		{
 			Console.WriteLine ($"\t{filename} {arguments}");
 			using (var p = Process.Start (filename, arguments)) {
@@ -438,18 +445,18 @@ namespace Embeddinator {
 			}
 		}
 
-		static bool RunProcess (string filename, string arguments, out int exitCode)
+		public static bool RunProcess (string filename, string arguments, out int exitCode)
 		{
 			exitCode = RunProcess (filename, arguments);
 			return exitCode == 0;
 		}
 
-		static bool Xcrun (StringBuilder options, out int exitCode)
+		public static bool Xcrun (StringBuilder options, out int exitCode)
 		{
 			return RunProcess ("xcrun", options.ToString (), out exitCode);
 		}
 
-		static bool DSymUtil (string input, out int exitCode)
+		bool DSymUtil (string input, out int exitCode)
 		{
 			exitCode = 0;
 
@@ -473,7 +480,7 @@ namespace Embeddinator {
 			return Xcrun (dsymutil_options, out exitCode);
 		}
 
-		static bool Lipo (List<string> inputs, string output, out int exitCode)
+		public static bool Lipo (List<string> inputs, string output, out int exitCode)
 		{
 			Directory.CreateDirectory (Path.GetDirectoryName (output));
 			if (inputs.Count == 1) {

--- a/tests/objcgentest/Cache.cs
+++ b/tests/objcgentest/Cache.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Xamarin
+{
+	// A class that creates temporary directories next to the test assembly, and cleans the output on startup
+	// Advantages:
+	// * The temporary directories are automatically cleaned on Wrench (unlike /tmp, which isn't)
+	// * The temporary directories stay after a test is run (until a new test run is started),
+	//   which makes it easier to re-run (copy-paste) commands that failed.
+	public static class Cache // Not really a cache (since the root directory is cleaned in the cctor), but I couldn't come up with a better name.
+	{
+		static string root;
+		static int last_number;
+
+		static Cache ()
+		{
+			root = Path.Combine (Path.GetDirectoryName (System.Reflection.Assembly.GetExecutingAssembly ().Location), "tmp-test-dir");
+			if (Directory.Exists (root))
+				Directory.Delete (root, true);
+			Directory.CreateDirectory (root);
+		}
+
+		[DllImport ("libc", SetLastError = true)]
+		static extern int mkdir (string path, ushort mode);
+
+		public static string CreateTemporaryDirectory (string name = null)
+		{
+			if (string.IsNullOrEmpty (name)) {
+				var calling_method = new System.Diagnostics.StackFrame (1).GetMethod ();
+				if (calling_method != null) {
+					name = calling_method.DeclaringType.FullName + "." + calling_method.Name;
+				} else {
+					name = "unknown-test";
+				}
+			}
+
+			var rv = Path.Combine (root, name);
+			for (int i = last_number; i < 10000 + last_number; i++) {
+				// There's no way to know if Directory.CreateDirectory
+				// created the directory or not (which would happen if the directory
+				// already existed). Checking if the directory exists before
+				// creating it would result in a race condition if multiple
+				// threads create temporary directories at the same time.
+				if (mkdir (rv, Convert.ToUInt16 ("777", 8)) == 0) {
+					last_number = i;
+					return rv;
+				}
+				rv = Path.Combine (root, name + i);
+			}
+
+			throw new Exception ("Could not create temporary directory");
+		}
+	}
+}

--- a/tests/objcgentest/DriverTest.cs
+++ b/tests/objcgentest/DriverTest.cs
@@ -14,11 +14,12 @@ namespace DriverTest {
 			Random rnd = new Random ();
 			string valid = Path.Combine (Path.GetTempPath (), "output-" + rnd.Next ().ToString ());
 			try {
-				Driver.OutputDirectory = valid;
+				var embedder = new Embedder ();
+				embedder.OutputDirectory = valid;
 				Assert.That (Directory.Exists (valid), "valid");
 
 				try {
-					Driver.OutputDirectory = "/:output";
+					embedder.OutputDirectory = "/:output";
 					Assert.Fail ("invalid");
 				} catch (EmbeddinatorException ee) {
 					Assert.True (ee.Error, "Error");
@@ -34,8 +35,9 @@ namespace DriverTest {
 		{
 			var valid = new string [] { "ObjC", "Obj-C", "ObjectiveC", "objective-c" };
 			foreach (var t in valid) {
-				Driver.SetTarget (t);
-				Assert.That (Driver.TargetLanguage, Is.EqualTo (TargetLanguage.ObjectiveC), t);
+				var embedder = new Embedder ();
+				embedder.SetTarget (t);
+				Assert.That (embedder.TargetLanguage, Is.EqualTo (TargetLanguage.ObjectiveC), t);
 			}
 		}
 
@@ -45,7 +47,8 @@ namespace DriverTest {
 			var notsupported = new string [] { "C", "C++", "Java" };
 			foreach (var t in notsupported) {
 				try {
-					Driver.SetTarget (t);
+					var embedder = new Embedder ();
+					embedder.SetTarget (t);
 				}
 				catch (EmbeddinatorException ee) {
 					Assert.True (ee.Error, "Error");
@@ -58,7 +61,8 @@ namespace DriverTest {
 		public void Target_Invalid ()
 		{
 			try {
-				Driver.SetTarget ("invalid");
+				var embedder = new Embedder ();
+				embedder.SetTarget ("invalid");
 			}
 			catch (EmbeddinatorException ee) {
 				Assert.True (ee.Error, "Error");
@@ -71,23 +75,27 @@ namespace DriverTest {
 		{
 			var valid = new string [] { "OSX", "MacOSX", "MacOS", "Mac" };
 			foreach (var p in valid) {
-				Driver.SetPlatform (p);
-				Assert.That (Driver.Platform, Is.EqualTo (Platform.macOS), p);
+				var embedder = new Embedder ();
+				embedder.SetPlatform (p);
+				Assert.That (embedder.Platform, Is.EqualTo (Platform.macOS), p);
 			}
 
 			foreach (var p in new string [] { "ios", "iOS" }) {
-				Driver.SetPlatform (p);
-				Assert.That (Driver.Platform, Is.EqualTo (Platform.iOS), p);
+				var embedder = new Embedder ();
+				embedder.SetPlatform (p);
+				Assert.That (embedder.Platform, Is.EqualTo (Platform.iOS), p);
 			}
 
 			foreach (var p in new string [] { "tvos", "tvOS" }) {
-				Driver.SetPlatform (p);
-				Assert.That (Driver.Platform, Is.EqualTo (Platform.tvOS), p);
+				var embedder = new Embedder ();
+				embedder.SetPlatform (p);
+				Assert.That (embedder.Platform, Is.EqualTo (Platform.tvOS), p);
 			}
 
 			foreach (var p in new string [] { "watchos", "watchOS" }) {
-				Driver.SetPlatform (p);
-				Assert.That (Driver.Platform, Is.EqualTo (Platform.watchOS), p);
+				var embedder = new Embedder ();
+				embedder.SetPlatform (p);
+				Assert.That (embedder.Platform, Is.EqualTo (Platform.watchOS), p);
 			}
 		}
 
@@ -97,7 +105,8 @@ namespace DriverTest {
 			var notsupported = new string [] { "Windows", "Android", "iOS", "tvOS", "watchOS" };
 			foreach (var p in notsupported) {
 				try {
-					Driver.SetPlatform (p);
+					var embedder = new Embedder ();
+					embedder.SetPlatform (p);
 				} catch (EmbeddinatorException ee) {
 					Assert.True (ee.Error, "Error");
 					Assert.That (ee.Code, Is.EqualTo (3), "Code");
@@ -109,7 +118,8 @@ namespace DriverTest {
 		public void Platform_Invalid ()
 		{
 			try {
-				Driver.SetPlatform ("invalid");
+				var embedder = new Embedder ();
+				embedder.SetPlatform ("invalid");
 			} catch (EmbeddinatorException ee) {
 				Assert.True (ee.Error, "Error");
 				Assert.That (ee.Code, Is.EqualTo (3), "Code");
@@ -141,20 +151,21 @@ namespace DriverTest {
 		[Test]
 		public void CompilationTarget ()
 		{
+			var embedder = new Embedder ();
 			Asserts.ThrowsEmbeddinatorException (5, "The compilation target `invalid` is not valid.", () => Driver.Main2 (new [] { "--target=invalid" }));
-			Asserts.ThrowsEmbeddinatorException (5, "The compilation target `invalid` is not valid.", () => Driver.SetCompilationTarget ("invalid"));
+			Asserts.ThrowsEmbeddinatorException (5, "The compilation target `invalid` is not valid.", () => embedder.SetCompilationTarget ("invalid"));
 
 			foreach (var ct in new string [] { "library", "sharedlibrary", "dylib" }) {
-				Driver.SetCompilationTarget (ct);
-				Assert.That (Driver.CompilationTarget, Is.EqualTo (global::Embeddinator.CompilationTarget.SharedLibrary), ct);
+				embedder.SetCompilationTarget (ct);
+				Assert.That (embedder.CompilationTarget, Is.EqualTo (global::Embeddinator.CompilationTarget.SharedLibrary), ct);
 			}
 			foreach (var ct in new string [] { "framework" }) {
-				Driver.SetCompilationTarget (ct);
-				Assert.That (Driver.CompilationTarget, Is.EqualTo (global::Embeddinator.CompilationTarget.Framework), ct);
+				embedder.SetCompilationTarget (ct);
+				Assert.That (embedder.CompilationTarget, Is.EqualTo (global::Embeddinator.CompilationTarget.Framework), ct);
 			}
 			foreach (var ct in new string [] { "static", "staticlibrary" }) {
-				Driver.SetCompilationTarget (ct);
-				Assert.That (Driver.CompilationTarget, Is.EqualTo (global::Embeddinator.CompilationTarget.StaticLibrary), ct);
+				embedder.SetCompilationTarget (ct);
+				Assert.That (embedder.CompilationTarget, Is.EqualTo (global::Embeddinator.CompilationTarget.StaticLibrary), ct);
 			}
 		}
 	}

--- a/tests/objcgentest/objcgentest.csproj
+++ b/tests/objcgentest/objcgentest.csproj
@@ -34,6 +34,7 @@
     <Compile Include="ObjCGeneratorTest.cs" />
     <Compile Include="DriverTest.cs" />
     <Compile Include="Asserts.cs" />
+    <Compile Include="Cache.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
This makes it easier to test, because Driver.Main can be called multiple
times, each time independent from previous executions.