### PR TITLE
[objc] Generated (property) indexers as methods

### DIFF
--- a/objcgen/objcgenerator-processor.cs
+++ b/objcgen/objcgenerator-processor.cs
@@ -161,6 +161,9 @@ namespace ObjC {
 						// setter only property are valid in .NET and we need to generate a method in ObjC (there's no writeonly properties)
 						if (getter == null)
 							continue;
+						// indexers are implemented as methods
+						if ((getter.ParameterCount > 0) || ((setter != null) && setter.ParameterCount > 1))
+							continue;
 						// we can do better than methods for the more common cases (readonly and readwrite)
 						meths.Remove (getter);
 						meths.Remove (setter);

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -582,7 +582,7 @@ namespace ObjC {
 						return "object";
 					}
 				default:
-					return t.IsValueType ? t.FullName : "object";
+					return t.FullName;
 				}
 			case TypeCode.Boolean:
 				return "bool";

--- a/tests/managed/methods.cs
+++ b/tests/managed/methods.cs
@@ -63,4 +63,26 @@ namespace Methods {
 			return new Item (id);
 		}
 	}
+
+	public class Collection {
+
+		List<Item> c = new List<Item> ();
+
+		public void Add (Item item)
+		{
+			c.Add (item);
+		}
+
+		public void Remove (Item item)
+		{
+			c.Remove (item);
+		}
+
+		public int Count => c.Count;
+
+		public Item this [int index] {
+			get { return c [index]; }
+			set { c [index] = value; }
+		}
+	}
 }

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -137,6 +137,23 @@
 
 	id item = [Methods_Factory createItemId:1];
 	XCTAssert ([item integer] == 1, "indirect creation 1");
+
+	Methods_Collection *collection = [[Methods_Collection alloc] init];
+	XCTAssert ([collection count] == 0, "count 0");
+	[collection addItem:item];
+	XCTAssert ([collection count] == 1, "count 1");
+	XCTAssert ([[collection getItem:0] integer] == [item integer], "get 1");
+
+	id item2 = [Methods_Factory createItemId:2];
+	[collection setItem:0 value:item2];
+	XCTAssert ([collection count] == 1, "count 2");
+	XCTAssert ([[collection getItem:0] integer] == [item2 integer], "get 2");
+	
+	[collection removeItem:item]; // not there
+	XCTAssert ([collection count] == 1, "count 3");
+
+	[collection removeItem:item2];
+	XCTAssert ([collection count] == 0, "count 4");
 }
 
 - (void) testStructs {


### PR DESCRIPTION
That's basic support. The nicer way would be to use subscripts [1]

[1] https://github.com/mono/Embeddinator-4000/issues/122