### PR TITLE
[objc] Name the output directory for iOS to match the binary to avoid an mtouch warning.

### DIFF
--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -529,7 +529,7 @@ namespace Embeddinator {
 					case Platform.tvOS:
 					case Platform.watchOS:
 						var mtouch = new StringBuilder ();
-						var appdir = Path.GetFullPath (Path.Combine (OutputDirectory, build_info.Sdk, "appdir"));
+						var appdir = Path.GetFullPath (Path.Combine (OutputDirectory, build_info.Sdk, LibraryName));
 						var cachedir = Path.GetFullPath (Path.Combine (outputDirectory, build_info.Sdk, "mtouch-cache"));
 						mtouch.Append (build_info.IsSimulator ? "--sim " : "--dev ");
 						mtouch.Append ($"{Quote (appdir)} ");


### PR DESCRIPTION
Avoids this warning:

> warning MT0030: The executable name (managed-ios) and the app name (appdir) are different, this may prevent crash logs from getting symbolicated properly.