### PR TITLE
[objc] Fix clang warnings about nullability

### DIFF
--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -13,3 +13,8 @@ It is not possible to have two mono runtimes co-exists inside the same applicati
 
 ## ObjC generated code
 
+### Nullability
+
+There is no metadata, in .NET, that tell us if a null reference is acceptable or not for an API. Most API will throw `ArgumentNullException` if they cannot cope with a `null` argument. This is problematic as ObjC handling of exceptions is something better avoided.
+
+Since we cannot generate accurate nullability annotations in the header files and wish to minimize  managed exceptions we default to non-null arguments (`NS_ASSUME_NONNULL_BEGIN`) and add some specific, when precision is possible, nullability annotations.

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -31,6 +31,8 @@ namespace ObjC {
 			foreach (var t in types)
 				headers.WriteLine ($"@class {GetTypeName (t)};");
 			headers.WriteLine ();
+			headers.WriteLine ("NS_ASSUME_NONNULL_BEGIN");
+			headers.WriteLine ();
 
 			implementation.WriteLine ("#include \"bindings.h\"");
 			implementation.WriteLine ("#include \"glib.h\"");
@@ -63,6 +65,9 @@ namespace ObjC {
 			implementation.WriteLine ();
 
 			base.Generate (assemblies);
+
+			headers.WriteLine ("NS_ASSUME_NONNULL_END");
+			headers.WriteLine ();
 		}
 
 		protected override void Generate (Assembly a)
@@ -209,7 +214,7 @@ namespace ObjC {
 
 					var builder = new MethodHelper (headers, implementation) {
 						AssemblyName = aname,
-						ReturnType = "instancetype",
+						ReturnType = "nullable instancetype",
 						ManagedTypeName = t.FullName,
 						MetadataToken = ctor.MetadataToken,
 						MonoSignature = signature,
@@ -269,7 +274,7 @@ namespace ObjC {
 				headers.WriteLine (" */");
 				headers.WriteLine ("- (nullable instancetype)initForSuper;");
 
-				implementation.WriteLine ("- (instancetype) initForSuper {");
+				implementation.WriteLine ("- (nullable instancetype) initForSuper {");
 				// calls super's initForSuper until we reach a non-generated type
 				if (types.Contains (t.BaseType))
 					implementation.WriteLine ("\treturn self = [super initForSuper];");
@@ -618,8 +623,10 @@ namespace ObjC {
 		// TODO override with attribute ? e.g. [Obj.Name ("XAMType")]
 		public static string GetTypeName (Type t)
 		{
-			if (t.IsByRef)
-				return GetTypeName (t.GetElementType ()) + "*";
+			if (t.IsByRef) {
+				var et = t.GetElementType ();
+				return GetTypeName (et) + (et.IsValueType ? " " : " _Nonnull ") + "* _Nullable";
+			}
 
 			if (t.IsEnum)
 				return GetObjCName (t);

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -316,7 +316,7 @@ namespace ObjC {
 			if (icomparable.TryGetValue (t, out m)) {
 				var pt = m.GetParameters () [0].ParameterType;
 				var builder = new ComparableHelper (headers, implementation) {
-					ObjCSignature = $"compare:({managed_name} *)other",
+					ObjCSignature = $"compare:({managed_name} * _Nullable)other",
 					AssemblyName = aname,
 					MetadataToken = m.MetadataToken,
 					ObjCTypeName = managed_name,

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -23,6 +23,10 @@
 	[super tearDown];
 }
 
+#pragma clang diagnostic push
+// our unit tests are _abusing_ nil since we know the internals of the managed code we call
+#pragma clang diagnostic ignored "-Wnonnull"
+
 - (void)testProperties {
 	XCTAssertFalse ([Platform isWindows], "static class property getter only");
 	XCTAssert ([Platform exitCode] == 0, "static class property getter");
@@ -557,4 +561,7 @@
     StringCollection[@"asdf"] = @"two";
     XCTAssert ([StringCollection [@"asdf"] isEqual:@"two"], "get 25");
 }
+
+#pragma clang diagnostic pop
+
 @end


### PR DESCRIPTION
In general we don't encourage `null` since it's likely to get managed
`ArgumentNullException` which cannot be well handled on the ObjC side.
That's covered by:

> NS_ASSUME_NONNULL_BEGIN

Right now we lack any metadata to make this more precise :-(. However,
when possible, we can put specific annotations on some API, e.g.

1. Any managed exception in a `.ctor` (or the `.cctor`) will make the
corresponding `init*` method return `nil`, so we always mark them as
`nullable`.

2. `ref` and `out` on reference types can be `nullable`