### PR TITLE
[objc] Add basic (readonly) support for fields

### DIFF
--- a/tests/managed/structs.cs
+++ b/tests/managed/structs.cs
@@ -4,6 +4,8 @@ namespace Structs {
 
 	public struct Point {
 
+		public static readonly Point Zero;
+
 		public Point (float x, float y)
 		{
 			X = x;

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -175,6 +175,10 @@
 
 	id p4 = [Structs_Point subtraction:p3 right:p2];
 	XCTAssert ([Structs_Point equality:p4 right:p1], "p4 == p1");
+
+	id z = [Structs_Point zero];
+	XCTAssert ([z x] == 0.0f, "x 4");
+	XCTAssert ([z y] == 0.0f, "y 4");
 }
 
 - (void) testEnums {


### PR DESCRIPTION
We cannot access them directly but we can provide (ObjC) property
wrappers around them, making them usable from ObjC code.