### PR TITLE
[objc] Attach pointer char '*' to variable for properties

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -544,7 +544,11 @@ namespace ObjC {
 			var property_type = NameGenerator.GetTypeName (pt);
 			if (types.Contains (pt))
 				property_type += " *";
-			headers.WriteLine ($") {property_type} {name};");
+
+			var spacing = " ";
+			if (property_type.EndsWith ("*", StringComparison.Ordinal))
+				spacing = string.Empty;
+			headers.WriteLine ($") {property_type}{spacing}{name};");
 
 			ImplementMethod (getter, name, false, pi);
 			if (setter == null)
@@ -573,7 +577,11 @@ namespace ObjC {
 				field_type += " *";
 
 			var name = fi.Name.CamelCase ();
-			headers.WriteLine ($") {field_type} {name};");
+
+			var spacing = " ";
+			if (field_type.EndsWith ("*", StringComparison.Ordinal))
+				spacing = string.Empty;
+			headers.WriteLine ($") {field_type}{spacing}{name};");
 
 			// it's similar, but different from implementing a method
 

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -545,9 +545,7 @@ namespace ObjC {
 			if (types.Contains (pt))
 				property_type += " *";
 
-			var spacing = " ";
-			if (property_type.EndsWith ("*", StringComparison.Ordinal))
-				spacing = string.Empty;
+			var spacing = property_type [property_type.Length - 1] == '*' ? string.Empty : " ";
 			headers.WriteLine ($") {property_type}{spacing}{name};");
 
 			ImplementMethod (getter, name, false, pi);
@@ -578,9 +576,7 @@ namespace ObjC {
 
 			var name = fi.Name.CamelCase ();
 
-			var spacing = " ";
-			if (field_type.EndsWith ("*", StringComparison.Ordinal))
-				spacing = string.Empty;
+			var spacing = field_type [field_type.Length - 1] == '*' ? string.Empty : " ";
 			headers.WriteLine ($") {field_type}{spacing}{name};");
 
 			// it's similar, but different from implementing a method


### PR DESCRIPTION
When coding, people attach the pointer char to either the type or the variable but the convention is to attach it to the variable.
See first example in https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingIvarsAndTypes.html#//apple_ref/doc/uid/20001284-BAJGIIJE
Also all properties in the iOS framework are following this convention.

You never see `NSString * myName`.