### PR TITLE
[tests][objc] Make sure variables are declared with the right type.

### DIFF
--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -157,11 +157,11 @@
 }
 
 - (void) testStructs {
-	id p1 = [[Structs_Point alloc] initWithX:1.0f y:-1.0f];
+	Structs_Point* p1 = [[Structs_Point alloc] initWithX:1.0f y:-1.0f];
 	XCTAssert ([p1 x] == 1.0f, "x 1");
 	XCTAssert ([p1 y] == -1.0f, "y 1");
 
-	id p2 = [[Structs_Point alloc] initWithX:2.0f y:-2.0f];
+	Structs_Point* p2 = [[Structs_Point alloc] initWithX:2.0f y:-2.0f];
 	XCTAssert ([p2 x] == 2.0f, "x 2");
 	XCTAssert ([p2 y] == -2.0f, "y 2");
 
@@ -169,14 +169,14 @@
 	XCTAssert ([Structs_Point equality:p2 right:p2], "p2 == p2");
 	XCTAssert ([Structs_Point inequality:p1 right:p2], "p1 != p2");
 
-	id p3 = [Structs_Point addition:p1 right:p2];
+	Structs_Point* p3 = [Structs_Point addition:p1 right:p2];
 	XCTAssert ([p3 x] == 3.0f, "x 3");
 	XCTAssert ([p3 y] == -3.0f, "y 3");
 
-	id p4 = [Structs_Point subtraction:p3 right:p2];
+	Structs_Point* p4 = [Structs_Point subtraction:p3 right:p2];
 	XCTAssert ([Structs_Point equality:p4 right:p1], "p4 == p1");
 
-	id z = [Structs_Point zero];
+	Structs_Point* z = [Structs_Point zero];
 	XCTAssert ([z x] == 0.0f, "x 4");
 	XCTAssert ([z y] == 0.0f, "y 4");
 }


### PR DESCRIPTION
Otherwise we might not be able to call methods, because clang will look for any matching selector in any type it knows about, which results compiler errors like:

```
In module 'XCTest' imported from /work/Embeddinator-4000/tests/objc-cli/libmanaged/Tests/Tests.m:1:
In module 'UIKit' imported from /Applications/Xcode83.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCUIElement.h:8:
/Applications/Xcode83.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator10.3.sdk/System/Library/Frameworks/UIKit.framework/Headers/UIAccelerometer.h:24:51: note: one possibility
@property(nonatomic,readonly) UIAccelerationValue x;
                                                  ^
In file included from /work/Embeddinator-4000/tests/objc-cli/libmanaged/Tests/Tests.m:3:
../build/test-framework-ios-temp-dir/iPhoneSimulator/managed.framework/Headers/managed.h:323:39: note: also found
@property (nonatomic, readonly) float x;
                                      ^
/work/Embeddinator-4000/tests/objc-cli/libmanaged/Tests/Tests.m:171:13: error: multiple methods named 'y' found with mismatched result, parameter type or attributes
        XCTAssert ([p2 y] == -2.0f, "y 2");
                   ^~~~~~
```

So by declaring the proper type for variables, clang doesn't have to guess.