### PR TITLE
[objc] Warn that arrays are not yet supported

### DIFF
--- a/objcgen/objcgenerator-processor.cs
+++ b/objcgen/objcgenerator-processor.cs
@@ -36,6 +36,12 @@ namespace ObjC {
 			if (unsupported.Contains (t))
 				return false;
 
+			if (t.IsArray) {
+				delayed.Add (ErrorHelper.CreateWarning (1010, $"Type `{t}` is not generated because `arrays` are not supported."));
+				unsupported.Add (t);
+				return false;
+			}
+
 			if (t.IsGenericParameter || t.IsGenericType) {
 				delayed.Add (ErrorHelper.CreateWarning (1010, $"Type `{t}` is not generated because `generics` are not supported."));
 				unsupported.Add (t);


### PR DESCRIPTION
reference: https://github.com/mono/Embeddinator-4000/issues/189

We prefer to warn and skip generation of known missing features
rather than throw an error that blocks testing existing assemblies