### PR TITLE
[objc] Fix the case where bound type A creates instance of bound type B

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -133,7 +133,7 @@ namespace ObjC {
 			headers.WriteLine ($"// {t.AssemblyQualifiedName}");
 			headers.WriteLine ($"@interface {native_name} : {GetTypeName (t.BaseType)} {{");
 			if (!static_type && !has_bound_base_class) {
-				headers.WriteLine ("\tMonoEmbedObject* _object;");
+				headers.WriteLine ("\t@public MonoEmbedObject* _object;");
 			}
 			headers.WriteLine ("}");
 			headers.WriteLine ();
@@ -332,7 +332,7 @@ namespace ObjC {
 					if (pt.IsValueType)
 						implementation.WriteLine ($"\t\t__args [{i}] = mono_object_unbox (mono_gchandle_get_target ({p.Name}->_object->_handle));");
 					else if (types.Contains (pt))
-						implementation.WriteLine ($"\t\t__args [{i}] = {p.Name};");
+						implementation.WriteLine ($"\t\t__args [{i}] = mono_gchandle_get_target ({p.Name}->_object->_handle);");
 					else
 						throw new NotImplementedException ($"Converting type {pt.FullName} to mono code");
 					break;

--- a/tests/managed/methods.cs
+++ b/tests/managed/methods.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Methods {
 	
@@ -41,6 +42,25 @@ namespace Methods {
 		{
 			length = @string == null ? 0 : @string.Length;
 			upper =  @string == null ? null : @string.ToUpperInvariant ();
+		}
+	}
+
+	public class Item {
+
+		// not generated
+		internal Item (int id)
+		{
+			Integer = id;
+		}
+
+		public int Integer { get; private set; }
+	}
+
+	public static class Factory {
+
+		public static Item CreateItem (int id)
+		{
+			return new Item (id);
 		}
 	}
 }

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -134,6 +134,9 @@
 	[Methods_Parameters outString:@"Xamarin" length:&l upper:&s];
 	XCTAssert (l == 7, "out int 2");
 	XCTAssertEqualObjects (@"XAMARIN", s, "ref string 2");
+
+	id item = [Methods_Factory createItemId:1];
+	XCTAssert ([item integer] == 1, "indirect creation 1");
 }
 
 - (void) testStructs {


### PR DESCRIPTION
As Alex pointed out this scenario requires the `_object` field to be
public.