### PR TITLE
[objcgen] Capture the inner exception for handled NotImplementedExceptions.

### DIFF
--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -106,7 +106,7 @@ namespace Embeddinator {
 					Console.WriteLine ("Done");
 					return result;
 				} catch (NotImplementedException e) {
-					throw new EmbeddinatorException (9, $"The feature `{e.Message}` is not currently supported by the tool");
+					throw new EmbeddinatorException (9, true, e, $"The feature `{e.Message}` is not currently supported by the tool");
 				}
 			default:
 				throw ErrorHelper.CreateError (99, "Internal error: invalid action {0}. Please file a bug report with a test case (https://github.com/mono/Embeddinator-4000/issues)", action);


### PR DESCRIPTION
This makes sure that we can print the original stack trace, which makes
finding out what wasn't implemented easier.