### PR TITLE
Allow many operator overloads

### DIFF
--- a/objcgen/operatoroverloads.cs
+++ b/objcgen/operatoroverloads.cs
@@ -65,9 +65,6 @@ namespace ObjC
 			}
 
 			foreach (var match in matches.Where (x => x.Value.Count > 1)) {
-				if (match.Value.Count != 2)
-					throw new EmbeddinatorException (99, $"Internal error `FindOperatorPairs found {match.Value.Count} matches?`. Please file a bug report with a test case (https://github.com/mono/Embeddinator-4000/issues");
-
 				// If we have a friendly method, ignore op variants and vice versa
 				MethodInfo friendlyMethod = match.Value.FirstOrDefault (x => !x.Name.StartsWith ("op_", StringComparison.Ordinal));
 				if (friendlyMethod != null) {

--- a/tests/managed/overloads.cs
+++ b/tests/managed/overloads.cs
@@ -68,6 +68,11 @@ namespace Overloads {
 			return new AllOperators (c1.Value / c2);
 		}
 
+		public static AllOperators operator / (AllOperators c1, long c2) 
+		{
+			return new AllOperators (c1.Value / (int)c2);
+		}
+
 		public static AllOperators operator ^ (AllOperators c1, AllOperators c2)
 		{
 			return new AllOperators (c1.Value ^ c2.Value);


### PR DESCRIPTION
- https://github.com/mono/Embeddinator-4000/commit/c36d639770f86ca5602e52aceddf5d6417ef0514 removed need for exception but it was not removed
- Fixes https://github.com/mono/Embeddinator-4000/issues/207 from operator issues. Now hitting:
	error EM0009: The feature `Returning type Nullable`1 from native code` is not currently supported by the tool