### PR TITLE
[objc] Add an assembly load hook, and use it to find assemblies in bundles.

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -72,6 +72,7 @@ namespace ObjC {
 			implementation.WriteLine ("return;");
 			implementation.Indent--;
 			implementation.WriteLine ("mono_embeddinator_init (&__mono_context, \"mono_embeddinator_binding\");");
+			implementation.WriteLine ("mono_embeddinator_install_assembly_load_hook (&mono_embeddinator_find_assembly_in_bundle);");
 			implementation.Indent--;
 			implementation.WriteLine ("}");
 			implementation.WriteLine ();

--- a/support/mono_embeddinator.h
+++ b/support/mono_embeddinator.h
@@ -86,15 +86,16 @@ MonoImage* mono_embeddinator_load_assembly(mono_embeddinator_context_t* ctx,
 MONO_EMBEDDINATOR_API
 char* mono_embeddinator_search_assembly(const char* assembly);
 
-/** Represents the assembly search hook function type. */
-typedef const char* (*mono_embeddinator_assembly_search_hook_t)(const char*);
+/** Represents the assembly load hook function type */
+typedef MonoAssembly * (*mono_embeddinator_assembly_load_hook_t)(const char *);
 
 /**
- * Installs an hook that returns the path to the given managed assembly.
- * Returns the previous installed hook.
+ * Installs an hook that loads the given managed assembly (or NULL if the assembly can't be found).
+ * Returns the previously installed hook.
  */
 MONO_EMBEDDINATOR_API
-void* mono_embeddinator_install_assembly_search_hook(mono_embeddinator_assembly_search_hook_t hook);
+mono_embeddinator_assembly_load_hook_t mono_embeddinator_install_assembly_load_hook(mono_embeddinator_assembly_load_hook_t hook);
+
 
 /** 
  * Searches and returns for the Mono class in the given assembly.

--- a/support/objc-support.h
+++ b/support/objc-support.h
@@ -42,5 +42,8 @@ NSComparisonResult mono_embeddinator_compare_to (MonoEmbedObject *object, MonoMe
 MONO_EMBEDDINATOR_API
 MonoObject* mono_embeddinator_get_object (id native, bool assertOnFailure);
 
+MONO_EMBEDDINATOR_API
+MonoAssembly *mono_embeddinator_find_assembly_in_bundle (const char *assembly);
+
 MONO_EMBEDDINATOR_END_DECLS
 	


### PR DESCRIPTION
Remove the assembly search hook that returns the path of an assembly, and
instead have an assembly load hook, which returns an already loaded
MonoAssembly *.

This makes writing the hook a bit simpler, because string-returning hooks need
specific memory management (a hook that returns a `const char *` won't be able
to use dynamically allocated strings easily, and returning a `char *` runs
into questions about how to free that string). It's much simpler to just
return a MonoAssembly*, which mono must free when unloaded.