### PR TITLE
[objc] Ease the addition of assemblies and types while processing code

### DIFF
--- a/objcgen/NameGenerator.cs
+++ b/objcgen/NameGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Embeddinator;
@@ -168,7 +168,7 @@ namespace ObjC {
 			string ptname = GetTypeName (pt);
 			if (pt.IsInterface)
 				ptname = $"id<{ptname}>";
-			if (allTypes.Contains (pt))
+			if (allTypes.HasClass (pt))
 				ptname += " *";
 			return ptname;
 		}

--- a/objcgen/extensions.cs
+++ b/objcgen/extensions.cs
@@ -144,10 +144,19 @@ namespace Embeddinator {
 	}
 
 	public static class ListExtensions {
-		public static bool Contains (this List<ProcessedType> list, Type type)
+		public static bool HasClass (this List<ProcessedType> list, Type type)
 		{
 			foreach (ProcessedType t in list) {
-				if (t.Type == type)
+				if (t.IsClass && (type == t.Type))
+					return true;
+			}
+			return false;
+		}
+
+		public static bool HasProtocol (this List<ProcessedType> list, Type type)
+		{
+			foreach (ProcessedType t in list) {
+				if (t.IsProtocol && (type == t.Type))
 					return true;
 			}
 			return false;

--- a/objcgen/objcgenerator-processor.cs
+++ b/objcgen/objcgenerator-processor.cs
@@ -266,7 +266,7 @@ namespace ObjC {
 			var typeQueue = new Queue<ProcessedType> (types);
 			types.Clear (); // reuse
 			while (typeQueue.Count > 0) {
-		                Process (typeQueue.Dequeue ());
+				Process (typeQueue.Dequeue ());
 			}
 
 			types = types.OrderBy ((arg) => arg.Type.FullName).OrderBy ((arg) => types.HasClass (arg.Type.BaseType)).ToList ();

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -17,6 +17,8 @@ namespace Embeddinator {
 		public string Name { get; private set; }
 		public string SafeName { get; private set; }
 
+		public bool UserCode { get; set; }
+
 		public ProcessedAssembly (Assembly assembly)
 		{
 			Assembly = assembly;
@@ -29,6 +31,14 @@ namespace Embeddinator {
 		public Type Type { get; private set; }
 		public string TypeName { get; private set; }
 		public string ObjCName { get; private set; }
+
+		public ProcessedAssembly Assembly { get; set; }
+
+		public bool IsClass => !IsEnum && !IsProtocol;
+		public bool IsEnum => Type.IsEnum;
+		public bool IsProtocol => Type.IsInterface;
+
+		public bool UserCode => Assembly.UserCode;
 
 		public ProcessedType (Type type)
 		{


### PR DESCRIPTION
Use queues for assemblies and types so it's possible to add some while
processing them, e.g.

* adding code from another assembly, e.g. TimeSpan from mscorlib;

* adding new types, e.g. extensions methods creates one (or many)
  categories;

Start reducing the field sharing between the processor and the
generator. Both should, ideally, split off completely (but that
will require a few more PR)