### PR TITLE
[objc] Print (NSLog) any managed exceptions that we are ignoring

### DIFF
--- a/objcgen/methodhelper.cs
+++ b/objcgen/methodhelper.cs
@@ -96,15 +96,17 @@ namespace ObjC {
 				implementation.Write ("MonoObject* __result = ");
 			implementation.WriteLine ($"mono_runtime_invoke ({method}, {instance}, {args}, &__exception);");
 
-			implementation.WriteLine ("if (__exception)");
+			implementation.WriteLine ("if (__exception) {");
 			implementation.Indent++;
 			if (IgnoreException) {
 				// TODO: Apple often do NSLog (or asserts but they are more brutal) and returning nil is allowed (and common)
+				implementation.WriteLine ("NSLog (@\"%@\", mono_embeddinator_get_nsstring (mono_object_to_string (__exception, nil)));");
 				implementation.WriteLine ("return nil;");
 			} else {
 				implementation.WriteLine ("mono_embeddinator_throw_exception (__exception);");
 			}
 			implementation.Indent--;
+			implementation.WriteLine ("}");
 		}
 
 		public void EndImplementation ()

--- a/support/mono-support.h
+++ b/support/mono-support.h
@@ -43,6 +43,7 @@ MonoObject *    mono_field_get_value_object (MonoDomain *domain, MonoClassField 
 void            mono_field_set_value (MonoObject *obj, MonoClassField *field, void *value);
 MonoVTable *    mono_class_vtable          (MonoDomain *domain, MonoClass *klass);
 void            mono_field_static_set_value (MonoVTable *vt, MonoClassField *field, void *value);
+MonoString *    mono_object_to_string (MonoObject *obj, MonoObject **exc);
 
 MONO_EMBEDDINATOR_END_DECLS
 #else


### PR DESCRIPTION
Right now exceptions from `init*` are ignored and returns null, so no
half backed instance is returned to native code.

This will actually print the _ignored_ exception so a debugger is not
needed to report what went wrong with those calls.

E.g. from Xcode unit tests

2017-04-28 10:01:45.409171-0400 xctest[92173:48871203] System.NotFiniteNumberException: Number encountered was not a finite quantity.
  at Exceptions.Throwers..ctor () [0x00008] in <ad2101828b344b3fb1eff45170e0bcb4>:0
2017-04-28 10:01:45.412577-0400 xctest[92173:48871203] System.TypeInitializationException: The type initializer for 'Exceptions.ThrowInStaticCtor' threw an exception. ---> System.Exception: Exception of type 'System.Exception' was thrown.
  at Exceptions.ThrowInStaticCtor..cctor () [0x00001] in <ad2101828b344b3fb1eff45170e0bcb4>:0
   --- End of inner exception stack trace ---