### PR TITLE
Move operation naming code into post processing

### DIFF
--- a/objcgen/objcgenerator-postprocessor.cs
+++ b/objcgen/objcgenerator-postprocessor.cs
@@ -22,6 +22,9 @@ namespace ObjC {
 				if (duplicateNames.Contains (CreateStringRep (method)) && method.Name != "CompareTo") // HACK
 					processedMethod.FallBackToTypeName = true;
 
+				if (method.IsSpecialName && method.IsStatic && method.Name.StartsWith ("op_", StringComparison.Ordinal))
+					processedMethod.IsOperator = true;
+
 				yield return processedMethod;
 			}
 		}

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -709,18 +709,10 @@ namespace ObjC {
 
 		protected override void Generate (ProcessedMethod method)
 		{
-			MethodInfo mi = method.Method;
-			string name;
+			var objcsig = ImplementMethod (method.Method, method.BaseName, useTypeNames: method.FallBackToTypeName);
 
-			if (mi.IsSpecialName && mi.IsStatic && mi.Name.StartsWith ("op_", StringComparison.Ordinal))
-				name = CamelCase (mi.Name.Substring (3));
-			else
-				name = CamelCase (mi.Name);
-
-			var objcsig = ImplementMethod (mi, name, useTypeNames: method.FallBackToTypeName);
-
-			if (members_with_default_values.Contains (mi))
-				GenerateDefaultValuesWrappers (objcsig, mi);
+			if (members_with_default_values.Contains (method.Method))
+				GenerateDefaultValuesWrappers (objcsig, method.Method);
 		}
 
 		protected void GenerateGetGCHandle ()

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -16,6 +16,9 @@ namespace ObjC {
 
 	public class ProcessedMethod : ProcessedBase {
 		public MethodInfo Method { get; private set; }
+		public bool IsOperator { get; set; }
+
+		public string BaseName => IsOperator ? ObjCGenerator.CamelCase (Method.Name.Substring (3)) : ObjCGenerator.CamelCase (Method.Name);
 
 		public ProcessedMethod (MethodInfo method)
 		{


### PR DESCRIPTION
- https://github.com/mono/Embeddinator-4000/issues/174
- No test needed as fails exisitng test if op name change code is commented out
- Once we move more logic into the ProcessedMethod we can likely push it down into ImplementMethod