### PR TITLE
[objc] Xamarin.iOS now supports stripping when in embeddinator mode.

### DIFF
--- a/objcgen/Make.config
+++ b/objcgen/Make.config
@@ -4,9 +4,9 @@ MAX_MONO_VERSION=5.0.99
 MIN_MONO_URL=https://bosstoragemirror.blob.core.windows.net/wrench/mono-2017-02/9e/9ed0907eea13005d4e93b9c5f42c5c3015eba409/MonoFramework-MDK-5.0.0.18.macos10.xamarin.universal.pkg
 
 # Minimum Xamarin.iOS version
-MIN_XI_VERSION=10.11.0.107
-MAX_XI_VERSION=10.11.0.107
-MIN_XI_URL=https://bosstoragemirror.blob.core.windows.net/wrench/macios-mac-master/f4/f445856652727a331b783dbb9e4e5069a8071c20/xamarin.ios-10.11.0.107.pkg
+MIN_XI_VERSION=10.11.0.129
+MAX_XI_VERSION=10.11.0.129
+MIN_XI_URL=https://bosstoragemirror.blob.core.windows.net/wrench/macios-mac-master/d8/d811ef4c3916c528592343b45b8596f61c45bb2e/xamarin.ios-10.11.0.129.pkg
 
 # Minimum Xamarin.Mac version
 MIN_XM_VERSION=3.2.0.175

--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -538,7 +538,6 @@ namespace Embeddinator {
 						mtouch.Append ($"--targetver {build_info.MinVersion} ");
 						mtouch.Append ("--dsym:false ");
 						mtouch.Append ("--msym:false ");
-						mtouch.Append ("--nosymbolstrip ");
 						mtouch.Append ($"--embeddinator ");
 						foreach (var asm in Assemblies)
 							mtouch.Append (Quote (Path.GetFullPath (asm.Location))).Append (" ");


### PR DESCRIPTION
Fixes issue #237.