### PR TITLE
[objc] Generate better looking names for operators

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -409,7 +409,7 @@ namespace ObjC {
 			var aname = type.Assembly.GetName ().Name;
 			implementation.WriteLine ($"\t\t__method = mono_get_method (__{aname}_image, 0x{info.MetadataToken:X8}, {managed_type_name}_class);");
 			implementation.WriteLine ("#else");
-			implementation.WriteLine ($"\t\tconst char __method_name [] = \"{type.FullName}:{monosig})\";");
+			implementation.WriteLine ($"\t\tconst char __method_name [] = \"{type.FullName}:{monosig}\";");
 			implementation.WriteLine ($"\t\t__method = mono_embeddinator_lookup_method (__method_name, {managed_type_name}_class);");
 			implementation.WriteLine ("#endif");
 			implementation.WriteLine ("\t}");
@@ -449,7 +449,11 @@ namespace ObjC {
 
 		protected override void Generate (MethodInfo mi)
 		{
-			var name = CamelCase (mi.Name);
+			string name;
+			if (mi.IsSpecialName && mi.IsStatic && mi.Name.StartsWith ("op_", StringComparison.Ordinal))
+				name = CamelCase (mi.Name.Substring (3));
+			else
+				name = CamelCase (mi.Name);
 			ImplementMethod (mi, name);
 		}
 

--- a/tests/managed/structs.cs
+++ b/tests/managed/structs.cs
@@ -23,5 +23,15 @@ namespace Structs {
 		{
 			return !(left == right);
 		}
+
+		public static Point operator + (Point left, Point right)
+		{
+			return new Point (left.X + right.X, left.Y + right.Y);
+		}
+
+		public static Point operator - (Point left, Point right)
+		{
+			return new Point (left.X - right.X, left.Y - right.Y);
+		}
 	}
 }

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -145,9 +145,16 @@
 	XCTAssert ([p2 x] == 2.0f, "x 2");
 	XCTAssert ([p2 y] == -2.0f, "y 2");
 
-	XCTAssert ([Structs_Point opEquality:p1 right:p1], "p1 == p1");
-	XCTAssert ([Structs_Point opEquality:p2 right:p2], "p2 == p2");
-	XCTAssert ([Structs_Point opInequality:p1 right:p2], "p1 != p2");
+	XCTAssert ([Structs_Point equality:p1 right:p1], "p1 == p1");
+	XCTAssert ([Structs_Point equality:p2 right:p2], "p2 == p2");
+	XCTAssert ([Structs_Point inequality:p1 right:p2], "p1 != p2");
+
+	id p3 = [Structs_Point addition:p1 right:p2];
+	XCTAssert ([p3 x] == 3.0f, "x 3");
+	XCTAssert ([p3 y] == -3.0f, "y 3");
+
+	id p4 = [Structs_Point subtraction:p3 right:p2];
+	XCTAssert ([Structs_Point equality:p4 right:p1], "p4 == p1");
 }
 
 - (void) testEnums {


### PR DESCRIPTION
Remove the `op_` prefix on operators.

Also fix a (non fatal) typo, extra `)`, when computing mono signatures.