### PR TITLE
[objc] Check if __result is not null to create an object

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -574,6 +574,9 @@ namespace ObjC {
 					return;
 				if (!types.Contains (t))
 					goto default;
+
+				implementation.WriteLine ($"\tif (!__result)");
+				implementation.WriteLine ($"\t\t return nil;");
 				// TODO: cheating by reusing `initForSuper` - maybe a better name is needed
 				implementation.WriteLine ($"\t{GetTypeName (t)}* __peer = [[{GetTypeName (t)} alloc] initForSuper];");
 				implementation.WriteLine ("\t__peer->_object = mono_embeddinator_create_object (__result);");

--- a/tests/managed/methods.cs
+++ b/tests/managed/methods.cs
@@ -62,6 +62,8 @@ namespace Methods {
 		{
 			return new Item (id);
 		}
+
+		public static Item ReturnNull () => null;
 	}
 
 	public class Collection {

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -148,7 +148,10 @@
 	[collection setItem:0 value:item2];
 	XCTAssert ([collection count] == 1, "count 2");
 	XCTAssert ([[collection getItem:0] integer] == [item2 integer], "get 2");
-	
+
+	Methods_Item *nilitem = [Methods_Factory returnNull];
+	XCTAssertNil(nilitem);
+
 	[collection removeItem:item]; // not there
 	XCTAssert ([collection count] == 1, "count 3");
 


### PR DESCRIPTION
The managed API could return `null` even if no exception occurred so we tried to create an object with `mono_embeddinator_create_object (__result);` and 💥  so we check now if `__result` is `null` and return `nil` instead.