### PR TITLE
[objc] Do not require setting constants values to use [Equals|Hash]Helper

### DIFF
--- a/objcgen/EqualsHelper.cs
+++ b/objcgen/EqualsHelper.cs
@@ -8,6 +8,7 @@ namespace ObjC {
 		public EqualsHelper (SourceWriter headers, SourceWriter implementation) : base (headers, implementation)
 		{
 			MonoSignature = "Equals(object)";
+			ObjCSignature = "isEqual:(id _Nullable)other";
 			ReturnType = "bool";
 		}
 

--- a/objcgen/HashHelper.cs
+++ b/objcgen/HashHelper.cs
@@ -7,7 +7,8 @@ namespace ObjC {
 	public class HashHelper : MethodHelper {
 		public HashHelper (SourceWriter headers, SourceWriter implementation) : base (headers, implementation)
 		{
-			MonoSignature = "GetHashCode ()";
+			MonoSignature = "GetHashCode()";
+			ObjCSignature = "hash";
 			ReturnType = "NSUInteger";
 		}
 

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -327,7 +327,6 @@ namespace ObjC {
 
 			if (equals.TryGetValue (t, out m)) {
 				var builder = new EqualsHelper (headers, implementation) {
-					ObjCSignature = "isEqual:(id)other",
 					AssemblySafeName = aname,
 					MetadataToken = m.MetadataToken,
 					ObjCTypeName = managed_name,
@@ -343,7 +342,6 @@ namespace ObjC {
 
 			if (hashes.TryGetValue (t, out m)) {
 				var builder = new HashHelper (headers, implementation) {
-					ObjCSignature = "hash",
 					AssemblySafeName = aname,
 					MetadataToken = m.MetadataToken,
 					ObjCTypeName = managed_name,


### PR DESCRIPTION
* Move constants from the caller into the helper code;
* Specify that the argument (id) to isEqual can be null (`_Nullable`);