### PR TITLE
[objc] Do not create categories for extension methods on primitive types. Fix issue #249

### DIFF
--- a/docs/error.md
+++ b/docs/error.md
@@ -146,9 +146,15 @@ This is a **warning** that the default parameters of method `M` are not generati
 
 Note: Supported features will evolve with new versions of the tool.
 
+
 <h3><a name="EM1033"/>Method `M` is not generated because another method exposes the operator with a friendly name.</h3>
 
 This is a **warning** that the method `M` is not generated because another method exposes the operator with a friendly name. (https://msdn.microsoft.com/en-us/library/ms229032(v=vs.110).aspx)
+
+
+<h3><a name="EM1034"/>Extension method `M` is not generated inside a category because they cannot be created on primitive type `T`. A normal, static method was generated.</h3>
+
+This is a **warning** that an extension method on a primivite type (e.g. `System.Int32`) was found. In ObjC it is not possible to create categories on primitive type. Instead the generator will be produce a normal, static method.
 
 
 

--- a/objcgen/objcgenerator-processor.cs
+++ b/objcgen/objcgenerator-processor.cs
@@ -179,19 +179,23 @@ namespace ObjC {
 
 				// handle extension methods
 				if (extension_type && mi.HasCustomAttribute ("System.Runtime.CompilerServices", "ExtensionAttribute")) {
-					Dictionary<Type, List<MethodInfo>> extensions;
-					if (!extensions_methods.TryGetValue (t, out extensions)) {
-						extensions = new Dictionary<Type, List<MethodInfo>> ();
-						extensions_methods.Add (t, extensions);
-					}
 					var extended_type = mi.GetParameters () [0].ParameterType;
-					List<MethodInfo> extmethods;
-					if (!extensions.TryGetValue (extended_type, out extmethods)) {
-						extmethods = new List<MethodInfo> ();
-						extensions.Add (extended_type, extmethods);
+					if (extended_type.IsPrimitive) {
+						delayed.Add (ErrorHelper.CreateWarning (1034, $"Extension method `{mi}` is not generated inside a category because they cannot be created on primitive type `{extended_type}`. A normal, static method was generated."));
+					} else {
+						Dictionary<Type, List<MethodInfo>> extensions;
+						if (!extensions_methods.TryGetValue (t, out extensions)) {
+							extensions = new Dictionary<Type, List<MethodInfo>> ();
+							extensions_methods.Add (t, extensions);
+						}
+						List<MethodInfo> extmethods;
+						if (!extensions.TryGetValue (extended_type, out extmethods)) {
+							extmethods = new List<MethodInfo> ();
+							extensions.Add (extended_type, extmethods);
+						}
+						extmethods.Add (mi);
+						continue;
 					}
-					extmethods.Add (mi);
-					continue;
 				}
 
 				yield return mi;

--- a/tests/managed/methods.cs
+++ b/tests/managed/methods.cs
@@ -130,6 +130,12 @@ namespace Methods {
 			return null;
 		}
 
+		// objc: this will be generated as a normal method since categories cannot be created on primitive types
+		public static int Increment (this int value)
+		{
+			return value + 1;
+		}
+
 		public static string NotAnExtensionMethod ()
 		{
 			return String.Empty;

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -204,6 +204,8 @@
 	XCTAssert ([default_item integer] == 0, "default creation 0");
 
 	XCTAssertEqualObjects (@"", [Methods_SomeExtensions notAnExtensionMethod], "empty string");
+
+	XCTAssert ([Methods_SomeExtensions incrementValue:1] == 2, "no category on primitive types");
 }
 
 - (void)testCategories {


### PR DESCRIPTION
Creating categories on primitive types is not possible with ObjC.
Instead just create a _normal_ static method so the API can still be
used.

https://github.com/mono/Embeddinator-4000/issues/249