### PR TITLE
[objc] Allow the inclusion/generation of BCL types to help bind user code

### DIFF
--- a/objcgen/NameGenerator.cs
+++ b/objcgen/NameGenerator.cs
@@ -110,7 +110,7 @@ namespace ObjC {
 					case "Void":
 						return "void";
 					default:
-						return "object";
+						return t.IsInterface ? t.FullName : "object";
 					}
 				default:
 					return t.FullName;

--- a/tests/managed/types.cs
+++ b/tests/managed/types.cs
@@ -80,3 +80,9 @@ public static class Type_String
 	public static string NonEmptyString { get { return "Hello World"; } }
 }
 
+public class ExposeExtraTypes {
+
+	public TimeSpan TimeOfDay {
+		get { return DateTime.Now.TimeOfDay; }
+	}
+}

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -767,6 +767,29 @@
 	XCTAssert ([testClass twoUshortK:5 l:8] == 13, "Two ushorts");
 }
 
+- (void)testTimeSpan {
+	// because we have an API that expose TimeSpan we generate the type from mscorlib.dll (because NSTimeInterval is not a very good alternative)
+	System_TimeSpan *ts = [[System_TimeSpan alloc] initWithDays:1 hours:2 minutes:3 seconds:4 milliseconds:5];
+	XCTAssertTrue ([ts days] == 1, "days");
+	XCTAssertTrue ([ts hours] == 2, "hours");
+	XCTAssertTrue ([ts minutes] == 3, "minutes");
+	XCTAssertTrue ([ts seconds] == 4, "seconds");
+	XCTAssertTrue ([ts milliseconds] == 5, "milliseconds");
+
+	XCTAssertTrue ([ts ticks] == 937840050000ll, "ticks");
+}
+
+- (void)testIFormatProvider {
+	// TimeSpan also expose IFormatProvider which we can't really support but can't really ignore
+	// because IFormatProvider-less overloads might not exists and null is generally accepted
+	System_TimeSpan *ts = [[System_TimeSpan alloc] initWithTicks:937840050000ll];
+
+	NSString *s1 = [ts toStringFormat:@"c" formatprovider:nil];
+	NSString *s2 = [ts toStringFormat:@"c"];
+	XCTAssertEqualObjects (s1, @"1.02:03:04.0050000", "0");
+	XCTAssertEqualObjects (s1, s2, "1");
+}
+
 #pragma clang diagnostic pop
 
 @end


### PR DESCRIPTION
As mentioned in issue #176 [1] it's something better to bring an existing
type from the BCL (like `TimeSpan`) into the generated code than try to
convert all it's uses.

The same hack can be used to provide API even if the type itself cannot
be supported, e.g. `IFormatProvider` [2]

[1] https://github.com/mono/Embeddinator-4000/issues/176
[2] https://github.com/mono/Embeddinator-4000/issues/175