### PR TITLE
[objc] Add `--nowarn:` and `--warnaserror:` options to the driver

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -88,6 +88,10 @@ The dependency mentioned in the error message was found on the system, but it's 
 
 Could not create the symlink mentioned in the error message.
 
+<h3><a name="EM0026"/>EM0026 Could not parse the command line argument 'A': *</h3>
+
+The syntax given for the command line option `A` could not be parsed by the tool. It is likely incorrect, please check with the documentation or help for the correct syntax.
+
 <h3><a name="EM0099"/>EM0099: Internal error *. Please file a bug report with a test case (https://github.com/mono/Embeddinator-4000/issues).</h3>
 
 This error message is reported when an internal consistency check in the Embeddinator-4000 fails.

--- a/docs/releases/Embeddinator-4000_0.2.md
+++ b/docs/releases/Embeddinator-4000_0.2.md
@@ -51,6 +51,11 @@ tvOS Support
 
 * [pr329](https://github.com/mono/Embeddinator-4000/pull/329) - Support for tvOS is now available. It requires Xamarin.iOS to be installed;
 
+Other New Features
+------------------
+
+* [xxx]() - [driver] The command line tool now support `nowarn:` to reduce the number of warnings (e.g. when binding an assembly that cannot be modified);
+* [xxx]() - [driver] The command line tool now support `warnaserror:` to ensure some warnings cannot be overlooked;
 
 Known Issues
 ============

--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -82,6 +82,30 @@ namespace Embeddinator {
 				{ "v|verbose", "generates diagnostic verbose output", v => ErrorHelper.Verbosity++ },
 				{ "version", "Display the version information.", v => action = Action.Version },
 				{ "target=", "The compilation target (staticlibrary, sharedlibrary, framework).", embedder.SetCompilationTarget },
+				{ "warnaserror:", "An optional comma-separated list of warning codes that should be reported as errors (if no warnings are specified all warnings are reported as errors).", v => {
+					try {
+						if (!string.IsNullOrEmpty (v)) {
+							foreach (var code in v.Split (new char [] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+								ErrorHelper.SetWarningLevel (ErrorHelper.WarningLevel.Error, int.Parse (code));
+						} else {
+							ErrorHelper.SetWarningLevel (ErrorHelper.WarningLevel.Error);
+						}
+					} catch (Exception ex) {
+						ErrorHelper.Error (26, ex, "Could not parse the command line argument '{0}': {1}", "--warnaserror", ex.Message);
+					}
+				}},
+				{ "nowarn:", "An optional comma-separated list of warning codes to ignore (if no warnings are specified all warnings are ignored).", v => {
+					try {
+						if (!string.IsNullOrEmpty (v)) {
+							foreach (var code in v.Split (new char [] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+								ErrorHelper.SetWarningLevel (ErrorHelper.WarningLevel.Disable, int.Parse (code));
+						} else {
+							ErrorHelper.SetWarningLevel (ErrorHelper.WarningLevel.Disable);
+						}
+					} catch (Exception ex) {
+						ErrorHelper.Error (26, ex, "Could not parse the command line argument '{0}': {1}", "--nowarn", ex.Message);
+					}
+				}},
 			};
 
 			var assemblies = os.Parse (args);

--- a/samples/UnitsNet/Makefile
+++ b/samples/UnitsNet/Makefile
@@ -14,7 +14,7 @@ UNITSNET_VERSION=3.58.0
 
 unitsnet: $(OBJC_GEN)
 	nuget install UnitsNet -Version $(UNITSNET_VERSION)
-	$(MONO) $(OBJC_GEN) UnitsNet.$(UNITSNET_VERSION)/lib/netstandard1.0/UnitsNet.dll -debug -o Debug -c
+	$(MONO) $(OBJC_GEN) UnitsNet.$(UNITSNET_VERSION)/lib/netstandard1.0/UnitsNet.dll -debug -o Debug -c -nowarn:1032,1033,1034
 
 clean:
 	rm -rf UnitsNet.*/ Debug/ *.h *.c *.m

--- a/tests/objcgentest/ObjCGenErrWarnTests.cs
+++ b/tests/objcgentest/ObjCGenErrWarnTests.cs
@@ -25,9 +25,36 @@ namespace ObjCGenErrWarnTests {
 			// true: Does.Contain | false: Does.Not.Contain
 			arg2: new [] {
 				true,
-			}
+			},
+			// additional argument
+			arg3: ""
 		)]
-		public void GenWarningTest (string [] warnsToSearch, bool [] shouldFindWarn)
+		[TestCase (
+			// Warning message to [not] look for.
+			arg1: new [] {
+				"warning EM1011: Type `System.Type` is not generated because it lacks a native counterpart.",
+			},
+			// true: Does.Contain | false: Does.Not.Contain
+			arg2: new [] {
+				false,
+			},
+			// additional argument
+			arg3: "--nowarn:1011"
+		)]
+		// blocked by https://bugzilla.xamarin.com/show_bug.cgi?id=55801
+		//[TestCase (
+		//	// Warning message to [not] look for.
+		//	arg1: new [] {
+		//		"error EM1011: Type `System.Type` is not generated because it lacks a native counterpart.",
+		//	},
+		//	// true: Does.Contain | false: Does.Not.Contain
+		//	arg2: new [] {
+		//		false,
+		//	},
+		//	// additional argument
+		//	arg3: "--warnaserror:1011"
+		//)]
+		public void GenWarningTest (string [] warnsToSearch, bool [] shouldFindWarn, string argument)
 		{
 			Assert.That (warnsToSearch.Length, Is.EqualTo (shouldFindWarn.Length), $"{nameof (warnsToSearch)} array length must match {nameof (shouldFindWarn)}'s");
 			string tmpDir = Xamarin.Cache.CreateTemporaryDirectory ();
@@ -43,7 +70,15 @@ namespace ObjCGenErrWarnTests {
 					Console.SetOut (sw);
 					Console.SetError (sw);
 
-					Driver.Main2 (new string [] { $"-o={tmpDir}", "-c", warnerrAssembly.Location });
+					try {
+						var args = new List<string> { $"-o={tmpDir}", "-c", warnerrAssembly.Location };
+						if (!String.IsNullOrWhiteSpace (argument))
+							args.Add (argument);
+					    Driver.Main2 (args.ToArray ());
+					}
+					catch (Exception) {
+						throw;
+					}
 					sw.Flush ();
 					ms.Position = 0;
 					var sr = new StreamReader (ms);


### PR DESCRIPTION
Code was already present (copied from mtouch/mmp with ErrorHelper.cs) so
it's an easy and useful thing to expose.

Use `--nowarn` on UnitsNet sample to reduce the warnings that we cannot
fix (since we're using a binary downloaded from nuget)

Add unit tests for `--nowarn`. The one for `--warnaserror` did not work,
at least inside VSfM, due to bug #55801, resulting in:

> mono_os_mutex_lock: pthread_mutex_lock failed with "Invalid argument" (22)