### PR TITLE
[objc] Add more generated comments in headers

### DIFF
--- a/objcgen/EqualsHelper.cs
+++ b/objcgen/EqualsHelper.cs
@@ -11,6 +11,15 @@ namespace ObjC {
 			ReturnType = "bool";
 		}
 
+		public override void WriteHeaders ()
+		{
+			headers.WriteLine ();
+			headers.WriteLine ("/** This override the default equality check (defined in NSObject Protocol)");
+			headers.WriteLine (" * https://developer.apple.com/reference/objectivec/1418956-nsobject/1418795-isequal?language=objc");
+			headers.WriteLine (" */");
+			base.WriteHeaders ();
+		}
+
 		public void WriteImplementation ()
 		{
 			BeginImplementation ();

--- a/objcgen/HashHelper.cs
+++ b/objcgen/HashHelper.cs
@@ -12,6 +12,15 @@ namespace ObjC {
 			ReturnType = "NSUInteger";
 		}
 
+		public override void WriteHeaders ()
+		{
+			headers.WriteLine ();
+			headers.WriteLine ("/** This override the default hashing computation (defined in NSObject Protocol)");
+			headers.WriteLine (" * https://developer.apple.com/reference/objectivec/1418956-nsobject/1418859-hash?language=objc");
+			headers.WriteLine (" */");
+			base.WriteHeaders ();
+		}
+
 		public void WriteImplementation ()
 		{
 			BeginImplementation ();

--- a/objcgen/methodhelper.cs
+++ b/objcgen/methodhelper.cs
@@ -43,7 +43,7 @@ namespace ObjC {
 			writer.Write ($" ({ReturnType}){ObjCSignature}");
 		}
 
-		public void WriteHeaders ()
+		public virtual void WriteHeaders ()
 		{
 			WriteSignature (headers);
 			headers.WriteLine (';');

--- a/objcgen/protocolhelper.cs
+++ b/objcgen/protocolhelper.cs
@@ -27,6 +27,9 @@ namespace ObjC {
 			headers.WriteLine ();
 			headers.WriteLine ($"/** Protocol {ProtocolName}");
 			headers.WriteLine ($" *  Corresponding .NET Qualified Name: `{AssemblyQualifiedName}`");
+			headers.WriteLine (" *");
+			headers.WriteLine (" * @warning This expose a managed (.net) interface. Conforming to this protocol from Objective-C code");
+			headers.WriteLine (" * does not allow interop with managed code. https://mono.github.io/Embeddinator-4000/Limitations#Subclassing");
 			headers.WriteLine (" */");
 			headers.WriteLine ($"@protocol {ProtocolName} <NSObject>");
 			headers.WriteLine ();


### PR DESCRIPTION
The comments covers `NSObject` protocol support for

* `- (bool)isEqual:(id _Nullable)other;`
* `- (NSUInteger)hash;`

and all `@protocol` where we link to the subclassing limitation.