### PR TITLE
[objc] Add support for non-generic `IComparable` interface

### DIFF
--- a/objcgen/comparablehelper.cs
+++ b/objcgen/comparablehelper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.IO;
+
+namespace ObjC {
+	
+	public class ComparableHelper : MethodHelper {
+
+		public ComparableHelper (TextWriter headers, TextWriter implementation) :
+			base (headers, implementation)
+		{
+			MonoSignature = "CompareTo(object)";
+			ReturnType = "NSComparisonResult";
+		}
+
+		public void WriteImplementation ()
+		{
+			BeginImplementation ();
+			WriteMethodLookup ();
+			implementation.WriteLine ($"\treturn mono_embeddinator_compare_to (_object, __method, other ? other->_object : nil);");
+			EndImplementation ();
+		}
+	}
+}

--- a/objcgen/extensions.cs
+++ b/objcgen/extensions.cs
@@ -12,6 +12,37 @@ namespace Embeddinator {
 			return (self.Namespace == @namespace) && (self.Name == name);
 		}
 
+		public static bool Implements (this Type self, string @namespace, string name)
+		{
+			if (self.Is ("System", "Object"))
+				return false;
+			foreach (var intf in self.GetInterfaces ()) {
+				if (intf.Is (@namespace, name))
+					return true;
+			}
+			return self.BaseType.Implements (@namespace, name);
+		}
+
+		public static bool Match (this MethodInfo self, string returnType, string name, params string[] parameterTypes)
+		{
+			if (self.Name != name)
+				return false;
+			var pc = self.ParameterCount;
+			if (pc != parameterTypes.Length)
+				return false;
+			if (self.ReturnType.FullName != returnType)
+				return false;
+			var parameters = self.GetParameters ();
+			for (int i = 0; i < pc; i++) {
+				// parameter type not specified, useful for generics
+				if (parameterTypes [i] == null)
+					continue;
+				if (parameterTypes [i] != parameters [i].ParameterType.FullName)
+					return false;
+			}
+			return true;
+		}
+
 		public static bool HasCustomAttribute (this Type self, string @namespace, string name)
 		{
 			foreach (var ca in self.CustomAttributes) {

--- a/objcgen/methodhelper.cs
+++ b/objcgen/methodhelper.cs
@@ -5,8 +5,8 @@ namespace ObjC {
 
 	public class MethodHelper {
 
-		TextWriter headers;
-		TextWriter implementation;
+		protected TextWriter headers;
+		protected TextWriter implementation;
 
 		public MethodHelper (TextWriter headers, TextWriter implementation)
 		{

--- a/objcgen/objcgen.csproj
+++ b/objcgen/objcgen.csproj
@@ -311,6 +311,7 @@
     <Compile Include="extensions.cs" />
     <Compile Include="methodhelper.cs" />
     <Compile Include="objcgenerator-subscripts.cs" />
+    <Compile Include="comparablehelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="support\" />

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -289,6 +289,19 @@ namespace ObjC {
 					Generate (mi);
 			}
 
+			MethodInfo m;
+			if (icomparable.TryGetValue (t, out m)) {
+				var builder = new ComparableHelper (headers, implementation) {
+					ObjCSignature = $"compare:({managed_name} *)other",
+					AssemblyName = aname,
+					MetadataToken = m.MetadataToken,
+					ObjCTypeName = managed_name,
+					ManagedTypeName = t.FullName,
+				};
+				builder.WriteHeaders ();
+				builder.WriteImplementation ();
+			}
+
 			headers.WriteLine ("@end");
 			headers.WriteLine ();
 

--- a/support/objc-support.h
+++ b/support/objc-support.h
@@ -36,5 +36,8 @@ MONO_EMBEDDINATOR_BEGIN_DECLS
 MONO_EMBEDDINATOR_API
 NSString* mono_embeddinator_get_nsstring (MonoString* string);
 
+MONO_EMBEDDINATOR_API
+NSComparisonResult mono_embeddinator_compare_to (MonoEmbedObject *object, MonoMethod *method, MonoEmbedObject *other);
+
 MONO_EMBEDDINATOR_END_DECLS
 	

--- a/support/objc-support.m
+++ b/support/objc-support.m
@@ -33,3 +33,19 @@ NSString* mono_embeddinator_get_nsstring (MonoString* string)
 	gunichar2 *str = mono_string_chars (string);
 	return [[NSString alloc] initWithBytes: str length: length * 2 encoding: NSUTF16LittleEndianStringEncoding];
 }
+
+// helper for System.IComparable
+NSComparisonResult mono_embeddinator_compare_to (MonoEmbedObject *object, MonoMethod *method, MonoEmbedObject *other)
+{
+	if (!other)
+		return NSOrderedSame;
+	void* __args [1];
+	__args [0] = mono_gchandle_get_target (other->_handle);
+	MonoObject* __exception = nil;
+	MonoObject* __instance = mono_gchandle_get_target (object->_handle);
+	MonoObject* __result = mono_runtime_invoke (method, __instance, __args, &__exception);
+	if (__exception)
+		mono_embeddinator_throw_exception (__exception);
+	void* __unbox = mono_object_unbox (__result);
+	return (NSComparisonResult) *((int*)__unbox);
+}

--- a/tests/managed/icomparable.cs
+++ b/tests/managed/icomparable.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Comparable {
+
+	public class Class : IComparable {
+
+		public Class (int i)
+		{
+			Integer = i;
+		}
+
+		public int Integer { get; private set; }
+
+		public int CompareTo (object obj)
+		{
+			var c = obj as Class;
+			var i = (c == null) ? 0 : c.Integer;
+			return Integer.CompareTo (i);
+		}
+	}
+}

--- a/tests/managed/managed.csproj
+++ b/tests/managed/managed.csproj
@@ -39,6 +39,7 @@
     <Compile Include="structs.cs" />
     <Compile Include="enums.cs" />
     <Compile Include="fields.cs" />
+    <Compile Include="icomparable.cs" />
     <Compile Include="subscripts.cs">
       <DependentUpon>subscripts.tt</DependentUpon>
     </Compile>

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -255,6 +255,21 @@
 	XCTAssertFalse ([struct2 boolean], "init / boolean / false");
 }
 
+- (void) testComparable {
+	// nil behaviour check
+	NSDate *d1 = [[NSDate alloc] initWithTimeIntervalSinceNow:0];
+	NSDate *d2 = nil;
+	XCTAssert ([d1 compare:d2] == NSOrderedSame, "foundation / compare w/nil");
+
+	Comparable_Class *c1 = [[Comparable_Class alloc] initWithI:1];
+	XCTAssert ([c1 compare:nil] == NSOrderedSame, "compare w/nil");
+	XCTAssert ([c1 compare:c1] == NSOrderedSame, "compare self");
+
+	Comparable_Class *c2 = [[Comparable_Class alloc] initWithI:2];
+	XCTAssert ([c1 compare:c2] == NSOrderedAscending, "compare <");
+	XCTAssert ([c2 compare:c1] == NSOrderedDescending, "compare >");
+}
+
 - (void)testStaticCallPerformance {
 	const int iterations = 1000000;
 	[self measureBlock:^{

--- a/tests/objcgentest/ExtensionsTest.cs
+++ b/tests/objcgentest/ExtensionsTest.cs
@@ -23,11 +23,30 @@ namespace ObjCGeneratorTest {
 		}
 
 		[Test]
-		public void HasAttribute ()
+		public void HasCustomAttribute ()
 		{
 			var fa = mscorlib.GetType ("System.IO.FileAccess");
 			Assert.True (fa.HasCustomAttribute ("System", "FlagsAttribute"), "Has");
 			Assert.False (fa.HasCustomAttribute ("System", "Flags"), "Has Not");
+		}
+
+		[Test]
+		public void Implements ()
+		{
+			Assert.True (mscorlib.GetType ("System.Int32").Implements ("System", "IComparable`1"), "int");
+			Assert.False (mscorlib.GetType ("System.Object").Implements ("System", "IComparable"), "object");
+		}
+
+		[Test]
+		public void Match ()
+		{
+			var o = mscorlib.GetType ("System.Object");
+			var m1 = o.GetMethod ("GetHashCode");
+			Assert.True (m1.Match ("System.Int32", "GetHashCode"), "GetHashCode");
+
+			var m2 = o.GetMethod ("ReferenceEquals");
+			Assert.False (m2.Match ("System.Boolean", "ReferenceEquals"), "ReferenceEquals - no param");
+			Assert.True (m2.Match ("System.Boolean", "ReferenceEquals", "System.Object", "System.Object"), "Equals");
 		}
 	}
 }


### PR DESCRIPTION
We cannot support the _normal_ `IComparable` signature
> Int32 CompareTo(System.Object)
because `System.Object` is not `NSObject`. It's also not the pattern used
in Apple frameworks.'

But we can easily match it to the common (Foundation) signature
> - (NSComparisonResult)compare:(NSSomething *)other;

Part of the fix for:
https://github.com/mono/Embeddinator-4000/issues/124