### PR TITLE
[objc][tests] Add objcgen warning and error tests. Fixes issue #104

### DIFF
--- a/tests/objcgenwarnerrtests/EnumsTest/EnumsLib.csproj
+++ b/tests/objcgenwarnerrtests/EnumsTest/EnumsLib.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4F4AC361-08F3-4566-839A-A6B3E740F81A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>EnumsLib</RootNamespace>
+    <AssemblyName>EnumsLib</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="EnumsTest.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/objcgenwarnerrtests/EnumsTest/EnumsTest.cs
+++ b/tests/objcgenwarnerrtests/EnumsTest/EnumsTest.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace EnumsLib {
+
+	public enum Pokemon {
+		Pikachu,
+		Charmander		
+	}
+
+	public class EnumsTest {
+		public EnumsTest ()
+		{
+		}
+
+		public Pokemon GetPokemon () => Pokemon.Pikachu;
+	}
+}

--- a/tests/objcgenwarnerrtests/GenericsTest/GenericsLib.csproj
+++ b/tests/objcgenwarnerrtests/GenericsTest/GenericsLib.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4F4AC361-08F3-4566-839A-A6B3E740F81A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>GenericsLib</RootNamespace>
+    <AssemblyName>GenericsLib</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GenericsTest.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/objcgenwarnerrtests/GenericsTest/GenericsTest.cs
+++ b/tests/objcgenwarnerrtests/GenericsTest/GenericsTest.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace GenericsLib {
+	public class GenericsTest {
+		public GenericsTest ()
+		{
+		}
+
+		public List<GenericsTest> GetEmptyList () => new List<GenericsTest> ();
+	}
+}

--- a/tests/objcgenwarnerrtests/Makefile
+++ b/tests/objcgenwarnerrtests/Makefile
@@ -1,0 +1,50 @@
+all: run-tests
+
+MONO=/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono
+MONOMSBUILD=/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild
+OBJC_GEN_DIR=../../objcgen
+OBJC_GEN=$(OBJC_GEN_DIR)/bin/Debug/objcgen.exe
+$(OBJC_GEN): $(wildcard $(OBJC_GEN_DIR)/*.cs) $(wildcard ../../support/*)
+	$(MAKE) -C $(OBJC_GEN_DIR)
+
+# Add here the name of the folder containing the tests
+TESTS = GenericsTest EnumsTest NoInitInSubclassTest
+.PHONY: clean $(TESTS)
+
+define FindGenErrWarnCodeTemplate
+$(1):
+	@echo "$1";
+	@$(MONOMSBUILD) /p:Configuration=$(3) $(1)/$(2).csproj /p:OutputPath=DllOutput $(if $(V),,> /dev/null)
+	@$(MONO) $(OBJC_GEN) $(if $(filter $(3),Debug),--debug,) -c $(1)/DllOutput/$(2).dll -o $(1)/E4KOutput 2>&1 | $(if $(V),grep --color=always EM$(4),grep EM$(4) > /dev/null)
+endef
+
+define DoNotFindGenErrWarnCodeTemplate
+$(1):
+	@echo "$1"
+	@$(MONOMSBUILD) /p:Configuration=$(3) $(1)/$(2).csproj /p:OutputPath=DllOutput $(if $(V),,> /dev/null)
+	@!($(MONO) $(OBJC_GEN) $(if $(filter $(3),Debug),--debug,) -c $(1)/DllOutput/$(2).dll -o $(1)/E4KOutput 2>&1 | grep EM$(4) $(if $(V),,> /dev/null))
+	$(if $(V),@echo "$1: Success EM$(4) not found";,)
+endef
+
+define FindXcodeErrWarnCodeTemplate
+$(1):
+	@echo "$1";
+	@$(MONOMSBUILD) /p:Configuration=$(5) $(1)/$(2).csproj /p:OutputPath=DllOutput $(if $(V),,> /dev/null)
+	@$(MONO) $(OBJC_GEN) $(if $(filter $(5),Debug),--debug,) -c $(1)/DllOutput/$(2).dll -o $(1)/E4KOutput $(if $(V),,> /dev/null)
+	@xcodebuild -project $(1)/$(3).xcodeproj -target $(4) -configuration $(5) 2>&1 | grep $(6) $(if $(V),,> /dev/null)
+endef
+
+# {Template},{GENERATOR_TEST},{csprojName},{Debug|Release},{[warn|error]code}
+$(eval $(call FindGenErrWarnCodeTemplate,GenericsTest,GenericsLib,Debug,1010))
+$(eval $(call DoNotFindGenErrWarnCodeTemplate,EnumsTest,EnumsLib,Release,1010))
+
+# {Template},{GENERATOR_TEST},{csprojName},{xcodeprojName},{target},{Debug|Release},{expected[warn|error]}
+$(eval $(call FindXcodeErrWarnCodeTemplate,NoInitInSubclassTest,ConstructorsLib,NoInitInSubclassTest,NoInitInSubclassTest,Release,"error: 'initWithId:' is unavailable"))
+
+run-tests: $(OBJC_GEN) $(TESTS)
+
+clean:
+	@find . -name "DllOutput" -type d -prune -exec rm -r "{}" +
+	@find . -name "E4KOutput" -type d -prune -exec rm -r "{}" +
+	@find . -name "obj" -type d -prune -exec rm -r "{}" +
+	@find . -name "build" -type d -prune -exec rm -r "{}" +

--- a/tests/objcgenwarnerrtests/NoInitInSubclassTest/ConstructorsLib.csproj
+++ b/tests/objcgenwarnerrtests/NoInitInSubclassTest/ConstructorsLib.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4F4AC361-08F3-4566-839A-A6B3E740F81A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ConstructorsLib</RootNamespace>
+    <AssemblyName>ConstructorsLib</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ConstructorsTest.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/objcgenwarnerrtests/NoInitInSubclassTest/ConstructorsTest.cs
+++ b/tests/objcgenwarnerrtests/NoInitInSubclassTest/ConstructorsTest.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace ConstructorsLib {
+	public class Parent {
+		public Parent () : this (1)
+		{
+		}
+
+		public Parent (int id)
+		{
+		}
+	}
+
+	public class Child : Parent {
+		public Child () : base (10)
+		{
+		}
+	}
+}

--- a/tests/objcgenwarnerrtests/NoInitInSubclassTest/NoInitInSubclassTest.xcodeproj/project.pbxproj
+++ b/tests/objcgenwarnerrtests/NoInitInSubclassTest/NoInitInSubclassTest.xcodeproj/project.pbxproj
@@ -1,0 +1,291 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		FAA132481EAA8F8100DB8A92 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FAA132471EAA8F8100DB8A92 /* main.m */; };
+		FAA132551EAA9D5F00DB8A92 /* libConstructorsLib.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FAA132511EAA9D5E00DB8A92 /* libConstructorsLib.dylib */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		FAA132421EAA8F8100DB8A92 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		FAA132441EAA8F8100DB8A92 /* NoInitInSubclassTest */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = NoInitInSubclassTest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FAA132471EAA8F8100DB8A92 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		FAA1324E1EAA9D5E00DB8A92 /* bindings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bindings.h; path = E4KOutput/bindings.h; sourceTree = "<group>"; };
+		FAA1324F1EAA9D5E00DB8A92 /* embeddinator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = embeddinator.h; path = E4KOutput/embeddinator.h; sourceTree = "<group>"; };
+		FAA132501EAA9D5E00DB8A92 /* glib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = glib.h; path = E4KOutput/glib.h; sourceTree = "<group>"; };
+		FAA132511EAA9D5E00DB8A92 /* libConstructorsLib.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libConstructorsLib.dylib; path = E4KOutput/libConstructorsLib.dylib; sourceTree = "<group>"; };
+		FAA132521EAA9D5E00DB8A92 /* mono_embeddinator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mono_embeddinator.h; path = E4KOutput/mono_embeddinator.h; sourceTree = "<group>"; };
+		FAA132531EAA9D5F00DB8A92 /* mono-support.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "mono-support.h"; path = "E4KOutput/mono-support.h"; sourceTree = "<group>"; };
+		FAA132541EAA9D5F00DB8A92 /* objc-support.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "objc-support.h"; path = "E4KOutput/objc-support.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		FAA132411EAA8F8100DB8A92 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FAA132551EAA9D5F00DB8A92 /* libConstructorsLib.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		FAA1323B1EAA8F8100DB8A92 = {
+			isa = PBXGroup;
+			children = (
+				FAA132561EAA9D6D00DB8A92 /* E4KOutput */,
+				FAA132461EAA8F8100DB8A92 /* NoInitInSubclassTest */,
+				FAA132451EAA8F8100DB8A92 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		FAA132451EAA8F8100DB8A92 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FAA132441EAA8F8100DB8A92 /* NoInitInSubclassTest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		FAA132461EAA8F8100DB8A92 /* NoInitInSubclassTest */ = {
+			isa = PBXGroup;
+			children = (
+				FAA132471EAA8F8100DB8A92 /* main.m */,
+			);
+			path = NoInitInSubclassTest;
+			sourceTree = "<group>";
+		};
+		FAA132561EAA9D6D00DB8A92 /* E4KOutput */ = {
+			isa = PBXGroup;
+			children = (
+				FAA1324E1EAA9D5E00DB8A92 /* bindings.h */,
+				FAA1324F1EAA9D5E00DB8A92 /* embeddinator.h */,
+				FAA132501EAA9D5E00DB8A92 /* glib.h */,
+				FAA132511EAA9D5E00DB8A92 /* libConstructorsLib.dylib */,
+				FAA132521EAA9D5E00DB8A92 /* mono_embeddinator.h */,
+				FAA132531EAA9D5F00DB8A92 /* mono-support.h */,
+				FAA132541EAA9D5F00DB8A92 /* objc-support.h */,
+			);
+			name = E4KOutput;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		FAA132431EAA8F8100DB8A92 /* NoInitInSubclassTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FAA1324B1EAA8F8100DB8A92 /* Build configuration list for PBXNativeTarget "NoInitInSubclassTest" */;
+			buildPhases = (
+				FAA132401EAA8F8100DB8A92 /* Sources */,
+				FAA132411EAA8F8100DB8A92 /* Frameworks */,
+				FAA132421EAA8F8100DB8A92 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NoInitInSubclassTest;
+			productName = NoInitInSubclassTest;
+			productReference = FAA132441EAA8F8100DB8A92 /* NoInitInSubclassTest */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		FAA1323C1EAA8F8100DB8A92 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0830;
+				ORGANIZATIONNAME = Xamarin;
+				TargetAttributes = {
+					FAA132431EAA8F8100DB8A92 = {
+						CreatedOnToolsVersion = 8.3.2;
+						DevelopmentTeam = V3QVSW8GNL;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = FAA1323F1EAA8F8100DB8A92 /* Build configuration list for PBXProject "NoInitInSubclassTest" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = FAA1323B1EAA8F8100DB8A92;
+			productRefGroup = FAA132451EAA8F8100DB8A92 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				FAA132431EAA8F8100DB8A92 /* NoInitInSubclassTest */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		FAA132401EAA8F8100DB8A92 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FAA132481EAA8F8100DB8A92 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		FAA132491EAA8F8100DB8A92 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		FAA1324A1EAA8F8100DB8A92 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		FAA1324C1EAA8F8100DB8A92 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEVELOPMENT_TEAM = V3QVSW8GNL;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/E4KOutput",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		FAA1324D1EAA8F8100DB8A92 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEVELOPMENT_TEAM = V3QVSW8GNL;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/E4KOutput",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		FAA1323F1EAA8F8100DB8A92 /* Build configuration list for PBXProject "NoInitInSubclassTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FAA132491EAA8F8100DB8A92 /* Debug */,
+				FAA1324A1EAA8F8100DB8A92 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FAA1324B1EAA8F8100DB8A92 /* Build configuration list for PBXNativeTarget "NoInitInSubclassTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FAA1324C1EAA8F8100DB8A92 /* Debug */,
+				FAA1324D1EAA8F8100DB8A92 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = FAA1323C1EAA8F8100DB8A92 /* Project object */;
+}

--- a/tests/objcgenwarnerrtests/NoInitInSubclassTest/NoInitInSubclassTest.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/tests/objcgenwarnerrtests/NoInitInSubclassTest/NoInitInSubclassTest.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:NoInitInSubclassTest.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/tests/objcgenwarnerrtests/NoInitInSubclassTest/NoInitInSubclassTest/main.m
+++ b/tests/objcgenwarnerrtests/NoInitInSubclassTest/NoInitInSubclassTest/main.m
@@ -1,0 +1,18 @@
+//
+//  main.m
+//  NoInitInSubclassTest
+//
+//  Created by Alex Soto on 4/21/17.
+//  Copyright © 2017 Xamarin. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "bindings.h"
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        // initWithId must be unavailable
+        ConstructorsLib_Child * child = [[ConstructorsLib_Child alloc] initWithId:1];
+    }
+    return 0;
+}

--- a/tests/objcgenwarnerrtests/README.md
+++ b/tests/objcgenwarnerrtests/README.md
@@ -1,0 +1,48 @@
+# objcgen warning and error tests
+
+The objective is to test warning and error conditions that you normally can't using unit tests.
+
+## Testing objcgen.exe
+
+Currently, we have 2 test templates inside `Makefile` for testing *objcgen.exe* error and warning codes.
+
+* **FindGenErrWarnCodeTemplate**: This is used to verify that error and warning codes are actually printed in *objcgen.exe* log output.
+* **DoNotFindGenErrWarnCodeTemplate**: This is used to verify that error and warning are not printed in *objcgen.exe* log output.
+
+In order to add additional tests create a new folder that includes the C# project with its files and add the following to the makefile:
+
+```makefile
+$(eval $(call {Template},{TEST},{csprojName},{Debug|Release},{[warn|error]code}))
+```
+
+For example:
+
+```makefile
+$(eval $(call FindGenErrWarnCodeTemplate,GenericsTest,GenericsLib,Debug,1010))
+```
+
+Also, do not forget to add your folder name into `TESTS` variable inside Makefile.
+
+## Testing error conditions when using binding headers produced by objcgen.exe
+
+Currently, we have 1 test template inside Makefile for testing binding headers.
+
+* **FindXcodeErrWarnCodeTemplate**: This is used to verify that an error or a warning is printed in the log output when building an *xcodeproj*.
+
+In order to add additional tests create a new folder that includes the C# project with its files that *objcgen.exe* will use as input, an Xcode project that uses the output headers of *objcgen.exe* and add the following to the makefile:
+
+```makefile
+$(eval $(call {Template},{TEST},{csprojName},{xcodeprojName},{xcodeTarget},{Debug|Release},{expected[warn|error]message}))
+```
+
+For example:
+
+```makefile
+$(eval $(call FindXcodeErrWarnCodeTemplate,NoInitInSubclassTest,ConstructorsLib,NoInitInSubclassTest,NoInitInSubclassTest,Release,"error: 'initWithId:' is unavailable"))
+```
+
+The `{expected[warn|error]message}` is given as a `grep` argument if it does not find it the test will fail. Also, do not forget to add your folder name into `TESTS` variable inside Makefile.
+
+## Custom tests
+
+If none of the above templates matches your testing needs feel free to add a makefile target with your own testing logic.


### PR DESCRIPTION
The objective is to test warning and error conditions that you normally can't using unit tests.

## Testing objcgen.exe

Currently, we have 2 test templates inside `Makefile` for testing *objcgen.exe* error and warning codes.

* **FindGenErrWarnCodeTemplate**: This is used to verify that error and warning codes are actually printed in *objcgen.exe* log output.
* **DoNotFindGenErrWarnCodeTemplate**: This is used to verify that error and warning are not printed in *objcgen.exe* log output.

In order to add additional tests create a new folder that includes the C# project with its files and add the following to the makefile:

```makefile
$(eval $(call {Template},{TEST},{csprojName},{Debug|Release},{[warn|error]code}))
```

For example:

```makefile
$(eval $(call FindGenErrWarnCodeTemplate,GenericsTest,GenericsLib,Debug,1010))
```

Also, do not forget to add your folder name into `TESTS` variable inside Makefile.

## Testing error conditions when using binding headers produced by objcgen.exe

Currently, we have 1 test template inside Makefile for testing binding headers.

* **FindXcodeErrWarnCodeTemplate**: This is used to verify that an error or a warning is printed in the log output when building an *xcodeproj*.

In order to add additional tests create a new folder that includes the C# project with its files that *objcgen.exe* will use as input, an Xcode project that uses the output headers of *objcgen.exe* and add the following to the makefile:

```makefile
$(eval $(call {Template},{TEST},{csprojName},{xcodeprojName},{xcodeTarget},{Debug|Release},{expected[warn|error]message}))
```

For example:

```makefile
$(eval $(call FindXcodeErrWarnCodeTemplate,NoInitInSubclassTest,ConstructorsLib,NoInitInSubclassTest,NoInitInSubclassTest,Release,"error: 'initWithId:' is unavailable"))
```

The `{expected[warn|error]message}` is given as a `grep` argument if it does not find it the test will fail. Also, do not forget to add your folder name into `TESTS` variable inside Makefile.

## Custom tests

If none of the above templates matches your testing needs feel free to add a makefile target with your own testing logic.