### PR TITLE
[objc] Fix issues found while working on issue #176

### DIFF
--- a/objcgen/NameGenerator.cs
+++ b/objcgen/NameGenerator.cs
@@ -110,7 +110,7 @@ namespace ObjC {
 					case "Void":
 						return "void";
 					default:
-						return "object";
+						return t.IsInterface ? t.FullName : "object";
 					}
 				default:
 					return t.FullName;

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -101,6 +101,8 @@ namespace ObjC {
 				implementation.WriteLine ("// we cannot use `+initialize` inside categories as they would replace the original type code");
 				implementation.WriteLine ("// since there should not be tons of them we're pre-loading them when loading the assembly");
 				foreach (var definedType in extensions_methods.Keys) {
+					if (definedType.Assembly != a.Assembly)
+						continue;
 					var managed_name = NameGenerator.GetObjCName (definedType);
 					implementation.WriteLineUnindented ("#if TOKENLOOKUP");
 					implementation.WriteLine ($"{managed_name}_class = mono_class_get (__{name}_image, 0x{definedType.MetadataToken:X8});");
@@ -693,7 +695,7 @@ namespace ObjC {
 				ObjCSignature = objcsig,
 				ObjCTypeName = managed_type_name,
 				IsValueType = type.IsValueType,
-				IsVirtual = info.IsVirtual,
+				IsVirtual = info.IsVirtual && !info.IsFinal,
 			};
 
 			if (pi == null)


### PR DESCRIPTION
Spinoff of PR #251 [1], which goal is postponed for a bit, to fix issues
found while implementing support for mscorlib types.

* mono signatures for interfaces != `object`;

* we should only generate class handles for extension types part of the
  current assembly;

* if a method is final (sealed) then it's not really virtual

Sadly the original test cases cannot be applied :(

[1] https://github.com/mono/Embeddinator-4000/pull/251