### PR TITLE
[objc] Removes `readwrite` in objc properties since it is the default

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -361,8 +361,6 @@ namespace ObjC {
 				headers.Write (", class");
 			if (setter == null)
 				headers.Write (", readonly");
-			else
-				headers.Write (", readwrite");
 			var pt = pi.PropertyType;
 			var property_type = GetTypeName (pt);
 			if (types.Contains (pt))
@@ -385,8 +383,6 @@ namespace ObjC {
 				headers.Write (", class");
 			if (read_only)
 				headers.Write (", readonly");
-			else
-				headers.Write (", readwrite");
 			var ft = fi.FieldType;
 			var field_type = GetTypeName (ft);
 			if (types.Contains (ft))


### PR DESCRIPTION
Adding `readwrite` to objective-c properties adds no value since it
is the default setting.

Removal was suggested in https://github.com/mono/Embeddinator-4000/pull/129#issuecomment-294491293