### PR TITLE
[objc] Correctly expose types that conforms to (bound) protocols

### DIFF
--- a/objcgen/EqualsHelper.cs
+++ b/objcgen/EqualsHelper.cs
@@ -14,15 +14,15 @@ namespace ObjC {
 		public void WriteImplementation ()
 		{
 			BeginImplementation ();
-			implementation.WriteLine ("if (![other respondsToSelector: @selector (xamarinGetGCHandle)])");
+			implementation.WriteLine ("MonoObject* __other = mono_embeddinator_get_object (other, false);");
+			implementation.WriteLine ("if (!__other)");
 			implementation.Indent++;
 			implementation.WriteLine ("return false;");
 			implementation.Indent--;
 			WriteMethodLookup ();
 
 			implementation.WriteLine ("void* __args [1];");
-			implementation.WriteLine ("int gchandle = [other xamarinGetGCHandle];");
-			implementation.WriteLine ("__args[0] = mono_gchandle_get_target (gchandle);");
+			implementation.WriteLine ("__args [0] = __other;");
 
 			WriteInvoke ("__args");
 

--- a/objcgen/objcgenerator-helpers.cs
+++ b/objcgen/objcgenerator-helpers.cs
@@ -37,7 +37,10 @@ namespace ObjC {
 						objc.Append (paramName.ToLowerInvariant ());
 				}
 				var pt = p.ParameterType;
-				var ptname = NameGenerator.GetTypeName (p.ParameterType);
+				var ptname = NameGenerator.GetTypeName (pt);
+				if (pt.IsInterface)
+					ptname = $"id<{ptname}>";
+
 				if (types.Contains (pt))
 					ptname += " *";
 				if (n > 0 || !isExtension)

--- a/support/objc-support.h
+++ b/support/objc-support.h
@@ -39,5 +39,8 @@ NSString* mono_embeddinator_get_nsstring (MonoString* string);
 MONO_EMBEDDINATOR_API
 NSComparisonResult mono_embeddinator_compare_to (MonoEmbedObject *object, MonoMethod *method, MonoEmbedObject *other);
 
+MONO_EMBEDDINATOR_API
+MonoObject* mono_embeddinator_get_object (id native, bool assertOnFailure);
+
 MONO_EMBEDDINATOR_END_DECLS
 	

--- a/support/objc-support.m
+++ b/support/objc-support.m
@@ -49,3 +49,15 @@ NSComparisonResult mono_embeddinator_compare_to (MonoEmbedObject *object, MonoMe
 	void* __unbox = mono_object_unbox (__result);
 	return (NSComparisonResult) *((int*)__unbox);
 }
+
+MonoObject* mono_embeddinator_get_object (id native, bool assertOnFailure)
+{
+	if (![native respondsToSelector:@selector (xamarinGetGCHandle)]) {
+		if (!assertOnFailure)
+			return nil;
+		NSLog (@"`%@` is not a managed instance and cannot be used like one", [native description]);
+		abort ();
+	}
+	int gchandle = (int) [native performSelector:@selector (xamarinGetGCHandle)];
+	return mono_gchandle_get_target (gchandle);
+}

--- a/tests/managed/interfaces.cs
+++ b/tests/managed/interfaces.cs
@@ -42,4 +42,28 @@ namespace Interfaces {
 			return new MakeItUp ();
 		}
 	}
+
+	public interface IOperations {
+		int AddInt (int a, int b);
+	}
+
+	public class ManagedAdder: IOperations {
+
+		public int AddInt (int a, int b)
+		{
+			return a + b;
+		}
+	}
+
+	public class OpConsumer {
+		public static int DoAddition (IOperations ops, int a, int b)
+		{
+			return ops.AddInt (a, b);
+		}
+
+		public static bool TestManagedAdder (int a, int b)
+		{
+			return DoAddition (new ManagedAdder (), a, b) == (a + b);
+		}
+	}
 }

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -676,11 +676,20 @@
 
 - (void)testProtocols {
 	id<Interfaces_IMakeItUp> m = [Interfaces_Supplier create];
+	XCTAssertTrue ([m conformsToProtocol:@protocol(Interfaces_IMakeItUp)], "conformsToProtocol 1");
 	XCTAssertTrue ([m boolean], "true");
 	XCTAssertFalse ([m boolean], "false");
 
 	XCTAssertEqualObjects (@"0", [m convertInt32:0], "0");
 	XCTAssertEqualObjects (@"1", [m convertInt64:1ll], "1");
+
+	Interfaces_ManagedAdder *adder = [[Interfaces_ManagedAdder alloc] init];
+	XCTAssertTrue ([adder conformsToProtocol:@protocol(Interfaces_IOperations)], "conformsToProtocol 2");
+	XCTAssertTrue ([Interfaces_OpConsumer doAdditionOps:adder a:40 b:2] == 42, "doAdditionOps");
+	XCTAssertTrue ([Interfaces_OpConsumer testManagedAdderA:1 b:-1], "testManagedAdder");
+
+	// FIXME: today it is not possible to define a native type that conforms
+	// to `Interfaces_IOperations` and pass it on the managed side (abort)
 }
 
 - (void) testOperatorOverloading {


### PR DESCRIPTION
and add unit tests. This required a few other changes like:

* Getting the managed instance, if it exists, from a native instance is
  moved to the support code (so it can be shared for multiple usages);

* Most (unless static) bound types now expose `xamarinGetGCHandle`, i.e.
  not just the one where `isEqual:` is implemented);

* `xamarinGetGCHandle` exists only inside the implementation (.m), not
  in the header (.h) file and is commented to be for internal uses only;

* EqualsHelper is modified to reuse the shared code;