### PR TITLE
[objc] Skip generation for subclasses of unsupported types

### DIFF
--- a/objcgen/objcgenerator-processor.cs
+++ b/objcgen/objcgenerator-processor.cs
@@ -74,7 +74,9 @@ namespace ObjC {
 				}
 				break;
 			}
-			return true;
+
+			var base_type = t.BaseType;
+			return (base_type == null) || base_type.Is ("System", "Object") ? true : IsSupported (base_type);
 		}
 
 		protected IEnumerable<Type> GetTypes (Assembly a)

--- a/tests/managed/types.cs
+++ b/tests/managed/types.cs
@@ -80,3 +80,10 @@ public static class Type_String
 	public static string NonEmptyString { get { return "Hello World"; } }
 }
 
+// objc: this type won't be generated (Exception is not supported) but the generation will succeed (with warnings)
+public class MyException : Exception {
+}
+
+// objc: this type won't be generated (subclassing an unsupported type) but the generation will succeed (with warnings)
+public class MyNextException : MyException {
+}


### PR DESCRIPTION
In such case a warning will be displayed and nothing will be generated.

Test added so we can ensure such condition does not stop the generation
with an error.