### PR TITLE
[objc] Add support for System.TimeSpan into generated projects

### DIFF
--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -710,7 +710,11 @@ namespace Embeddinator {
 							mmp.Append (Quote (Path.GetFullPath (asm.Location))).Append (" ");
 						mmp.Append ($"-a:{GetPlatformAssembly ()} ");
 						mmp.Append ($"--sdk {GetSdkVersion (build_info.Sdk.ToLower ())} ");
-						mmp.Append ("--linksdkonly ");
+						if (Platform == Platform.macOSModern) {
+							mmp.Append ("--linksdkonly ");
+							mmp.Append ($"--xml={Quote (Path.Combine (OutputDirectory, "bindings.xml"))} ");
+						}
+						// FIXME: once merge add support for linking the platform (Xamarin.Mac.dll)
 						mmp.Append ("--registrar:static ");
 						mmp.Append ($"--cache {Quote (cachedir)} ");
 						if (Debug)

--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -710,11 +710,14 @@ namespace Embeddinator {
 							mmp.Append (Quote (Path.GetFullPath (asm.Location))).Append (" ");
 						mmp.Append ($"-a:{GetPlatformAssembly ()} ");
 						mmp.Append ($"--sdk {GetSdkVersion (build_info.Sdk.ToLower ())} ");
+						// FIXME: once merged add support for linking the platform (Xamarin.Mac.dll)
 						if (Platform == Platform.macOSModern) {
 							mmp.Append ("--linksdkonly ");
 							mmp.Append ($"--xml={Quote (Path.Combine (OutputDirectory, "bindings.xml"))} ");
+						} else {
+							// mmp default is to link everything
+							mmp.Append ("--nolink ");
 						}
-						// FIXME: once merge add support for linking the platform (Xamarin.Mac.dll)
 						mmp.Append ("--registrar:static ");
 						mmp.Append ($"--cache {Quote (cachedir)} ");
 						if (Debug)

--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -753,9 +753,6 @@ namespace Embeddinator {
 						mtouch.Append ("--dsym:false ");
 						mtouch.Append ("--msym:false ");
 						mtouch.Append ($"--embeddinator ");
-						// FIXME: we need to generate this XML file, issue #301
-						// https://github.com/mono/Embeddinator-4000/issues/301
-						mtouch.Append ($"--xml={Quote (Path.Combine (OutputDirectory, "linker.xml"))} ");
 						foreach (var asm in Assemblies)
 							mtouch.Append (Quote (Path.GetFullPath (asm.Location))).Append (" ");
 						mtouch.Append ($"-r:{GetPlatformAssembly ()} ");

--- a/objcgen/objcgen.csproj
+++ b/objcgen/objcgen.csproj
@@ -365,10 +365,6 @@
       <Link>support\objc-support.m</Link>
       <LogicalName>objc-support.m</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\support\linker.xml">
-      <Link>support\linker.xml</Link>
-      <LogicalName>linker.xml</LogicalName>
-    </EmbeddedResource>
     <EmbeddedResource Include="Make.config">
       <LogicalName>Make.config</LogicalName>
     </EmbeddedResource>

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -77,9 +77,12 @@ namespace Embeddinator {
 		public bool HasMethods => Methods != null && Methods.Count > 0;
 		public bool HasProperties => Properties != null && Properties.Count > 0;
 
-		public bool IsClass => !IsEnum && !IsProtocol;
-		public bool IsEnum => Type.IsEnum;
-		public bool IsProtocol => Type.IsInterface;
+		public bool IsClass => !IsEnum && !IsProtocol && !IsNativeReference;
+		public bool IsEnum => Type.IsEnum && !IsNativeReference;
+		public bool IsProtocol => Type.IsInterface && !IsNativeReference;
+
+		// we can track types that we don't need/want to generate (e.g. linker requirements)
+		public bool IsNativeReference { get; set; }
 
 		public bool UserCode => Assembly.UserCode;
 

--- a/support/linker.xml
+++ b/support/linker.xml
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<linker>
-	<assembly fullname="mscorlib">
-		<type fullname="System.Decimal">
-			<method signature="System.String ToString(System.IFormatProvider)" />
-			<method signature="System.Decimal Parse(System.String,System.IFormatProvider)" />
-		</type>
-	</assembly>
-</linker>

--- a/tests/managed/types.cs
+++ b/tests/managed/types.cs
@@ -103,3 +103,10 @@ public static class Type_Decimal {
 	public static void GetRefPi (ref decimal dec) => dec = Pi;
 	public static decimal [] GetDecimalArr (decimal [] dec) => dec;
 }
+
+public class ExposeExtraTypes {
+
+	public TimeSpan TimeOfDay {
+		get { return DateTime.Now.TimeOfDay; }
+	}
+}

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -1228,6 +1228,18 @@
 	XCTAssertEqualObjects (@"1", [interNullArr2[2] convertLongValue:1ll], "interNullArr2[2] 1");
 }
 
+- (void)testTimeSpan {
+	// because we have an API that expose TimeSpan we generate the type from mscorlib.dll (because NSTimeInterval is not a very good alternative)
+	System_TimeSpan *ts = [[System_TimeSpan alloc] initWithDays:1 hours:2 minutes:3 seconds:4 milliseconds:5];
+	XCTAssertTrue ([ts days] == 1, "days");
+	XCTAssertTrue ([ts hours] == 2, "hours");
+	XCTAssertTrue ([ts minutes] == 3, "minutes");
+	XCTAssertTrue ([ts seconds] == 4, "seconds");
+	XCTAssertTrue ([ts milliseconds] == 5, "milliseconds");
+
+	XCTAssertTrue ([ts ticks] == 937840050000ll, "ticks");
+}
+
 - (void)testIFormatProvider {
 	id<System_IFormatProvider> enUS = [Interfaces_ExposeIFormatProvider getCultureName:@"en-US"];
 	XCTAssertNotNil (enUS, "en-US");
@@ -1238,6 +1250,12 @@
 	XCTAssertNotNil (frCA, "fr-CA");
 	NSString *s2 = [Interfaces_ExposeIFormatProvider formatValue:1.2 provider:frCA];
 	XCTAssertEqualObjects (@"1,2", s2, "1,2");
+
+	System_TimeSpan *ts = [[System_TimeSpan alloc] initWithTicks:937840050000ll];
+	NSString *s3 = [ts toStringFormat:@"c" formatProvider:nil];
+	NSString *s4 = [ts toStringFormat:@"c"];
+	XCTAssertEqualObjects (s3, @"1.02:03:04.0050000", "toStringFormat");
+	XCTAssertEqualObjects (s3, s4, "toStringFormat:formatprovider");
 }
 
 #pragma clang diagnostic pop


### PR DESCRIPTION
This replace the older (not linker friendly) PR #251.

It brings, if required, `System.TimeSpan` inside your projects since
there is direct, good alternative, i.e. `NSTimeInterval` is just a
typedef on `double`.