### PR TITLE
[objc] Support ValueType with no default constructor

### DIFF
--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -223,6 +223,10 @@
 }
 
 - (void) testStructs {
+	Structs_Point* def = [[Structs_Point alloc] init];
+	XCTAssert ([def x] == .0f, "x 0");
+	XCTAssert ([def y] == .0f, "y 0");
+
 	Structs_Point* p1 = [[Structs_Point alloc] initWithX:1.0f y:-1.0f];
 	XCTAssert ([p1 x] == 1.0f, "x 1");
 	XCTAssert ([p1 y] == -1.0f, "y 1");


### PR DESCRIPTION
This happens if there's no initialization. Previously the lack of a
public `.ctor()` meant we did not generate the code (nothing to call).

This was not correct (since it's valid in .net) so we detect the
condition and generate a simpler `init` method in such case.

Unit tests added (for the existing `Point` type that suffered, unnoticed,
from this)

Fix https://github.com/mono/Embeddinator-4000/issues/202