### PR TITLE
[objc] Add support for `IComparable<T>`

### DIFF
--- a/objcgen/comparablehelper.cs
+++ b/objcgen/comparablehelper.cs
@@ -8,7 +8,6 @@ namespace ObjC {
 		public ComparableHelper (TextWriter headers, TextWriter implementation) :
 			base (headers, implementation)
 		{
-			MonoSignature = "CompareTo(object)";
 			ReturnType = "NSComparisonResult";
 		}
 

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -292,12 +292,14 @@ namespace ObjC {
 
 			MethodInfo m;
 			if (icomparable.TryGetValue (t, out m)) {
+				var pt = m.GetParameters () [0].ParameterType;
 				var builder = new ComparableHelper (headers, implementation) {
 					ObjCSignature = $"compare:({managed_name} *)other",
 					AssemblyName = aname,
 					MetadataToken = m.MetadataToken,
 					ObjCTypeName = managed_name,
 					ManagedTypeName = t.FullName,
+					MonoSignature = $"CompareTo({GetMonoName (pt)})",
 				};
 				builder.WriteHeaders ();
 				builder.WriteImplementation ();

--- a/tests/managed/icomparable.cs
+++ b/tests/managed/icomparable.cs
@@ -18,4 +18,64 @@ namespace Comparable {
 			return Integer.CompareTo (i);
 		}
 	}
+
+	public class Generic : IComparable<Generic> {
+
+		public Generic (int i)
+		{
+			Integer = i;
+		}
+
+		public int Integer { get; private set; }
+
+		public int CompareTo (Generic other)
+		{
+			var i = other == null ? 0 : other.Integer;
+			return Integer.CompareTo (i);
+		}
+	}
+
+	public class Both : IComparable, IComparable<Both> {
+
+		public Both (int i)
+		{
+			Integer = i;
+		}
+
+		public int Integer { get; private set; }
+
+		// this will not be called - we'll prefer the generic version when both are available
+		public int CompareTo (object obj)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public int CompareTo (Both other)
+		{
+			var i = other == null ? 0 : other.Integer;
+			return Integer.CompareTo (i);
+		}
+	}
+
+	// not the common `compare` with same type case - generated "normally"
+	public class Different : IComparable<Generic>, IComparable<int> {
+
+		public Different (int i)
+		{
+			Integer = i;
+		}
+
+		public int Integer { get; private set; }
+
+		public int CompareTo (Generic generic)
+		{
+			var i = generic == null ? 0 : generic.Integer;
+			return Integer.CompareTo (i);
+		}
+
+		public int CompareTo (int integer)
+		{
+			return Integer.CompareTo (integer);
+		}
+	}
 }

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -268,6 +268,30 @@
 	Comparable_Class *c2 = [[Comparable_Class alloc] initWithI:2];
 	XCTAssert ([c1 compare:c2] == NSOrderedAscending, "compare <");
 	XCTAssert ([c2 compare:c1] == NSOrderedDescending, "compare >");
+
+	Comparable_Generic *g1 = [[Comparable_Generic alloc] initWithI:-3];
+	XCTAssert ([g1 compare:nil] == NSOrderedSame, "generic / compare w/nil");
+	XCTAssert ([g1 compare:g1] == NSOrderedSame, "generic / compare self");
+
+	Comparable_Generic *g2 = [[Comparable_Generic alloc] initWithI:-1];
+	XCTAssert ([g1 compare:g2] == NSOrderedAscending, "generic / compare <");
+	XCTAssert ([g2 compare:g1] == NSOrderedDescending, "generic / compare >");
+
+	Comparable_Both *b1 = [[Comparable_Both alloc] initWithI:10];
+	XCTAssert ([b1 compare:nil] == NSOrderedSame, "both / compare w/nil");
+	XCTAssert ([b1 compare:b1] == NSOrderedSame, "both / compare self");
+
+	Comparable_Both *b2 = [[Comparable_Both alloc] initWithI:20];
+	XCTAssert ([b1 compare:b2] == NSOrderedAscending, "both / compare <");
+	XCTAssert ([b2 compare:b1] == NSOrderedDescending, "both / compare >");
+
+	// normally bound methods for IComparable<T> where T is not the current type
+	Comparable_Different *d = [[Comparable_Different alloc] initWithI:-2];
+	XCTAssert ([d compareToGeneric:g2] == NSOrderedAscending, "different generic / compare <");
+	XCTAssert ([d compareToGeneric:g1] == NSOrderedDescending, "different generic / compare >");
+
+	XCTAssert ([d compareToInteger:10] == NSOrderedAscending, "different int / compare <");
+	XCTAssert ([d compareToInteger:-10] == NSOrderedDescending, "different int / compare >");
 }
 
 - (void)testStaticCallPerformance {


### PR DESCRIPTION
This gets priority over the `IComparable` implementation, using
`System.Object`, if present.

We let the normal generation cover cses of `IComparable<T>` when `T` is
not the declaring type. E.g.

> public class X : IComparable<Y>, IComparable<Z> {}