### PR TITLE
[objc][samples] Add Makefile to download UnitsNet nuget and create a native macOS dylib for the library

### DIFF
--- a/samples/Makefile
+++ b/samples/Makefile
@@ -9,4 +9,5 @@ clean:
 IOS_SAMPLES=
 
 MAC_SAMPLES=\
-	mac/weather\
+	mac/weather	\
+	UnitsNet

--- a/samples/UnitsNet/.gitignore
+++ b/samples/UnitsNet/.gitignore
@@ -1,0 +1,6 @@
+UnitsNet.3.57.0/
+Debug/
+*.h
+*.c
+*.m
+*.nupkg

--- a/samples/UnitsNet/Makefile
+++ b/samples/UnitsNet/Makefile
@@ -1,0 +1,20 @@
+all: unitsnet
+	
+TOP=../..
+OBJC_GEN=$(OBJC_GEN_DIR)/bin/Debug/objcgen.exe
+
+MONO=/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono
+
+OBJC_GEN_DIR=../../objcgen
+OBJC_GEN=$(OBJC_GEN_DIR)/bin/Debug/objcgen.exe
+$(OBJC_GEN): $(wildcard $(OBJC_GEN_DIR)/*.cs) $(wildcard ../../support/*)
+	$(MAKE) -C $(OBJC_GEN_DIR)
+
+UNITSNET_VERSION=3.58.0
+
+unitsnet: $(OBJC_GEN)
+	nuget install UnitsNet -Version $(UNITSNET_VERSION)
+	$(MONO) $(OBJC_GEN) UnitsNet.$(UNITSNET_VERSION)/lib/netstandard1.0/UnitsNet.dll -debug -o Debug -c
+
+clean:
+	rm -rf UnitsNet.*/ Debug/ *.h *.c *.m

--- a/samples/UnitsNet/README.md
+++ b/samples/UnitsNet/README.md
@@ -1,0 +1,15 @@
+# UnitsNet 
+
+This is a sample to bind an existing .net library, UnitsNet, as a native library usable from ObjC.
+
+github: https://github.com/anjdreas/UnitsNet
+nuget: https://www.nuget.org/packages/UnitsNet/
+
+Right now there are **many** warnings for API that cannot be generated. Most of the warnings comes from the use of:
+
+* `System.Nullable<T>`, see issue [#229](https://github.com/mono/Embeddinator-4000/issues/229)
+* `System.Decimal`, see issue [#254](https://github.com/mono/Embeddinator-4000/issues/254)
+* `System.TimeSpan`, discussed in issue [#176](https://github.com/mono/Embeddinator-4000/issues/176)
+* `System.IFormatProvider`, see issue [#175](https://github.com/mono/Embeddinator-4000/issues/175)
+
+Still the embeddinator is able to generate a fat (i386/x86_64) `libUnitsNet.dylib` usable with an ObjC-written macOS application.


### PR DESCRIPTION
There is a large number of warnings (for things we don't yet support) but
both the generation (to ObjC) and compiling (with clang) should succeed
and produce a fat (i386/x86_64) .dylib that can be used for macOS apps