### PR TITLE
[objc] Disable metadata token lookup when using the linker.

### DIFF
--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -429,8 +429,18 @@ namespace Embeddinator {
 					var common_options = new StringBuilder ("clang ");
 					if (Debug)
 						common_options.Append ("-g -O0 ");
-					else
-						common_options.Append ("-O2 -DTOKENLOOKUP ");
+					else {
+						common_options.Append ("-O2 ");
+						if (Platform == Platform.macOS) {
+							// Token lookup only works if the linker isn't involved.
+							// If the linker is enabled, all assemblies are loaded and re-saved
+							// (even if only linking SDK assemblies), which means metadata
+							// tokens may change even for non-linked assemblies. So completely 
+							// disable token lookup for platforms that uses the linker (all platforms
+							// except macOS).
+							common_options.Append ("-DTOKENLOOKUP ");
+						}
+					}
 					common_options.Append ("-fobjc-arc ");
 					common_options.Append ("-ObjC ");
 					common_options.Append ("-Wall ");


### PR DESCRIPTION
The linker can re-save assemblies that aren't linked, which may change
metadata tokens.

So we need to disable metadata token lookup when linking.

See also https://github.com/mono/Embeddinator-4000/issues/304