### PR TITLE
Implement Indexed and Keyed Subscripting

### DIFF
--- a/docs/error.md
+++ b/docs/error.md
@@ -135,16 +135,6 @@ Note: Supported features will evolve with new versions of the tool.
 
 This is a **warning** that the indexed properties on `T` will be ignored (i.e. nothing will be generated) because multiple indexed properties are not supported.
 
-Note: Supported features will evolve with new versions of the tool.
-
-<h3><a name="EM1050"/>Property `P` is not generated because of field type `T` is not supported.</h3>
-
-This is a **warning** that the property `P` will be ignored (i.e. nothing will be generated) because field type `T` is not supported.
-
-There should be an earlier warning giving more information why type `T` is not supported.
-
-Note: Supported features will evolve with new versions of the tool.
-
 
 
 <!-- 2xxx: code generation -->

--- a/docs/error.md
+++ b/docs/error.md
@@ -131,6 +131,11 @@ There should be an earlier warning giving more information why type `T` is not s
 
 Note: Supported features will evolve with new versions of the tool.
 
+<h3><a name="EM1041"/>Indexed properties on `T` is not generated because multiple indexed properties are not supported.</h3>
+
+This is a **warning** that the indexed properties on `T` will be ignored (i.e. nothing will be generated) because multiple indexed properties are not supported.
+
+Note: Supported features will evolve with new versions of the tool.
 
 <h3><a name="EM1050"/>Property `P` is not generated because of field type `T` is not supported.</h3>
 
@@ -141,11 +146,6 @@ There should be an earlier warning giving more information why type `T` is not s
 Note: Supported features will evolve with new versions of the tool.
 
 
-<h3><a name="EM1060"/>Property `P` is not generated because multiple indexed properties not supported.</h3>
-
-This is a **warning** that the property `P` will be ignored (i.e. nothing will be generated) because multiple indexed properties not supported.
-
-Note: Supported features will evolve with new versions of the tool.
 
 <!-- 2xxx: code generation -->
 

--- a/docs/error.md
+++ b/docs/error.md
@@ -132,6 +132,21 @@ There should be an earlier warning giving more information why type `T` is not s
 Note: Supported features will evolve with new versions of the tool.
 
 
+<h3><a name="EM1050"/>Property `P` is not generated because of field type `T` is not supported.</h3>
+
+This is a **warning** that the property `P` will be ignored (i.e. nothing will be generated) because field type `T` is not supported.
+
+There should be an earlier warning giving more information why type `T` is not supported.
+
+Note: Supported features will evolve with new versions of the tool.
+
+
+<h3><a name="EM1060"/>Property `P` is not generated because multiple indexed properties not supported.</h3>
+
+This is a **warning** that the property `P` will be ignored (i.e. nothing will be generated) because multiple indexed properties not supported.
+
+Note: Supported features will evolve with new versions of the tool.
+
 <!-- 2xxx: code generation -->
 
 # EM2xxx: Code Generation

--- a/objcgen/objcgen.csproj
+++ b/objcgen/objcgen.csproj
@@ -309,6 +309,7 @@
     <Compile Include="objcgenerator-helpers.cs" />
     <Compile Include="objcgenerator-processor.cs" />
     <Compile Include="extensions.cs" />
+    <Compile Include="objcgenerator-subscripts.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="support\" />

--- a/objcgen/objcgenerator-processor.cs
+++ b/objcgen/objcgenerator-processor.cs
@@ -203,9 +203,10 @@ namespace ObjC {
 						properties.Add (t, props);
 
 					if (subscriptProps.Count > 0) {
-						if (subscriptProps.Count > 1)
+						if (subscriptProps.Count > 1) {
 							delayed.Add (ErrorHelper.CreateWarning (1041, $"Indexed properties on {t.Name} is not generated because multiple indexed properties not supported."));
-
+							subscriptProps.RemoveRange (1, subscriptProps.Count - 1);
+						}
 						subscriptProperties.Add (t, subscriptProps);
 					}
 

--- a/objcgen/objcgenerator-processor.cs
+++ b/objcgen/objcgenerator-processor.cs
@@ -203,11 +203,10 @@ namespace ObjC {
 						properties.Add (t, props);
 
 					if (subscriptProps.Count > 0) {
-						if (subscriptProps.Count > 1) {
+						if (subscriptProps.Count > 1)
 							delayed.Add (ErrorHelper.CreateWarning (1041, $"Indexed properties on {t.Name} is not generated because multiple indexed properties not supported."));
-							subscriptProps.RemoveRange (1, subscriptProps.Count - 1);
-						}
-						subscriptProperties.Add (t, subscriptProps);
+						else
+							subscriptProperties.Add (t, subscriptProps);
 					}
 
 					// fields will need to be wrapped within properties

--- a/objcgen/objcgenerator-processor.cs
+++ b/objcgen/objcgenerator-processor.cs
@@ -202,7 +202,7 @@ namespace ObjC {
 
 					if (subscriptProps.Count > 0) {
 						if (subscriptProps.Count > 1)
-							delayed.Add (ErrorHelper.CreateWarning (1060, $"Property `fi` is not generated because multiple indexed properties not supported."));
+							delayed.Add (ErrorHelper.CreateWarning (1041, $"Indexed properties on {t.Name} is not generated because multiple indexed properties not supported."));
 
 						subscriptProperties.Add (t, subscriptProps);
 					}

--- a/objcgen/objcgenerator-processor.cs
+++ b/objcgen/objcgenerator-processor.cs
@@ -157,6 +157,7 @@ namespace ObjC {
 		Dictionary<Type, List<MethodInfo>> methods = new Dictionary<Type, List<MethodInfo>> ();
 		Dictionary<Type, List<PropertyInfo>> properties = new Dictionary<Type, List<PropertyInfo>> ();
 		Dictionary<Type, List<FieldInfo>> fields = new Dictionary<Type, List<FieldInfo>> ();
+		Dictionary<Type, List<PropertyInfo>> subscriptProperties = new Dictionary<Type, List<PropertyInfo>> ();
 
 		public override void Process (IEnumerable<Assembly> assemblies)
 		{
@@ -176,15 +177,20 @@ namespace ObjC {
 						methods.Add (t, meths);
 
 					var props = new List<PropertyInfo> ();
+					var subscriptProps = new List<PropertyInfo> ();
 					foreach (var pi in GetProperties (t)) {
 						var getter = pi.GetGetMethod ();
 						var setter = pi.GetSetMethod ();
 						// setter only property are valid in .NET and we need to generate a method in ObjC (there's no writeonly properties)
 						if (getter == null)
 							continue;
-						// indexers are implemented as methods
-						if ((getter.ParameterCount > 0) || ((setter != null) && setter.ParameterCount > 1))
+
+						// indexers are implemented as methods and object subscripting
+						if ((getter.ParameterCount > 0) || ((setter != null) && setter.ParameterCount > 1)) {
+							subscriptProps.Add (pi);
 							continue;
+						}
+
 						// we can do better than methods for the more common cases (readonly and readwrite)
 						meths.Remove (getter);
 						meths.Remove (setter);
@@ -193,6 +199,13 @@ namespace ObjC {
 					props = props.OrderBy ((arg) => arg.Name).ToList ();
 					if (props.Count > 0)
 						properties.Add (t, props);
+
+					if (subscriptProps.Count > 0) {
+						if (subscriptProps.Count > 1)
+							delayed.Add (ErrorHelper.CreateWarning (1060, $"Property `fi` is not generated because multiple indexed properties not supported."));
+
+						subscriptProperties.Add (t, subscriptProps);
+					}
 
 					// fields will need to be wrapped within properties - except for enums
 					if (!t.IsEnum) {

--- a/objcgen/objcgenerator-subscripts.cs
+++ b/objcgen/objcgenerator-subscripts.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using IKVM.Reflection;
+using Type = IKVM.Reflection.Type;
+
+using Embeddinator;
+
+namespace ObjC
+{
+	public partial class ObjCGenerator
+	{
+		protected void GenerateSubscript (PropertyInfo pi)
+		{
+			Type indexType = pi.GetSetMethod ().GetParameters ()[0].ParameterType;
+			Type paramType = pi.PropertyType;
+			switch (Type.GetTypeCode (indexType)) {
+				case TypeCode.Byte:
+				case TypeCode.SByte:
+				case TypeCode.UInt16:
+				case TypeCode.UInt32:
+				case TypeCode.UInt64:
+				case TypeCode.Int16:
+				case TypeCode.Int32:
+					GenerateIndexedSubscripting (indexType, paramType);
+					return;
+				default:
+					GenerateKeyedSubscripting (paramType);
+					return;
+			}
+		}
+
+		protected void GenerateKeyedSubscripting (Type paramType)
+		{
+		}
+
+		protected void GenerateIndexedSubscripting (Type indexType, Type propertyType)
+		{
+			string indexTypeString = GetTypeName (indexType);
+
+			headers.WriteLine ($"- (id)objectAtIndexedSubscript:({indexTypeString})idx;");
+
+			implementation.WriteLine ($"- (id)objectAtIndexedSubscript:({indexTypeString})idx");
+			implementation.WriteLine ("{");
+			implementation.WriteLine ($"\treturn {FromRawToNSObject (propertyType, "[self getItem:idx]")};");
+			implementation.WriteLine ("}");
+			implementation.WriteLine ();
+
+			headers.WriteLine ($"- (void)setObject:(id)obj atIndexedSubscript: ({indexTypeString})idx;");
+
+			implementation.WriteLine ($"- (void)setObject:(id)obj atIndexedSubscript: ({indexTypeString})idx");
+			implementation.WriteLine ("{");
+			implementation.WriteLine ($"\t[self setItem:idx value:{FromNSObjectToRaw (propertyType, "obj")}];");
+			implementation.WriteLine ("}");
+			implementation.WriteLine ();
+		}
+
+		internal string FromRawToNSObject (Type type, string code)
+		{
+			switch (Type.GetTypeCode (type)) {
+				case TypeCode.Boolean:
+					return $"[[NSNumber alloc] initWithBool: {code}]";
+				case TypeCode.SByte:
+					return $"[[NSNumber alloc] initWithChar: {code}]";
+				case TypeCode.Byte:
+					return $"[[NSNumber alloc] initWithUnsignedChar: {code}]";
+				case TypeCode.Int16:
+					return $"[[NSNumber alloc] initWithShort: {code}]";
+				case TypeCode.UInt16:
+					return $"[[NSNumber alloc] initWithUnsignedShort: {code}]";
+				case TypeCode.Int32:
+					return $"[[NSNumber alloc] initWithInt: {code}]";
+				case TypeCode.UInt32:
+					return $"[[NSNumber alloc] initWithUnsignedInt: {code}]";
+				case TypeCode.Int64:
+					return $"[[NSNumber alloc] initWithLongLong: {code}]";
+				case TypeCode.UInt64:
+					return $"[[NSNumber alloc] initWithUnsignedLong: {code}]";
+				case TypeCode.Single:
+					return $"[[NSNumber alloc] initWithFloat: {code}]";
+				case TypeCode.Double:
+					return $"[[NSNumber alloc] initWithDouble: {code}]";
+				case TypeCode.Char:
+					return $"[[NSNumber alloc] initWithUnsignedChar: {code}]"; // TODO - Not sure on this
+				case TypeCode.String:
+				case TypeCode.Object:
+					return code;
+				default:
+					throw new NotSupportedException ();
+			}
+		}
+
+		internal string FromNSObjectToRaw (Type type, string code)
+		{
+			switch (Type.GetTypeCode (type)) {
+				case TypeCode.Boolean:
+					return $"[{code} boolValue]";
+				case TypeCode.SByte:
+					return $"[{code} charValue]";
+				case TypeCode.Byte:
+					return $"[{code} unsignedCharValue]";
+				case TypeCode.Int16:
+					return $"[{code} shortValue]";
+				case TypeCode.UInt16:
+					return $"[{code} unsignedShortValue]";
+				case TypeCode.Int32:
+					return $"[{code} intValue]";
+				case TypeCode.UInt32:
+					return $"[{code} unsignedIntValue]";
+				case TypeCode.Int64:
+					return $"[{code} longLongValue]";
+				case TypeCode.UInt64:
+					return $"[{code} unsignedLongLongValue]";
+				case TypeCode.Single:
+					return $"[{code} floatValue]";
+				case TypeCode.Double:
+					return $"[{code} doubleValue]";
+				case TypeCode.Char:
+					return $"[{code} unsignedCharValue]"; // TODO - Not sure on this
+				case TypeCode.String:
+				case TypeCode.Object:
+					return code;
+				default:
+					throw new NotSupportedException ();
+			}
+		}
+	}
+}

--- a/objcgen/objcgenerator-subscripts.cs
+++ b/objcgen/objcgenerator-subscripts.cs
@@ -6,9 +6,9 @@ using Type = IKVM.Reflection.Type;
 using Embeddinator;
 
 namespace ObjC {
-	
+
 	public partial class ObjCGenerator {
-		
+
 		protected void GenerateSubscript (PropertyInfo pi)
 		{
 			Type indexType = pi.GetSetMethod ().GetParameters ()[0].ParameterType;

--- a/objcgen/objcgenerator-subscripts.cs
+++ b/objcgen/objcgenerator-subscripts.cs
@@ -1,18 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 
 using IKVM.Reflection;
 using Type = IKVM.Reflection.Type;
 
 using Embeddinator;
 
-namespace ObjC
-{
-	public partial class ObjCGenerator
-	{
+namespace ObjC {
+	
+	public partial class ObjCGenerator {
+		
 		protected void GenerateSubscript (PropertyInfo pi)
 		{
 			Type indexType = pi.GetSetMethod ().GetParameters ()[0].ParameterType;
@@ -25,6 +21,7 @@ namespace ObjC
 			case TypeCode.UInt64:
 			case TypeCode.Int16:
 			case TypeCode.Int32:
+			case TypeCode.Int64:
 				GenerateIndexedSubscripting (indexType, paramType);
 				return;
 			default:
@@ -88,6 +85,7 @@ namespace ObjC
 				return $"[[NSNumber alloc] initWithUnsignedChar: {code}]";
 			case TypeCode.Int16:
 				return $"[[NSNumber alloc] initWithShort: {code}]";
+			case TypeCode.Char:
 			case TypeCode.UInt16:
 				return $"[[NSNumber alloc] initWithUnsignedShort: {code}]";
 			case TypeCode.Int32:
@@ -102,13 +100,11 @@ namespace ObjC
 				return $"[[NSNumber alloc] initWithFloat: {code}]";
 			case TypeCode.Double:
 				return $"[[NSNumber alloc] initWithDouble: {code}]";
-			case TypeCode.Char:
-				return $"[[NSNumber alloc] initWithUnsignedChar: {code}]"; // TODO - Not sure on this
 			case TypeCode.String:
 			case TypeCode.Object:
 				return code;
 			default:
-				throw new NotSupportedException ();
+				throw new EmbeddinatorException (99, $"Internal error `unexpected type {type} in subscript generation`. Please file a bug report with a test case (https://github.com/mono/Embeddinator-4000/issues");
 			}
 		}
 
@@ -123,6 +119,7 @@ namespace ObjC
 				return $"[{code} unsignedCharValue]";
 			case TypeCode.Int16:
 				return $"[{code} shortValue]";
+			case TypeCode.Char:
 			case TypeCode.UInt16:
 				return $"[{code} unsignedShortValue]";
 			case TypeCode.Int32:
@@ -137,13 +134,11 @@ namespace ObjC
 				return $"[{code} floatValue]";
 			case TypeCode.Double:
 				return $"[{code} doubleValue]";
-			case TypeCode.Char:
-				return $"[{code} unsignedCharValue]"; // TODO - Not sure on this
 			case TypeCode.String:
 			case TypeCode.Object:
 				return code;
 			default:
-				throw new NotSupportedException ();
+				throw new EmbeddinatorException (99, $"Internal error `unexpected type {type} in subscript generation`. Please file a bug report with a test case (https://github.com/mono/Embeddinator-4000/issues");
 			}
 		}
 	}

--- a/objcgen/objcgenerator-subscripts.cs
+++ b/objcgen/objcgenerator-subscripts.cs
@@ -18,18 +18,18 @@ namespace ObjC
 			Type indexType = pi.GetSetMethod ().GetParameters ()[0].ParameterType;
 			Type paramType = pi.PropertyType;
 			switch (Type.GetTypeCode (indexType)) {
-				case TypeCode.Byte:
-				case TypeCode.SByte:
-				case TypeCode.UInt16:
-				case TypeCode.UInt32:
-				case TypeCode.UInt64:
-				case TypeCode.Int16:
-				case TypeCode.Int32:
-					GenerateIndexedSubscripting (indexType, paramType);
-					return;
-				default:
-					GenerateKeyedSubscripting (paramType);
-					return;
+			case TypeCode.Byte:
+			case TypeCode.SByte:
+			case TypeCode.UInt16:
+			case TypeCode.UInt32:
+			case TypeCode.UInt64:
+			case TypeCode.Int16:
+			case TypeCode.Int32:
+				GenerateIndexedSubscripting (indexType, paramType);
+				return;
+			default:
+				GenerateKeyedSubscripting (paramType);
+				return;
 			}
 		}
 
@@ -45,7 +45,7 @@ namespace ObjC
 
 			implementation.WriteLine ($"- (id)objectAtIndexedSubscript:({indexTypeString})idx");
 			implementation.WriteLine ("{");
-			implementation.WriteLine ($"\treturn {FromRawToNSObject (propertyType, "[self getItem:idx]")};");
+			implementation.WriteLine ($"\treturn {ToNSNumber (propertyType, "[self getItem:idx]")};");
 			implementation.WriteLine ("}");
 			implementation.WriteLine ();
 
@@ -53,78 +53,78 @@ namespace ObjC
 
 			implementation.WriteLine ($"- (void)setObject:(id)obj atIndexedSubscript: ({indexTypeString})idx");
 			implementation.WriteLine ("{");
-			implementation.WriteLine ($"\t[self setItem:idx value:{FromNSObjectToRaw (propertyType, "obj")}];");
+			implementation.WriteLine ($"\t[self setItem:idx value:{FromNSNumber (propertyType, "obj")}];");
 			implementation.WriteLine ("}");
 			implementation.WriteLine ();
 		}
 
-		internal string FromRawToNSObject (Type type, string code)
+		internal string ToNSNumber (Type type, string code)
 		{
 			switch (Type.GetTypeCode (type)) {
-				case TypeCode.Boolean:
-					return $"[[NSNumber alloc] initWithBool: {code}]";
-				case TypeCode.SByte:
-					return $"[[NSNumber alloc] initWithChar: {code}]";
-				case TypeCode.Byte:
-					return $"[[NSNumber alloc] initWithUnsignedChar: {code}]";
-				case TypeCode.Int16:
-					return $"[[NSNumber alloc] initWithShort: {code}]";
-				case TypeCode.UInt16:
-					return $"[[NSNumber alloc] initWithUnsignedShort: {code}]";
-				case TypeCode.Int32:
-					return $"[[NSNumber alloc] initWithInt: {code}]";
-				case TypeCode.UInt32:
-					return $"[[NSNumber alloc] initWithUnsignedInt: {code}]";
-				case TypeCode.Int64:
-					return $"[[NSNumber alloc] initWithLongLong: {code}]";
-				case TypeCode.UInt64:
-					return $"[[NSNumber alloc] initWithUnsignedLong: {code}]";
-				case TypeCode.Single:
-					return $"[[NSNumber alloc] initWithFloat: {code}]";
-				case TypeCode.Double:
-					return $"[[NSNumber alloc] initWithDouble: {code}]";
-				case TypeCode.Char:
-					return $"[[NSNumber alloc] initWithUnsignedChar: {code}]"; // TODO - Not sure on this
-				case TypeCode.String:
-				case TypeCode.Object:
-					return code;
-				default:
-					throw new NotSupportedException ();
+			case TypeCode.Boolean:
+				return $"[[NSNumber alloc] initWithBool: {code}]";
+			case TypeCode.SByte:
+				return $"[[NSNumber alloc] initWithChar: {code}]";
+			case TypeCode.Byte:
+				return $"[[NSNumber alloc] initWithUnsignedChar: {code}]";
+			case TypeCode.Int16:
+				return $"[[NSNumber alloc] initWithShort: {code}]";
+			case TypeCode.UInt16:
+				return $"[[NSNumber alloc] initWithUnsignedShort: {code}]";
+			case TypeCode.Int32:
+				return $"[[NSNumber alloc] initWithInt: {code}]";
+			case TypeCode.UInt32:
+				return $"[[NSNumber alloc] initWithUnsignedInt: {code}]";
+			case TypeCode.Int64:
+				return $"[[NSNumber alloc] initWithLongLong: {code}]";
+			case TypeCode.UInt64:
+				return $"[[NSNumber alloc] initWithUnsignedLong: {code}]";
+			case TypeCode.Single:
+				return $"[[NSNumber alloc] initWithFloat: {code}]";
+			case TypeCode.Double:
+				return $"[[NSNumber alloc] initWithDouble: {code}]";
+			case TypeCode.Char:
+				return $"[[NSNumber alloc] initWithUnsignedChar: {code}]"; // TODO - Not sure on this
+			case TypeCode.String:
+			case TypeCode.Object:
+				return code;
+			default:
+				throw new NotSupportedException ();
 			}
 		}
 
-		internal string FromNSObjectToRaw (Type type, string code)
+		internal string FromNSNumber (Type type, string code)
 		{
 			switch (Type.GetTypeCode (type)) {
-				case TypeCode.Boolean:
-					return $"[{code} boolValue]";
-				case TypeCode.SByte:
-					return $"[{code} charValue]";
-				case TypeCode.Byte:
-					return $"[{code} unsignedCharValue]";
-				case TypeCode.Int16:
-					return $"[{code} shortValue]";
-				case TypeCode.UInt16:
-					return $"[{code} unsignedShortValue]";
-				case TypeCode.Int32:
-					return $"[{code} intValue]";
-				case TypeCode.UInt32:
-					return $"[{code} unsignedIntValue]";
-				case TypeCode.Int64:
-					return $"[{code} longLongValue]";
-				case TypeCode.UInt64:
-					return $"[{code} unsignedLongLongValue]";
-				case TypeCode.Single:
-					return $"[{code} floatValue]";
-				case TypeCode.Double:
-					return $"[{code} doubleValue]";
-				case TypeCode.Char:
-					return $"[{code} unsignedCharValue]"; // TODO - Not sure on this
-				case TypeCode.String:
-				case TypeCode.Object:
-					return code;
-				default:
-					throw new NotSupportedException ();
+			case TypeCode.Boolean:
+				return $"[{code} boolValue]";
+			case TypeCode.SByte:
+				return $"[{code} charValue]";
+			case TypeCode.Byte:
+				return $"[{code} unsignedCharValue]";
+			case TypeCode.Int16:
+				return $"[{code} shortValue]";
+			case TypeCode.UInt16:
+				return $"[{code} unsignedShortValue]";
+			case TypeCode.Int32:
+				return $"[{code} intValue]";
+			case TypeCode.UInt32:
+				return $"[{code} unsignedIntValue]";
+			case TypeCode.Int64:
+				return $"[{code} longLongValue]";
+			case TypeCode.UInt64:
+				return $"[{code} unsignedLongLongValue]";
+			case TypeCode.Single:
+				return $"[{code} floatValue]";
+			case TypeCode.Double:
+				return $"[{code} doubleValue]";
+			case TypeCode.Char:
+				return $"[{code} unsignedCharValue]"; // TODO - Not sure on this
+			case TypeCode.String:
+			case TypeCode.Object:
+				return code;
+			default:
+				throw new NotSupportedException ();
 			}
 		}
 	}

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -280,6 +280,13 @@ namespace ObjC {
 					Generate (fi);
 			}
 
+			List<PropertyInfo> s;
+			if (subscriptProperties.TryGetValue (t, out s)) {
+				headers.WriteLine ();
+				foreach (var si in s)
+					GenerateSubscript (si);
+			}
+
 			List<MethodInfo> meths;
 			if (methods.TryGetValue (t, out meths)) {
 				headers.WriteLine ();

--- a/tests/managed/.gitignore
+++ b/tests/managed/.gitignore
@@ -1,0 +1,1 @@
+subscripts.cs

--- a/tests/managed/CustomBuildActions.targets
+++ b/tests/managed/CustomBuildActions.targets
@@ -1,0 +1,5 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="BeforeBuild">
+		<Exec Command="/Library/Frameworks/Mono.framework/Commands/mono &quot;/Applications/Xamarin Studio.app/Contents/Resources/lib/monodevelop/AddIns/MonoDevelop.TextTemplating/TextTransform.exe&quot; subscripts.tt -o subscripts.cs" />
+    	</Target>  
+</Project>

--- a/tests/managed/managed.csproj
+++ b/tests/managed/managed.csproj
@@ -50,4 +50,5 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="CustomBuildActions.targets" />
 </Project>

--- a/tests/managed/managed.csproj
+++ b/tests/managed/managed.csproj
@@ -38,6 +38,15 @@
     <Compile Include="methods.cs" />
     <Compile Include="structs.cs" />
     <Compile Include="enums.cs" />
+    <Compile Include="subscripts.cs">
+      <DependentUpon>subscripts.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="subscripts.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>subscripts.cs</LastGenOutput>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/managed/properties.cs
+++ b/tests/managed/properties.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 // static type
 public static class Platform {

--- a/tests/managed/properties.cs
+++ b/tests/managed/properties.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 // static type
 public static class Platform {

--- a/tests/managed/subscripts.tt
+++ b/tests/managed/subscripts.tt
@@ -1,7 +1,5 @@
 ﻿﻿<#@ template language="C#" #>
-<#@ assembly name="System.Core" #>
 <#@ import namespace="System" #>
-<#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
 using System.Collections.Generic;

--- a/tests/managed/subscripts.tt
+++ b/tests/managed/subscripts.tt
@@ -1,0 +1,35 @@
+﻿﻿<#@ template language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+using System.Collections.Generic;
+
+namespace Subscripts
+{
+<# foreach (var t in new string [] {"bool", "sbyte", "byte", "short", "ushort", "int", "uint", "long", "ulong", "float", "double", "char", "string"}) { #>
+	public class <#=Char.ToUpperInvariant (t[0]) + t.Substring(1).ToLowerInvariant()  #>Collection
+	{
+		List<<#=t#>> c = new List<<#=t#>> ();
+
+		public void Add (<#=t#> item)
+		{
+			c.Add (item);
+		}
+
+		public void Remove (<#=t#> item)
+		{
+			c.Remove (item);
+		}
+
+		public int Count => c.Count;
+
+		public <#=t#> this[int index] {
+			get { return c[index]; }
+			set { c[index] = value; }
+		}
+	}
+
+<# } #>
+}

--- a/tests/managed/subscripts.tt
+++ b/tests/managed/subscripts.tt
@@ -31,5 +31,27 @@ namespace Subscripts
 		}
 	}
 
+	public class <#=Char.ToUpperInvariant (t[0]) + t.Substring(1).ToLowerInvariant()  #>DictionaryCollection
+	{
+		Dictionary <string, <#=t#>> c = new Dictionary <string, <#=t#>> ();
+
+		public void Add (string key, <#=t#> item)
+		{
+			c.Add (key, item);
+		}
+
+		public void Remove (string key)
+		{
+			c.Remove (key);
+		}
+
+		public int Count => c.Count;
+
+		public <#=t#> this[string key] {
+			get { return c[key]; }
+			set { c[key] = value; }
+		}
+	}
+
 <# } #>
 }

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -357,9 +357,9 @@
     XCTAssert ([BoolCollection count] == 0, "count 0");
     [BoolCollection addKey:@"asdf" item:YES];
     XCTAssert ([BoolCollection count] == 1, "count 1");
-    XCTAssert ([BoolCollection [@"asdf"] isEqual:YES], "get 0");
+    XCTAssert ([BoolCollection [@"asdf"] isEqual:@YES], "get 0");
     BoolCollection[@"asdf"] = NO;
-    XCTAssert ([BoolCollection [@"asdf"] isEqual:NO], "get 1");
+    XCTAssert ([BoolCollection [@"asdf"] isEqual:@NO], "get 1");
     
     Subscripts_SbyteDictionaryCollection *SbyteCollection = [[Subscripts_SbyteDictionaryCollection alloc] init];
     XCTAssert ([SbyteCollection count] == 0, "count 2");

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -246,4 +246,110 @@
     XCTAssertEqualObjects (@"Hello World", [Type_String nonEmptyString], "non-empty string");
 }
 
+- (void) testObjectIndexedSubscripting {
+    Subscripts_BoolCollection *boolCollection = [[Subscripts_BoolCollection alloc] init];
+    XCTAssert ([boolCollection count] == 0, "count 0");
+    [boolCollection addItem:YES];
+    XCTAssert ([boolCollection count] == 1, "count 1");
+    XCTAssert ([boolCollection [0] isEqual:@YES], "get 0");
+    boolCollection[0] = NO;
+    XCTAssert ([boolCollection [0] isEqual:@NO], "get 1");
+    
+    Subscripts_SbyteCollection *sbyteCollection = [[Subscripts_SbyteCollection alloc] init];
+    XCTAssert ([sbyteCollection count] == 0, "count 2");
+    [sbyteCollection addItem:42];
+    XCTAssert ([sbyteCollection count] == 1, "count 3");
+    XCTAssert ([sbyteCollection [0] isEqual:@42], "get 2");
+    sbyteCollection[0] = @13;
+    XCTAssert ([sbyteCollection [0] isEqual:@13], "get 3");
+    
+    Subscripts_ByteCollection *byteCollection = [[Subscripts_ByteCollection alloc] init];
+    XCTAssert ([byteCollection count] == 0, "count 4");
+    [byteCollection addItem:42];
+    XCTAssert ([byteCollection count] == 1, "count 5");
+    XCTAssert ([byteCollection [0] isEqual:@42], "get 4");
+    byteCollection[0] = @13;
+    XCTAssert ([byteCollection [0] isEqual:@13], "get 5");
+    
+    Subscripts_ShortCollection *shortCollection = [[Subscripts_ShortCollection alloc] init];
+    XCTAssert ([shortCollection count] == 0, "count 6");
+    [shortCollection addItem:42];
+    XCTAssert ([shortCollection count] == 1, "count 7");
+    XCTAssert ([shortCollection [0] isEqual:@42], "get 6");
+    shortCollection[0] = @13;
+    XCTAssert ([shortCollection [0] isEqual:@13], "get 7");
+    
+    Subscripts_UshortCollection *ushortCollection = [[Subscripts_UshortCollection alloc] init];
+    XCTAssert ([ushortCollection count] == 0, "count 8");
+    [ushortCollection addItem:42];
+    XCTAssert ([ushortCollection count] == 1, "count 9");
+    XCTAssert ([ushortCollection [0] isEqual:@42], "get 8");
+    ushortCollection[0] = @13;
+    XCTAssert ([ushortCollection [0] isEqual:@13], "get 9");
+    
+    Subscripts_IntCollection *intCollection = [[Subscripts_IntCollection alloc] init];
+    XCTAssert ([intCollection count] == 0, "count 10");
+    [intCollection addItem:42];
+    XCTAssert ([intCollection count] == 1, "count 11");
+    XCTAssert ([intCollection [0] isEqual:@42], "get 10");
+    intCollection[0] = @13;
+    XCTAssert ([intCollection [0] isEqual:@13], "get 11");
+    
+    Subscripts_UintCollection *uintCollection = [[Subscripts_UintCollection alloc] init];
+    XCTAssert ([uintCollection count] == 0, "count 12");
+    [uintCollection addItem:42];
+    XCTAssert ([uintCollection count] == 1, "count 13");
+    XCTAssert ([uintCollection [0] isEqual:@42], "get 12");
+    uintCollection[0] = @13;
+    XCTAssert ([uintCollection [0] isEqual:@13], "get 13");
+    
+    Subscripts_LongCollection *longCollection = [[Subscripts_LongCollection alloc] init];
+    XCTAssert ([longCollection count] == 0, "count 14");
+    [longCollection addItem:42];
+    XCTAssert ([longCollection count] == 1, "count 15");
+    XCTAssert ([longCollection [0] isEqual:@42], "get 14");
+    longCollection[0] = @13;
+    XCTAssert ([longCollection [0] isEqual:@13], "get 15");
+    
+    Subscripts_UlongCollection *ulongCollection = [[Subscripts_UlongCollection alloc] init];
+    XCTAssert ([ulongCollection count] == 0, "count 16");
+    [ulongCollection addItem:42];
+    XCTAssert ([ulongCollection count] == 1, "count 17");
+    XCTAssert ([ulongCollection [0] isEqual:@42], "get 16");
+    ulongCollection[0] = @13;
+    XCTAssert ([ulongCollection [0] isEqual:@13], "get 17");
+    
+    Subscripts_FloatCollection *floatCollection = [[Subscripts_FloatCollection alloc] init];
+    XCTAssert ([floatCollection count] == 0, "count 18");
+    [floatCollection addItem:42];
+    XCTAssert ([floatCollection count] == 1, "count 19");
+    XCTAssert ([floatCollection [0] isEqual:@42], "get 18");
+    floatCollection[0] = @13;
+    XCTAssert ([floatCollection [0] isEqual:@13], "get 19");
+    
+    Subscripts_DoubleCollection *doubleCollection = [[Subscripts_DoubleCollection alloc] init];
+    XCTAssert ([doubleCollection count] == 0, "count 20");
+    [doubleCollection addItem:42];
+    XCTAssert ([doubleCollection count] == 1, "count 21");
+    XCTAssert ([doubleCollection [0] isEqual:@42], "get 20");
+    doubleCollection[0] = @13;
+    XCTAssert ([doubleCollection [0] isEqual:@13], "get 21");
+    
+    Subscripts_CharCollection *charCollection = [[Subscripts_CharCollection alloc] init];
+    XCTAssert ([charCollection count] == 0, "count 22");
+    [charCollection addItem:42];
+    XCTAssert ([charCollection count] == 1, "count 23");
+    XCTAssert ([charCollection [0] isEqual:@42], "get 22");
+    charCollection[0] = @13;
+    XCTAssert ([charCollection [0] isEqual:@13], "get 23");
+    
+    Subscripts_StringCollection *stringCollection = [[Subscripts_StringCollection alloc] init];
+    XCTAssert ([stringCollection count] == 0, "count 24");
+    [stringCollection addItem:@"asdf"];
+    XCTAssert ([stringCollection count] == 1, "count 25");
+    XCTAssert ([stringCollection [0] isEqual:@"asdf"], "get 24");
+    stringCollection[0] = @"fdsa";
+    XCTAssert ([stringCollection [0] isEqual:@"fdsa"], "get 25");
+}
+
 @end

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -352,4 +352,109 @@
     XCTAssert ([stringCollection [0] isEqual:@"fdsa"], "get 25");
 }
 
+- (void) testObjectKeyedSubscripting {
+    Subscripts_BoolDictionaryCollection *BoolCollection = [[Subscripts_BoolDictionaryCollection alloc] init];
+    XCTAssert ([BoolCollection count] == 0, "count 0");
+    [BoolCollection addKey:@"asdf" item:YES];
+    XCTAssert ([BoolCollection count] == 1, "count 1");
+    XCTAssert ([BoolCollection [@"asdf"] isEqual:YES], "get 0");
+    BoolCollection[@"asdf"] = NO;
+    XCTAssert ([BoolCollection [@"asdf"] isEqual:NO], "get 1");
+    
+    Subscripts_SbyteDictionaryCollection *SbyteCollection = [[Subscripts_SbyteDictionaryCollection alloc] init];
+    XCTAssert ([SbyteCollection count] == 0, "count 2");
+    [SbyteCollection addKey:@"asdf" item:42];
+    XCTAssert ([SbyteCollection count] == 1, "count 3");
+    XCTAssert ([SbyteCollection [@"asdf"] isEqual:@42], "get 2");
+    SbyteCollection[@"asdf"] = @13;
+    XCTAssert ([SbyteCollection [@"asdf"] isEqual:@13], "get 3");
+    
+    Subscripts_ByteDictionaryCollection *ByteCollection = [[Subscripts_ByteDictionaryCollection alloc] init];
+    XCTAssert ([ByteCollection count] == 0, "count 4");
+    [ByteCollection addKey:@"asdf" item:42];
+    XCTAssert ([ByteCollection count] == 1, "count 5");
+    XCTAssert ([ByteCollection [@"asdf"] isEqual:@42], "get 4");
+    ByteCollection[@"asdf"] = @13;
+    XCTAssert ([ByteCollection [@"asdf"] isEqual:@13], "get 5");
+    
+    Subscripts_ShortDictionaryCollection *ShortCollection = [[Subscripts_ShortDictionaryCollection alloc] init];
+    XCTAssert ([ShortCollection count] == 0, "count 6");
+    [ShortCollection addKey:@"asdf" item:42];
+    XCTAssert ([ShortCollection count] == 1, "count 7");
+    XCTAssert ([ShortCollection [@"asdf"] isEqual:@42], "get 6");
+    ShortCollection[@"asdf"] = @13;
+    XCTAssert ([ShortCollection [@"asdf"] isEqual:@13], "get 7");
+    
+    Subscripts_UshortDictionaryCollection *UshortCollection = [[Subscripts_UshortDictionaryCollection alloc] init];
+    XCTAssert ([UshortCollection count] == 0, "count 8");
+    [UshortCollection addKey:@"asdf" item:42];
+    XCTAssert ([UshortCollection count] == 1, "count 9");
+    XCTAssert ([UshortCollection [@"asdf"] isEqual:@42], "get 8");
+    UshortCollection[@"asdf"] = @13;
+    XCTAssert ([UshortCollection [@"asdf"] isEqual:@13], "get 9");
+    
+    Subscripts_IntDictionaryCollection *IntCollection = [[Subscripts_IntDictionaryCollection alloc] init];
+    XCTAssert ([IntCollection count] == 0, "count 10");
+    [IntCollection addKey:@"asdf" item:42];
+    XCTAssert ([IntCollection count] == 1, "count 11");
+    XCTAssert ([IntCollection [@"asdf"] isEqual:@42], "get 10");
+    IntCollection[@"asdf"] = @13;
+    XCTAssert ([IntCollection [@"asdf"] isEqual:@13], "get 11");
+    
+    Subscripts_UintDictionaryCollection *UintCollection = [[Subscripts_UintDictionaryCollection alloc] init];
+    XCTAssert ([UintCollection count] == 0, "count 12");
+    [UintCollection addKey:@"asdf" item:42];
+    XCTAssert ([UintCollection count] == 1, "count 13");
+    XCTAssert ([UintCollection [@"asdf"] isEqual:@42], "get 12");
+    UintCollection[@"asdf"] = @13;
+    XCTAssert ([UintCollection [@"asdf"] isEqual:@13], "get 13");
+    
+    Subscripts_LongDictionaryCollection *LongCollection = [[Subscripts_LongDictionaryCollection alloc] init];
+    XCTAssert ([LongCollection count] == 0, "count 14");
+    [LongCollection addKey:@"asdf" item:42];
+    XCTAssert ([LongCollection count] == 1, "count 15");
+    XCTAssert ([LongCollection [@"asdf"] isEqual:@42], "get 14");
+    LongCollection[@"asdf"] = @13;
+    XCTAssert ([LongCollection [@"asdf"] isEqual:@13], "get 15");
+    
+    Subscripts_UlongDictionaryCollection *UlongCollection = [[Subscripts_UlongDictionaryCollection alloc] init];
+    XCTAssert ([UlongCollection count] == 0, "count 16");
+    [UlongCollection addKey:@"asdf" item:42];
+    XCTAssert ([UlongCollection count] == 1, "count 17");
+    XCTAssert ([UlongCollection [@"asdf"] isEqual:@42], "get 16");
+    UlongCollection[@"asdf"] = @13;
+    XCTAssert ([UlongCollection [@"asdf"] isEqual:@13], "get 17");
+    
+    Subscripts_FloatDictionaryCollection *FloatCollection = [[Subscripts_FloatDictionaryCollection alloc] init];
+    XCTAssert ([FloatCollection count] == 0, "count 18");
+    [FloatCollection addKey:@"asdf" item:42];
+    XCTAssert ([FloatCollection count] == 1, "count 19");
+    XCTAssert ([FloatCollection [@"asdf"] isEqual:@42], "get 18");
+    FloatCollection[@"asdf"] = @13;
+    XCTAssert ([FloatCollection [@"asdf"] isEqual:@13], "get 19");
+    
+    Subscripts_DoubleDictionaryCollection *DoubleCollection = [[Subscripts_DoubleDictionaryCollection alloc] init];
+    XCTAssert ([DoubleCollection count] == 0, "count 20");
+    [DoubleCollection addKey:@"asdf" item:42];
+    XCTAssert ([DoubleCollection count] == 1, "count 21");
+    XCTAssert ([DoubleCollection [@"asdf"] isEqual:@42], "get 20");
+    DoubleCollection[@"asdf"] = @13;
+    XCTAssert ([DoubleCollection [@"asdf"] isEqual:@13], "get 21");
+    
+    Subscripts_CharDictionaryCollection *CharCollection = [[Subscripts_CharDictionaryCollection alloc] init];
+    XCTAssert ([CharCollection count] == 0, "count 22");
+    [CharCollection addKey:@"asdf" item:42];
+    XCTAssert ([CharCollection count] == 1, "count 23");
+    XCTAssert ([CharCollection [@"asdf"] isEqual:@42], "get 22");
+    CharCollection[@"asdf"] = @13;
+    XCTAssert ([CharCollection [@"asdf"] isEqual:@13], "get 23");
+    
+    Subscripts_StringDictionaryCollection *StringCollection = [[Subscripts_StringDictionaryCollection alloc] init];
+    XCTAssert ([StringCollection count] == 0, "count 24");
+    [StringCollection addKey:@"asdf" item:@"one"];
+    XCTAssert ([StringCollection count] == 1, "count 25");
+    XCTAssert ([StringCollection [@"asdf"] isEqual:@"one"], "get 24");
+    StringCollection[@"asdf"] = @"two";
+    XCTAssert ([StringCollection [@"asdf"] isEqual:@"two"], "get 25");
+}
 @end

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -355,15 +355,15 @@
 - (void) testObjectKeyedSubscripting {
     Subscripts_BoolDictionaryCollection *BoolCollection = [[Subscripts_BoolDictionaryCollection alloc] init];
     XCTAssert ([BoolCollection count] == 0, "count 0");
-    [BoolCollection addKey:@"asdf" item:YES];
+    BoolCollection[@"asdf"] = @YES;
     XCTAssert ([BoolCollection count] == 1, "count 1");
     XCTAssert ([BoolCollection [@"asdf"] isEqual:@YES], "get 0");
-    BoolCollection[@"asdf"] = NO;
+    BoolCollection[@"asdf"] = @NO;
     XCTAssert ([BoolCollection [@"asdf"] isEqual:@NO], "get 1");
     
     Subscripts_SbyteDictionaryCollection *SbyteCollection = [[Subscripts_SbyteDictionaryCollection alloc] init];
     XCTAssert ([SbyteCollection count] == 0, "count 2");
-    [SbyteCollection addKey:@"asdf" item:42];
+    SbyteCollection[@"asdf"] = @42;
     XCTAssert ([SbyteCollection count] == 1, "count 3");
     XCTAssert ([SbyteCollection [@"asdf"] isEqual:@42], "get 2");
     SbyteCollection[@"asdf"] = @13;
@@ -371,7 +371,7 @@
     
     Subscripts_ByteDictionaryCollection *ByteCollection = [[Subscripts_ByteDictionaryCollection alloc] init];
     XCTAssert ([ByteCollection count] == 0, "count 4");
-    [ByteCollection addKey:@"asdf" item:42];
+    ByteCollection[@"asdf"] = @42;
     XCTAssert ([ByteCollection count] == 1, "count 5");
     XCTAssert ([ByteCollection [@"asdf"] isEqual:@42], "get 4");
     ByteCollection[@"asdf"] = @13;
@@ -379,7 +379,7 @@
     
     Subscripts_ShortDictionaryCollection *ShortCollection = [[Subscripts_ShortDictionaryCollection alloc] init];
     XCTAssert ([ShortCollection count] == 0, "count 6");
-    [ShortCollection addKey:@"asdf" item:42];
+    ShortCollection[@"asdf"] = @42;
     XCTAssert ([ShortCollection count] == 1, "count 7");
     XCTAssert ([ShortCollection [@"asdf"] isEqual:@42], "get 6");
     ShortCollection[@"asdf"] = @13;
@@ -387,7 +387,7 @@
     
     Subscripts_UshortDictionaryCollection *UshortCollection = [[Subscripts_UshortDictionaryCollection alloc] init];
     XCTAssert ([UshortCollection count] == 0, "count 8");
-    [UshortCollection addKey:@"asdf" item:42];
+    UshortCollection[@"asdf"] = @42;
     XCTAssert ([UshortCollection count] == 1, "count 9");
     XCTAssert ([UshortCollection [@"asdf"] isEqual:@42], "get 8");
     UshortCollection[@"asdf"] = @13;
@@ -395,7 +395,7 @@
     
     Subscripts_IntDictionaryCollection *IntCollection = [[Subscripts_IntDictionaryCollection alloc] init];
     XCTAssert ([IntCollection count] == 0, "count 10");
-    [IntCollection addKey:@"asdf" item:42];
+    IntCollection[@"asdf"] = @42;
     XCTAssert ([IntCollection count] == 1, "count 11");
     XCTAssert ([IntCollection [@"asdf"] isEqual:@42], "get 10");
     IntCollection[@"asdf"] = @13;
@@ -403,7 +403,7 @@
     
     Subscripts_UintDictionaryCollection *UintCollection = [[Subscripts_UintDictionaryCollection alloc] init];
     XCTAssert ([UintCollection count] == 0, "count 12");
-    [UintCollection addKey:@"asdf" item:42];
+    UintCollection[@"asdf"] = @42;
     XCTAssert ([UintCollection count] == 1, "count 13");
     XCTAssert ([UintCollection [@"asdf"] isEqual:@42], "get 12");
     UintCollection[@"asdf"] = @13;
@@ -411,7 +411,7 @@
     
     Subscripts_LongDictionaryCollection *LongCollection = [[Subscripts_LongDictionaryCollection alloc] init];
     XCTAssert ([LongCollection count] == 0, "count 14");
-    [LongCollection addKey:@"asdf" item:42];
+    LongCollection[@"asdf"] = @42;
     XCTAssert ([LongCollection count] == 1, "count 15");
     XCTAssert ([LongCollection [@"asdf"] isEqual:@42], "get 14");
     LongCollection[@"asdf"] = @13;
@@ -419,7 +419,7 @@
     
     Subscripts_UlongDictionaryCollection *UlongCollection = [[Subscripts_UlongDictionaryCollection alloc] init];
     XCTAssert ([UlongCollection count] == 0, "count 16");
-    [UlongCollection addKey:@"asdf" item:42];
+    UlongCollection[@"asdf"] = @42;
     XCTAssert ([UlongCollection count] == 1, "count 17");
     XCTAssert ([UlongCollection [@"asdf"] isEqual:@42], "get 16");
     UlongCollection[@"asdf"] = @13;
@@ -427,7 +427,7 @@
     
     Subscripts_FloatDictionaryCollection *FloatCollection = [[Subscripts_FloatDictionaryCollection alloc] init];
     XCTAssert ([FloatCollection count] == 0, "count 18");
-    [FloatCollection addKey:@"asdf" item:42];
+    FloatCollection[@"asdf"] = @42;
     XCTAssert ([FloatCollection count] == 1, "count 19");
     XCTAssert ([FloatCollection [@"asdf"] isEqual:@42], "get 18");
     FloatCollection[@"asdf"] = @13;
@@ -435,7 +435,7 @@
     
     Subscripts_DoubleDictionaryCollection *DoubleCollection = [[Subscripts_DoubleDictionaryCollection alloc] init];
     XCTAssert ([DoubleCollection count] == 0, "count 20");
-    [DoubleCollection addKey:@"asdf" item:42];
+    DoubleCollection[@"asdf"] = @42;
     XCTAssert ([DoubleCollection count] == 1, "count 21");
     XCTAssert ([DoubleCollection [@"asdf"] isEqual:@42], "get 20");
     DoubleCollection[@"asdf"] = @13;
@@ -443,7 +443,7 @@
     
     Subscripts_CharDictionaryCollection *CharCollection = [[Subscripts_CharDictionaryCollection alloc] init];
     XCTAssert ([CharCollection count] == 0, "count 22");
-    [CharCollection addKey:@"asdf" item:42];
+    CharCollection[@"asdf"] = @42;
     XCTAssert ([CharCollection count] == 1, "count 23");
     XCTAssert ([CharCollection [@"asdf"] isEqual:@42], "get 22");
     CharCollection[@"asdf"] = @13;
@@ -451,7 +451,7 @@
     
     Subscripts_StringDictionaryCollection *StringCollection = [[Subscripts_StringDictionaryCollection alloc] init];
     XCTAssert ([StringCollection count] == 0, "count 24");
-    [StringCollection addKey:@"asdf" item:@"one"];
+    StringCollection[@"asdf"] = @"one";
     XCTAssert ([StringCollection count] == 1, "count 25");
     XCTAssert ([StringCollection [@"asdf"] isEqual:@"one"], "get 24");
     StringCollection[@"asdf"] = @"two";


### PR DESCRIPTION
#122

- For indexed properties with integral input types, we can expose those via "Indexed Subscripting":
   (id)objectAtIndexedSubscript:(*IndexType*)idx;
   (void)setObject:(id)obj atIndexedSubscript:(*IndexType*)idx;
- For the rest we can use "Keyed Subscripting":
   (id)objectForKeyedSubscript:(*KeyType*)key;
   (void)setObject:(id)obj forKeyedSubscript:(*KeyType*)key;