### PR TITLE
[objc] Hide `[]` and `&` when we use type names as parameter names to avoid duplicates on overloads. Fixes #309

### DIFF
--- a/objcgen/NameGenerator.cs
+++ b/objcgen/NameGenerator.cs
@@ -181,6 +181,17 @@ namespace ObjC {
 			}
 		}
 
+		public static string GetParameterTypeName (Type t)
+		{
+			var name = t.Name;
+			if (t.IsArray)
+				return t.GetElementType ().Name + "Array";
+			else if (t.IsByRef)
+				return t.GetElementType ().Name + "Ref";
+			else
+				return t.Name;
+		}
+
 		public static string GetExtendedParameterName (ParameterInfo p, ParameterInfo [] parameters)
 		{
 			string pName = p.Name;

--- a/objcgen/objcgenerator-helpers.cs
+++ b/objcgen/objcgenerator-helpers.cs
@@ -37,7 +37,7 @@ namespace ObjC {
 					mono.Append (',');
 				}
 
-				string paramName = useTypeNames ? p.ParameterType.Name : p.Name;
+				string paramName = useTypeNames ? NameGenerator.GetParameterTypeName (p.ParameterType) : p.Name;
 				if ((method != null) && (n > 0 || !isExtension)) {
 					if (n == 0) {
 						if (useTypeNames || method.IsConstructor || (!method.IsSpecialName && !isOperator))

--- a/tests/managed/overloads.cs
+++ b/tests/managed/overloads.cs
@@ -315,4 +315,18 @@ namespace Overloads {
 			return Value.GetHashCode ();
 		}
 	}
+
+	public class ConflictingNamingOverload {
+
+		// objc: no need to call it (from xcode), the fact it compiles is fine
+		public static string Format (string [] values)
+		{
+			return String.Join (" ", values);
+		}
+
+		public static string Format (int [] values)
+		{
+			return String.Join (" ", values);
+		}
+	}
 }


### PR DESCRIPTION
reference:
https://github.com/mono/Embeddinator-4000/issues/309