### PR TITLE
[objc] Make sure we can build for iOS release using mtouch. Partial fix for #237

### DIFF
--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -519,6 +519,8 @@ namespace Embeddinator {
 						mtouch.Append ($"--sdkroot {XcodeApp} ");
 						mtouch.Append ($"--targetver {build_info.MinVersion} ");
 						mtouch.Append ("--dsym:false ");
+						mtouch.Append ("--msym:false ");
+						mtouch.Append ("--nosymbolstrip ");
 						mtouch.Append ($"--embeddinator ");
 						foreach (var asm in Assemblies)
 							mtouch.Append (Quote (Path.GetFullPath (asm.Location))).Append (" ");

--- a/support/mono-support.h
+++ b/support/mono-support.h
@@ -44,6 +44,9 @@ void            mono_field_set_value (MonoObject *obj, MonoClassField *field, vo
 MonoVTable *    mono_class_vtable          (MonoDomain *domain, MonoClass *klass);
 void            mono_field_static_set_value (MonoVTable *vt, MonoClassField *field, void *value);
 MonoString *    mono_object_to_string (MonoObject *obj, MonoObject **exc);
+MonoClass *     mono_class_get (MonoImage *image, uint32_t type_token);
+MonoMethod *    mono_get_method (MonoImage *image, uint32_t token, MonoClass *klass);
+MonoClassField* mono_class_get_field (MonoClass *klass, uint32_t field_token);
 
 MONO_EMBEDDINATOR_END_DECLS
 #else

--- a/tests/objc-cli/Makefile
+++ b/tests/objc-cli/Makefile
@@ -21,6 +21,9 @@ MANAGED_DLL=$(GENERIC_MANAGED_DLL)
 debug/libmanaged-ios-framework/managed-ios.framework: $(IOS_MANAGED_DLL) $(OBJC_GEN)
 	$(MONO) --debug $(abspath $(OBJC_GEN)) --debug $(abspath $<) -c --outdir=$(abspath $(dir $@)) --target=framework --platform=ios
 
+release/libmanaged-ios-framework/managed-ios.framework: $(IOS_MANAGED_DLL) $(OBJC_GEN)
+	$(MONO) --debug $(abspath $(OBJC_GEN)) $(abspath $<) -c --outdir=$(abspath $(dir $@)) --target=framework --platform=ios
+
 debug/libmanaged.dylib: debug/managed.dll $(OBJC_GEN)
 	$(MONO) --debug $(OBJC_GEN) --debug debug/managed.dll -c -o debug
 
@@ -91,7 +94,7 @@ test-framework: test-framework-macos test-framework-ios test-framework-tvos test
 test-framework-%: debug/managed.dll $(OBJC_GEN)
 	/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono --debug $(abspath $(OBJC_GEN)) --debug $(abspath debug/managed.dll) -c --outdir=$(abspath build/$@-temp-dir) --target=framework --platform=$*
 
-xctest-ios-simulator: debug/libmanaged-ios-framework/managed-ios.framework
+xctest-ios-simulator: debug/libmanaged-ios-framework/managed-ios.framework release/libmanaged-ios-framework/managed-ios.framework
 	xcodebuild -quiet test -project libmanaged-ios/libmanaged-ios.xcodeproj -scheme libmanaged-ios -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest'
 
 xctest-ios-device: build/ios-device-id debug/libmanaged-ios-framework/managed-ios.framework


### PR DESCRIPTION
Embedding with Xamarin.iOS is different than doing it directly with mono.
This requires some methods to be defined, like the ones only used for
release (when `TOKENLOOKUP` is defined).

The integration with mtouch is also incomplete (for non-debug build) as
some steps (MdbSym) and SymbolStrip (only used in release by default)
causes FileNotFoundException (some state is not set correctly).

This PR is a fix for the former (headers), a workaround for the later
(mtouch invocation) and a Makefile change to make sure we always build
release/iOS on bots (because untested stuff never works, for long)

ref: https://github.com/mono/Embeddinator-4000/issues/237