### PR TITLE
[objc] Add ProcessedAssembly and uniqueness validation

### DIFF
--- a/docs/error.md
+++ b/docs/error.md
@@ -66,6 +66,12 @@ This might indicate a bug in the Embeddinator-4000; please file a bug report at 
 
 The tool could not find the assembly `X` specified in the arguments.
 
+<h3><a name="EM0012"/>EM0012: The assembly name `X` is not unique</h3>
+
+More than one assembly supplied have the same, internal name and it would not be possible to distinguish between them at runtime.
+
+The most likely cause is that an assembly is specified more than once on the command-line arguments. However a renamed assembly still keeps it's original name and multiple copies cannot coexists.
+
 <h3><a name="EM0099"/>EM0099: Internal error *. Please file a bug report with a test case (https://github.com/mono/Embeddinator-4000/issues).</h3>
 
 This error message is reported when an internal consistency check in the Embeddinator-4000 fails.

--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -229,7 +229,7 @@ namespace Embeddinator {
 			g.Process (Assemblies);
 
 			Console.WriteLine ("Generating binding code...");
-			g.Generate (Assemblies);
+			g.Generate ();
 			g.Write (OutputDirectory);
 
 			var exe = typeof (Driver).Assembly;

--- a/objcgen/extensions.cs
+++ b/objcgen/extensions.cs
@@ -1,9 +1,67 @@
 ﻿using System;
+using System.Text;
 
 using IKVM.Reflection;
 using Type = IKVM.Reflection.Type;
 
 namespace Embeddinator {
+
+	public static class StringExtensions {
+
+		public static string CamelCase (this string self)
+		{
+			if (self == null)
+				return null;
+			if (self.Length == 0)
+				return String.Empty;
+			return Char.ToLowerInvariant (self [0]) + self.Substring (1, self.Length - 1);
+		}
+
+		public static string PascalCase (this string self)
+		{
+			if (self == null)
+				return null;
+			if (self.Length == 0)
+				return String.Empty;
+			return Char.ToUpperInvariant (self [0]) + self.Substring (1, self.Length - 1);
+		}
+
+		public static string Sanitize (this string self)
+		{
+			if (self == null)
+				return null;
+
+			StringBuilder sb = null;
+
+			for (int i = 0; i < self.Length; i++) {
+				var ch = self [i];
+				switch (ch) {
+				case '.':
+				case '+':
+				case '/':
+				case '`':
+				case '@':
+				case '<':
+				case '>':
+				case '$':
+				case '-':
+				case ' ':
+					if (sb == null)
+						sb = new StringBuilder (self, 0, i, self.Length);
+					sb.Append ('_');
+					break;
+				default:
+					if (sb != null)
+						sb.Append (ch);
+					break;
+				}
+			}
+
+			if (sb != null)
+				return sb.ToString ();
+			return self;
+		}
+	}
 
 	public static class TypeExtensions {
 		

--- a/objcgen/generator.cs
+++ b/objcgen/generator.cs
@@ -8,20 +8,39 @@ namespace Embeddinator {
 
 	public class Generator {
 
-		public virtual void Process (IEnumerable<Assembly> assemblies)
+		protected List<ProcessedAssembly> assemblies = new List<ProcessedAssembly> ();
+
+		// uniqueness checks
+		HashSet<string> assembly_name = new HashSet<string> ();
+		HashSet<string> assembly_safename = new HashSet<string> ();
+
+		public virtual void Process (IEnumerable<Assembly> input)
 		{
 		}
 
-		public virtual void Generate (IEnumerable<Assembly> assemblies)
+		public bool AddIfUnique (ProcessedAssembly assembly)
+		{
+			if (assembly_name.Contains (assembly.Name))
+				return false;
+			if (assembly_safename.Contains (assembly.SafeName))
+				return false;
+
+			assemblies.Add (assembly);
+			assembly_name.Add (assembly.Name);
+			assembly_safename.Add (assembly.SafeName);
+			return true;
+		}
+
+		public virtual void Generate ()
 		{
 			foreach (var a in assemblies) {
 				Generate (a);
 			}
 		}
 
-		protected virtual void Generate (Assembly a)
+		protected virtual void Generate (ProcessedAssembly a)
 		{
-			foreach (var t in a.GetTypes ()) {
+			foreach (var t in a.Assembly.GetTypes ()) {
 				if (!t.IsPublic)
 					continue;
 				Generate (t);

--- a/objcgen/methodhelper.cs
+++ b/objcgen/methodhelper.cs
@@ -16,7 +16,7 @@ namespace ObjC {
 			this.implementation = implementation;
 		}
 
-		public string AssemblyName { get; set; }
+		public string AssemblySafeName { get; set; }
 
 		public bool IsConstructor { get; set; }
 		public bool IsExtension { get; set; }
@@ -62,7 +62,7 @@ namespace ObjC {
 			implementation.WriteLine ("if (!__method) {");
 			implementation.WriteLineUnindented ("#if TOKENLOOKUP");
 			implementation.Indent++;
-			implementation.WriteLine ($"__method = mono_get_method (__{ObjCGenerator.SanitizeName (AssemblyName)}_image, 0x{MetadataToken:X8}, {ObjCTypeName}_class);");
+			implementation.WriteLine ($"__method = mono_get_method (__{AssemblySafeName}_image, 0x{MetadataToken:X8}, {ObjCTypeName}_class);");
 			implementation.WriteLineUnindented ("#else");
 			implementation.WriteLine ($"const char __method_name [] = \"{ManagedTypeName}:{MonoSignature}\";");
 			implementation.WriteLine ($"__method = mono_embeddinator_lookup_method (__method_name, {ObjCTypeName}_class);");

--- a/objcgen/objcgenerator-helpers.cs
+++ b/objcgen/objcgenerator-helpers.cs
@@ -36,7 +36,7 @@ namespace ObjC {
 					if (n == 0) {
 						bool isPropertyMethod = method.IsSpecialName && (method.Name.StartsWith ("get") || method.Name.StartsWith ("set"));
 						if (method.IsConstructor || !method.IsSpecialName || (useTypeNames && isPropertyMethod))
-							objc.Append (PascalCase (paramName));
+							objc.Append (paramName.PascalCase ());
 					} else
 						objc.Append (paramName.ToLowerInvariant ());
 				}

--- a/objcgen/objcgenerator-processor.cs
+++ b/objcgen/objcgenerator-processor.cs
@@ -203,6 +203,7 @@ namespace ObjC {
 
 		List<Type> enums = new List<Type> ();
 		List<Type> types = new List<Type> ();
+
 		Dictionary<Type, List<ProcessedConstructor>> ctors = new Dictionary<Type, List<ProcessedConstructor>> ();
 		Dictionary<Type, List<ProcessedMethod>> methods = new Dictionary<Type, List<ProcessedMethod>> ();
 		Dictionary<Type, List<ProcessedProperty>> properties = new Dictionary<Type, List<ProcessedProperty>> ();
@@ -214,9 +215,14 @@ namespace ObjC {
 		bool implement_system_icomparable_t;
 		bool extension_type;
 
-		public override void Process (IEnumerable<Assembly> assemblies)
+		public override void Process (IEnumerable<Assembly> input)
 		{
-			foreach (var a in assemblies) {
+			foreach (var a in input) {
+				var pa = new ProcessedAssembly (a);
+				// ignoring/warning one is not an option as they could be different (e.g. different builds/versions)
+				if (!AddIfUnique (pa))
+					throw ErrorHelper.CreateError (12, $"The assembly name `{pa.Name}` is not unique");
+
 				foreach (var t in GetTypes (a)) {
 					if (t.IsEnum) {
 						enums.Add (t);

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -5,20 +5,35 @@ using System.Linq;
 using IKVM.Reflection;
 using Type = IKVM.Reflection.Type;
 
-namespace ObjC {
+namespace Embeddinator {
 
 	// While processing user assemblies, we may come across conditions that will affect
 	// final code generation that we need to pass to the generation pass
 
-	public abstract class ProcessedBase {
+	public abstract class ProcessedMemberBase {
 		public bool FallBackToTypeName { get; set; }
 	}
 
-	public class ProcessedMethod : ProcessedBase {
+	public class ProcessedAssembly {
+
+		public Assembly Assembly { get; private set; }
+
+		public string Name { get; private set; }
+		public string SafeName { get; private set; }
+
+		public ProcessedAssembly (Assembly assembly)
+		{
+			Assembly = assembly;
+			Name = assembly.GetName ().Name;
+			SafeName = Name.Sanitize ();
+		}
+	}
+
+	public class ProcessedMethod : ProcessedMemberBase {
 		public MethodInfo Method { get; private set; }
 		public bool IsOperator { get; set; }
 
-		public string BaseName => IsOperator ? ObjCGenerator.CamelCase (Method.Name.Substring (3)) : ObjCGenerator.CamelCase (Method.Name);
+		public string BaseName => IsOperator ? Method.Name.Substring (3).CamelCase () : Method.Name.CamelCase ();
 
 		public ProcessedMethod (MethodInfo method)
 		{
@@ -26,7 +41,7 @@ namespace ObjC {
 		}
 	}
 
-	public class ProcessedProperty: ProcessedBase {
+	public class ProcessedProperty: ProcessedMemberBase {
 		public PropertyInfo Property { get; private set; }
 
 		public ProcessedProperty (PropertyInfo property)
@@ -35,7 +50,7 @@ namespace ObjC {
 		}
 	}
 
-	public class ProcessedConstructor : ProcessedBase {
+	public class ProcessedConstructor : ProcessedMemberBase {
 		public ConstructorInfo Constructor { get; private set; }
 
 		public ProcessedConstructor (ConstructorInfo constructor)
@@ -44,7 +59,7 @@ namespace ObjC {
 		}
 	}
 
-	public class ProcessedFieldInfo : ProcessedBase {
+	public class ProcessedFieldInfo : ProcessedMemberBase {
 		public FieldInfo Field { get; private set; }
 
 		public ProcessedFieldInfo (FieldInfo field)

--- a/tests/objcgentest/EmbedderTest.cs
+++ b/tests/objcgentest/EmbedderTest.cs
@@ -62,6 +62,21 @@ namespace DriverTest
 			Assert.AreEqual (0, Driver.Main2 ("--platform", platform.ToString (), "--abi", "x86_64", "-c", dll, "-o", tmpdir), "build");
 		}
 
+		[Test]
+		public void DuplicateAssemblyName ()
+		{
+			var platform = Platform.macOS;
+			var dll = CompileLibrary (platform, libraryName: "dupe");
+			var tmpdir = Xamarin.Cache.CreateTemporaryDirectory ();
+			try {
+				Driver.Main2 ("--platform", platform.ToString (), "--abi", "x86_64", dll, dll, "-o", tmpdir);
+			}
+			catch (EmbeddinatorException ee) {
+				Assert.True (ee.Error, "Error");
+				Assert.That (ee.Code, Is.EqualTo (12), "Code");
+			}
+		}
+
 		string CompileLibrary (Platform platform, string code = null, string libraryName = null)
 		{
 			int exitCode;

--- a/tests/objcgentest/ObjCGeneratorTest.cs
+++ b/tests/objcgentest/ObjCGeneratorTest.cs
@@ -15,24 +15,6 @@ namespace ObjCGeneratorTest {
 		public static Assembly mscorlib { get; } = Universe.Load ("mscorlib.dll");
 
 		[Test]
-		public void CamelCase ()
-		{
-			Assert.Null (ObjCGenerator.CamelCase (null), "null");
-			Assert.That (ObjCGenerator.CamelCase (String.Empty), Is.EqualTo (""), "length == 0");
-			Assert.That (ObjCGenerator.CamelCase ("S"), Is.EqualTo ("s"), "length == 1");
-			Assert.That (ObjCGenerator.CamelCase ("TU"), Is.EqualTo ("tU"), "length == 2");
-		}
-
-		[Test]
-		public void PascalCase ()
-		{
-			Assert.Null (ObjCGenerator.PascalCase (null), "null");
-			Assert.That (ObjCGenerator.PascalCase (String.Empty), Is.EqualTo (""), "length == 0");
-			Assert.That (ObjCGenerator.PascalCase ("s"), Is.EqualTo ("S"), "length == 1");
-			Assert.That (ObjCGenerator.PascalCase ("tu"), Is.EqualTo ("Tu"), "length == 2");
-		}
-
-		[Test]
 		public void TypeMatch ()
 		{
 			Assert.That (ObjCGenerator.GetTypeName (mscorlib.GetType ("System.Boolean")), Is.EqualTo ("bool"), "bool");

--- a/tests/objcgentest/StringExtensionsTest.cs
+++ b/tests/objcgentest/StringExtensionsTest.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using System;
+
+using Embeddinator;
+
+namespace ObjCGeneratorTest {
+
+	[TestFixture]
+	public class StringExtensionsTest {
+
+		[Test]
+		public void CamelCase ()
+		{
+			Assert.Null ((null as string).CamelCase (), "null");
+			Assert.That (String.Empty.CamelCase (), Is.EqualTo (""), "length == 0");
+			Assert.That ("S".CamelCase (), Is.EqualTo ("s"), "length == 1");
+			Assert.That ("TU".CamelCase (), Is.EqualTo ("tU"), "length == 2");
+		}
+
+		[Test]
+		public void PascalCase ()
+		{
+			Assert.Null ((null as string).PascalCase (), "null");
+			Assert.That (String.Empty.PascalCase (), Is.EqualTo (""), "length == 0");
+			Assert.That ("s".PascalCase (), Is.EqualTo ("S"), "length == 1");
+			Assert.That ("tu".PascalCase (), Is.EqualTo ("Tu"), "length == 2");
+		}
+	}
+}

--- a/tests/objcgentest/TypeExtensionsTest.cs
+++ b/tests/objcgentest/TypeExtensionsTest.cs
@@ -9,7 +9,7 @@ using Type = IKVM.Reflection.Type;
 namespace ObjCGeneratorTest {
 
 	[TestFixture]
-	public class ExtensionsTest {
+	public class TypeExtensionsTest {
 
 		public static Universe Universe { get; } = new Universe (UniverseOptions.None);
 

--- a/tests/objcgentest/objcgentest.csproj
+++ b/tests/objcgentest/objcgentest.csproj
@@ -36,7 +36,8 @@
     <Compile Include="Asserts.cs" />
     <Compile Include="EmbedderTest.cs" />
     <Compile Include="Cache.cs" />
-    <Compile Include="ExtensionsTest.cs" />
+    <Compile Include="TypeExtensionsTest.cs" />
+    <Compile Include="StringExtensionsTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
* Detect any duplication based on the assembly (internal) name and also
  it's sanitized (safe) name. Otherwise generated code won't work;

* Avoid recomputing the name (or safe name) whenever possible;

* Adjust unit tests for some code movement that ease reuse;