### PR TITLE
[objc] Move the processing of extension methods after we check for unsupported types

### DIFF
--- a/objcgen/objcgenerator-processor.cs
+++ b/objcgen/objcgenerator-processor.cs
@@ -151,23 +151,6 @@ namespace ObjC {
 					continue;
 				}
 
-				// handle extension methods
-				if (extension_type && mi.HasCustomAttribute ("System.Runtime.CompilerServices", "ExtensionAttribute")) {
-					Dictionary<Type, List<MethodInfo>> extensions;
-					if (!extensions_methods.TryGetValue (t, out extensions)) {
-						extensions = new Dictionary<Type, List<MethodInfo>> ();
-						extensions_methods.Add (t, extensions);
-					}
-					var extended_type = mi.GetParameters () [0].ParameterType;
-					List<MethodInfo> methods;
-					if (!extensions.TryGetValue (extended_type, out methods)) {
-						methods = new List<MethodInfo> ();
-						extensions.Add (extended_type, methods);
-					}
-					methods.Add (mi);
-					continue;
-				}
-
 				var rt = mi.ReturnType;
 				if (!IsSupported (rt)) {
 					delayed.Add (ErrorHelper.CreateWarning (1030, $"Method `{mi}` is not generated because return type `{rt}` is not supported."));
@@ -186,6 +169,23 @@ namespace ObjC {
 				}
 				if (!pcheck)
 					continue;
+
+				// handle extension methods
+				if (extension_type && mi.HasCustomAttribute ("System.Runtime.CompilerServices", "ExtensionAttribute")) {
+					Dictionary<Type, List<MethodInfo>> extensions;
+					if (!extensions_methods.TryGetValue (t, out extensions)) {
+						extensions = new Dictionary<Type, List<MethodInfo>> ();
+						extensions_methods.Add (t, extensions);
+					}
+					var extended_type = mi.GetParameters () [0].ParameterType;
+					List<MethodInfo> extmethods;
+					if (!extensions.TryGetValue (extended_type, out extmethods)) {
+						extmethods = new List<MethodInfo> ();
+						extensions.Add (extended_type, extmethods);
+					}
+					extmethods.Add (mi);
+					continue;
+				}
 
 				yield return mi;
 			}

--- a/tests/managed/methods.cs
+++ b/tests/managed/methods.cs
@@ -124,6 +124,12 @@ namespace Methods {
 			return @string.Length == 0;
 		}
 
+		// objc: this won't be generated until nullable are supported but we want to make sure it does not stop the build with an error
+		public static bool? GetNull (this string @string)
+		{
+			return null;
+		}
+
 		public static string NotAnExtensionMethod ()
 		{
 			return String.Empty;


### PR DESCRIPTION
Solve:
```
Generating binding code...
error EM0009: The feature `Returning type Nullable`1 from native code` is not currently supported by the tool
```

when a nullable type (not yet supported [1]) was used in extensions
methods.

[1] https://github.com/mono/Embeddinator-4000/issues/229