### PR TITLE
[package/installer] Touch etc/paths.d/embeddinator-4000-commands

### DIFF
--- a/docs/getting-started-objc-ios.md
+++ b/docs/getting-started-objc-ios.md
@@ -52,7 +52,7 @@ Run the embeddinator to create a native framework for the managed assembly:
 
 ```shell
 cd ~/Projects/hello-from-csharp
-/Library/Frameworks/Xamarin.Embeddinator-4000.framework/Commands/objcgen ~/Projects/hello-from-csharp/hello-from-csharp/bin/Debug/hello-from-csharp.dll --target=framework --platform=iOS --outdir=output -c --debug
+objcgen ~/Projects/hello-from-csharp/hello-from-csharp/bin/Debug/hello-from-csharp.dll --target=framework --platform=iOS --outdir=output -c --debug
 ```
 
 The framework will be placed in `~/Projects/hello-from-csharp/output/hello-from-csharp.framework`.

--- a/docs/getting-started-objc-macos.md
+++ b/docs/getting-started-objc-macos.md
@@ -92,14 +92,14 @@ Now right click on *Weather* project node and select *Reveal in Finder*. In Find
 
 ## Using Embeddinator-4000
 
-If you installed Embeddinator-4000 using our pkg installer you should find **objcgen** in the following path `/Library/Frameworks/Xamarin.Embeddinator-4000.framework/Commands/objcgen`; **objcgen** is the tool that we need to generate a native library from a .NET assembly.
+If you installed Embeddinator-4000 using our pkg installer and started a new terminal session after the install, you should be able to use the **objcgen** command (otherwise you can use its absolute path: `/Library/Frameworks/Xamarin.Embeddinator-4000.framework/Commands/objcgen`); **objcgen** is the tool that we need to generate a native library from a .NET assembly.
 
 Open terminal, `cd` into the folder containing Weather.dll, and execute **objcgen** with the arguments shown below:
 
 ```shell
 cd /Users/Alex/Projects/Weather/Weather/bin/Debug
 
-/Library/Frameworks/Xamarin.Embeddinator-4000/Commands/objcgen --debug --outdir=output -c Weather.dll
+objcgen --debug --outdir=output -c Weather.dll
 ```
 
 Everything you need will be placed into the **output** directory next to *Weather.dll*. If you have your own .NET assembly, replace *Weather.dll* with it and follow the same steps above.

--- a/docs/getting-started-objective-c.md
+++ b/docs/getting-started-objective-c.md
@@ -34,7 +34,8 @@ The installer is a standard pkg based installer:
 ![Installer Install Type](Install2.png)
 ![Installer Summary](Install3.png)
 
-Once installed via an installer, you can run the tool via /Library/Frameworks/Xamarin.Embeddinator-4000.framework/Commands/objcgen 
+Once installed via the installer, after you start a new terminal session, you can use the `objcgen` command.  
+Otherwise you can always run the tool via its absolute path: `/Library/Frameworks/Xamarin.Embeddinator-4000.framework/Commands/objcgen`.
 
 ## Platforms
 

--- a/objcgen/Makefile
+++ b/objcgen/Makefile
@@ -26,12 +26,16 @@ else
 	$(SHELLCHECK) $^
 endif
 
-FRAMEWORK_DIR = _build/Library/Frameworks/Xamarin.Embeddinator-4000.framework
+E4K_FRAMEWORK_DIR = /Library/Frameworks/Xamarin.Embeddinator-4000.framework
+FRAMEWORK_DIR = _build/$(E4K_FRAMEWORK_DIR)
+PATHS_DIR = _build/etc/paths.d
 INSTALLER_FILES = Xamarin.Embeddinator-4000-$(PACKAGE_FULLVERSION).pkg
 
 package:: bin/Debug/objcgen.exe Make.config.inc
 	mkdir -p $(FRAMEWORK_DIR)/Commands/
 	mkdir -p $(FRAMEWORK_DIR)/Versions/$(PACKAGE_FULLVERSION)/bin
+	mkdir -p $(PATHS_DIR)
+	echo "${E4K_FRAMEWORK_DIR}/Commands" >> "${PATHS_DIR}/embeddinator-4000-commands"
 	ln -fs $(PACKAGE_FULLVERSION) $(FRAMEWORK_DIR)/Versions/Current
 	cp bin/Debug/objcgen.{exe,pdb} $(FRAMEWORK_DIR)/Versions/Current/bin/
 	cp bin/Debug/Mono.Options.dll $(FRAMEWORK_DIR)/Versions/Current/bin/


### PR DESCRIPTION
This embeddinator-4000-commands file has a path to the e4k command folder
which includes the objcgen command.

Fixes issue 277: [Package] Add Library/Frameworks/Xamarin.Embeddinator-4000.framework/Commands to $PATH
(https://github.com/mono/Embeddinator-4000/issues/277)