### PR TITLE
[objc] Warn if default values are used on parameters

### DIFF
--- a/docs/error.md
+++ b/docs/error.md
@@ -1,4 +1,4 @@
-id:{932C3F0C-D968-42D1-BB14-D97C73361983}
+﻿id:{932C3F0C-D968-42D1-BB14-D97C73361983}
 title:Embeddinator-4000 errors
 
 [//]: # (The original file resides under https://github.com/mono/Embeddinator-4000/tree/master/docs/error.md)
@@ -91,6 +91,13 @@ There should be an earlier warning giving more information why type `T` is not s
 Note: Supported features will evolve with new versions of the tool.
 
 
+<h3><a name="EM1021"/>Constructor `C` parameter `P` has a default value that is not supported.</h3>
+
+This is a **warning** that the default parameters of constructor `C` are not generating any extra code.
+
+Note: Supported features will evolve with new versions of the tool.
+
+
 <h3><a name="EM1030"/>Method `M` is not generated because return type `T` is not supported.</h3>
 
 This is a **warning** that the method `M` will be ignored (i.e. nothing will be generated) because it's return type `T` is not supported.
@@ -105,6 +112,13 @@ Note: Supported features will evolve with new versions of the tool.
 This is a **warning** that the method `M` will be ignored (i.e. nothing will be generated) because a parameter of type `T` is not supported.
 
 There should be an earlier warning giving more information why type `T` is not supported.
+
+Note: Supported features will evolve with new versions of the tool.
+
+
+<h3><a name="EM1032"/>Method `M` parameter `P` has a default value that is not supported.</h3>
+
+This is a **warning** that the default parameters of method `M` are not generating any extra code.
 
 Note: Supported features will evolve with new versions of the tool.
 

--- a/objcgen/objcgenerator-processor.cs
+++ b/objcgen/objcgenerator-processor.cs
@@ -85,6 +85,8 @@ namespace ObjC {
 					if (!IsSupported (pt)) {
 						delayed.Add (ErrorHelper.CreateWarning (1020, $"Constructor `{ctor}` is not generated because of parameter type `{pt}` is not supported."));
 						pcheck = false;
+					} else if (p.HasDefaultValue) {
+						delayed.Add (ErrorHelper.CreateWarning (1021, $"Constructor `{ctor}` parameter `{p.Name}` has a default value that is not supported."));
 					}
 				}
 				if (!pcheck)
@@ -112,6 +114,8 @@ namespace ObjC {
 					if (!IsSupported (pt)) {
 						delayed.Add (ErrorHelper.CreateWarning (1031, $"Method `{mi}` is not generated because of parameter type `{pt}` is not supported."));
 						pcheck = false;
+					} else if (p.HasDefaultValue) {
+						delayed.Add (ErrorHelper.CreateWarning (1032, $"Method `{mi}` parameter `{p.Name}` has a default value that is not supported."));
 					}
 				}
 				if (!pcheck)


### PR DESCRIPTION
Right now this is ignored [1] so we warn about them.

[1] https://github.com/mono/Embeddinator-4000/issues/73