### PR TITLE
More cleanup and improvements enabled by signature move

### DIFF
--- a/objcgen/objcgenerator-postprocessor.cs
+++ b/objcgen/objcgenerator-postprocessor.cs
@@ -32,7 +32,6 @@ namespace ObjC {
 
 				ProcessPotentialNameOverride (processedMethod);
 
-				processedMethod.ComputeSignatures ();
 				yield return processedMethod;
 			}
 		}
@@ -86,7 +85,6 @@ namespace ObjC {
 				if (duplicateNames.Contains (CreateStringRep(constructor)))
 					processedConstructor.FallBackToTypeName = true;
 
-				processedConstructor.ComputeSignatures ();
 				yield return processedConstructor;
 			}
 		}

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -980,7 +980,7 @@ namespace ObjC {
 			return objcsig;
 		}
 
-		void GenerateDefaultValuesWrapper (ProcessedMemberBase member)
+		void GenerateDefaultValuesWrapper (ProcessedMemberWithParameters member)
 		{
 			ProcessedMethod method = member as ProcessedMethod;
 			ProcessedConstructor ctor = member as ProcessedConstructor;
@@ -989,19 +989,17 @@ namespace ObjC {
 
 			MethodBase mb = method != null ? (MethodBase)method.Method : ctor.Constructor;
 			MethodInfo mi = mb as MethodInfo;
-			int firstDefaultParameter = method != null ? method.FirstDefaultParameter : ctor.FirstDefaultParameter;
-			var parameters = method != null ? method.Parameters : ctor.Parameters;
 
 			var plist = new List<ParameterInfo> ();
 			StringBuilder arguments = new StringBuilder ();
 			headers.WriteLine ("/** This is an helper method that inlines the following default values:");
-			foreach (var p in parameters) {
-				string pName = NameGenerator.GetExtendedParameterName (p, parameters);
+			foreach (var p in member.Parameters) {
+				string pName = NameGenerator.GetExtendedParameterName (p, member.Parameters);
 				if (arguments.Length == 0) {
 					arguments.Append (p.Name.PascalCase ()).Append (':');
 				} else
 					arguments.Append (' ').Append (p.Name.CamelCase ()).Append (':');
-				if (p.Position >= firstDefaultParameter && p.HasDefaultValue) {
+				if (p.Position >= member.FirstDefaultParameter && p.HasDefaultValue) {
 					var raw = FormatRawValue (p.ParameterType, p.RawDefaultValue);
 					headers.WriteLine ($" *     ({NameGenerator.GetTypeName (p.ParameterType)}) {pName} = {raw};");
 					arguments.Append (raw);

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -988,7 +988,7 @@ namespace ObjC {
 
 			MethodBase mb = method != null ? (MethodBase)method.Method : ctor.Constructor;
 			MethodInfo mi = mb as MethodInfo;
-
+			int firstDefaultParameter = method != null ? method.FirstDefaultParameter : ctor.FirstDefaultParameter;
 			var parameters = method != null ? method.Parameters : ctor.Parameters;
 
 			var plist = new List<ParameterInfo> ();
@@ -1000,7 +1000,7 @@ namespace ObjC {
 					arguments.Append (p.Name.PascalCase ()).Append (':');
 				} else
 					arguments.Append (' ').Append (p.Name.CamelCase ()).Append (':');
-				if (p.Position >= member.FirstDefaultParameter && p.HasDefaultValue) {
+				if (p.Position >= firstDefaultParameter && p.HasDefaultValue) {
 					var raw = FormatRawValue (p.ParameterType, p.RawDefaultValue);
 					headers.WriteLine ($" *     ({NameGenerator.GetTypeName (p.ParameterType)}) {pName} = {raw};");
 					arguments.Append (raw);

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -302,11 +302,11 @@ namespace ObjC {
 			var default_init = false;
 			if (type.HasConstructors) {
 				foreach (var ctor in type.Constructors) {
-					var pcount = ctor.Constructor.ParameterCount;
+					var pcount = ctor.Parameters.Length;
 					default_init |= pcount == 0;
 
-					var parameters = ctor.Constructor.GetParameters ();
-					string name = "init";
+					var parameters = ctor.Parameters;
+					string name = ctor.ObjCName;
 					string signature = ".ctor()";
 					if (parameters.Length > 0) {
 						name = ctor.GetObjcSignature ();
@@ -939,14 +939,8 @@ namespace ObjC {
 		{
 			var type = info.DeclaringType;
 			var managed_type_name = NameGenerator.GetObjCName (type);
-
-			string objcsig;
-			string monosig;
-			var managed_name = info.Name;
-			var parametersInfo = info.GetParameters ();
-
-			objcsig = method.GetObjcSignature (name, isExtension);
-			monosig = method.GetMonoSignature (managed_name);
+			string objcsig = method.GetObjcSignature (name, isExtension);
+			string monosig = method.GetMonoSignature (info.Name);
 
 			var builder = new MethodHelper (headers, implementation) {
 				AssemblySafeName = type.Assembly.GetName ().Name.Sanitize (),
@@ -968,6 +962,7 @@ namespace ObjC {
 			builder.BeginImplementation ();
 			builder.WriteMethodLookup ();
 
+			var parametersInfo = method.Parameters;
 			string postInvoke = String.Empty;
 			var args = "nil";
 			if (parametersInfo.Length > 0) {
@@ -993,9 +988,8 @@ namespace ObjC {
 
 			MethodBase mb = method != null ? (MethodBase)method.Method : ctor.Constructor;
 			MethodInfo mi = mb as MethodInfo;
-			string objcsig;
-			string monosig;
-			var parameters = method != null ? method.Method.GetParameters () : ctor.Constructor.GetParameters ();
+
+			var parameters = method != null ? method.Parameters : ctor.Parameters;
 
 			var plist = new List<ParameterInfo> ();
 			StringBuilder arguments = new StringBuilder ();
@@ -1016,14 +1010,9 @@ namespace ObjC {
 				}
 			}
 
-			string name;
-			if (method == null)
-				name = member.FirstDefaultParameter == 0 ? "init" : "initWith";
-			else
-				name = method.BaseName;
-
-			objcsig = method != null ? method.GetObjcSignature () : ctor.GetObjcSignature ();
-			monosig = method != null ? method.GetMonoSignature () : ctor.GetMonoSignature ();
+			string name = method != null ? method.BaseName : ctor.ObjCName;
+			string objcsig = method != null ? method.GetObjcSignature () : ctor.GetObjcSignature ();
+			string monosig = method != null ? method.GetMonoSignature () : ctor.GetMonoSignature ();
 
 			var type = mb.DeclaringType;
 

--- a/objcgen/objcprocessor.cs
+++ b/objcgen/objcprocessor.cs
@@ -432,9 +432,9 @@ namespace ObjC {
 
 			var finalList = new List<ProcessedConstructor> ();
 			foreach (var pctor in parentCtors) {
-				var pctorParams = pctor.Constructor.GetParameters ();
+				var pctorParams = pctor.Parameters;
 				foreach (var ctor in typeCtors) {
-					var ctorParams = ctor.Constructor.GetParameters ();
+					var ctorParams = ctor.Parameters;
 					if (pctorParams.Any (pc => !ctorParams.Any (p => p.Position == pc.Position && pc.ParameterType == p.ParameterType))) {
 						finalList.Add (pctor);
 						break;

--- a/objcgen/objcprocessor.cs
+++ b/objcgen/objcprocessor.cs
@@ -456,7 +456,6 @@ namespace ObjC {
 					ConstructorType = ConstructorType.DefaultValueWrapper,
 					FirstDefaultParameter = i,
 				};
-				pc.ComputeSignatures ();
 				yield return pc;
 			}
 		}
@@ -472,7 +471,6 @@ namespace ObjC {
 					MethodType = MethodType.DefaultValueWrapper,
 					FirstDefaultParameter = i,
 				};
-				pm.ComputeSignatures ();
 				yield return pm;
 			}
 		}

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -115,7 +115,6 @@ namespace Embeddinator {
 		protected Processor Processor;
 
 		public bool FallBackToTypeName { get; set; }
-		public int FirstDefaultParameter { get; set; }
 
 		public string ObjCSignature { get; set; }
 		public string MonoSignature { get; set; }
@@ -123,7 +122,6 @@ namespace Embeddinator {
 		public ProcessedMemberBase (Processor processor)
 		{
 			Processor = processor;
-			FirstDefaultParameter = -1;
 		}
 
 		// this format can be consumed by the linker xml files
@@ -160,6 +158,17 @@ namespace Embeddinator {
 		public string NameOverride { get; set; }
 		public ParameterInfo[] Parameters { get; private set; }
 
+		int firstDefaultParameter;
+		public int FirstDefaultParameter {
+			get {
+				return firstDefaultParameter;
+			}
+			set {
+				firstDefaultParameter = value;
+				ComputeSignatures ();
+			}
+		}
+
 		public string BaseName {
 			get {
 				if (NameOverride != null)
@@ -175,9 +184,10 @@ namespace Embeddinator {
 			Method = method;
 			MethodType = MethodType.Normal;
 			Parameters = method.GetParameters ();
+			FirstDefaultParameter = -1;
 		}
 
-		public void ComputeSignatures ()
+		void ComputeSignatures ()
 		{
 			// FIXME this is a quite crude hack waiting for a correct move of the signature code
 			ObjCSignature = GetObjcSignature ();
@@ -276,6 +286,20 @@ namespace Embeddinator {
 	public class ProcessedConstructor : ProcessedMemberBase {
 		public ConstructorInfo Constructor { get; private set; }
 
+		int firstDefaultParameter;
+		public int FirstDefaultParameter
+		{
+			get
+			{
+				return firstDefaultParameter;
+			}
+			set
+			{
+				firstDefaultParameter = value;
+				ComputeSignatures ();
+			}
+		}
+
 		public bool Unavailable { get; set; }
 		public string ObjCName
 		{
@@ -293,9 +317,10 @@ namespace Embeddinator {
 		{
 			Constructor = constructor;
 			Parameters = Constructor.GetParameters ();
+			FirstDefaultParameter = -1;
 		}
 
-		public void ComputeSignatures ()
+		void ComputeSignatures ()
 		{
 			// FIXME this is a quite crude hack waiting for a correct move of the signature code
 			ObjCSignature = GetObjcSignature ();

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -93,7 +93,7 @@ namespace Embeddinator {
 			ObjCName = ObjC.NameGenerator.GetObjCName (Type);
 		}
 
-		public bool SignatureExists (ProcessedMemberWithParams p)
+		public bool SignatureExists (ProcessedMemberWithParameters p)
 		{
 			foreach (var pc in Constructors) {
 				if (p.ObjCSignature == pc.ObjCSignature)
@@ -148,8 +148,8 @@ namespace Embeddinator {
 		DefaultValueWrapper,
 	}
 
-	public abstract class ProcessedMemberWithParams : ProcessedMemberBase {
-		public ProcessedMemberWithParams (Processor processor) : base (processor)
+	public abstract class ProcessedMemberWithParameters : ProcessedMemberBase {
+		public ProcessedMemberWithParameters (Processor processor) : base (processor)
 		{
 		}
 
@@ -162,19 +162,17 @@ namespace Embeddinator {
 		int firstDefaultParameter;
 		public int FirstDefaultParameter
 		{
-			get
-			{
+			get {
 				return firstDefaultParameter;
 			}
-			set
-			{
+			set {
 				firstDefaultParameter = value;
 				ComputeSignatures ();
 			}
 		}
 	}
 
-	public class ProcessedMethod : ProcessedMemberWithParams {
+	public class ProcessedMethod : ProcessedMemberWithParameters {
 		public MethodInfo Method { get; private set; }
 		public bool IsOperator { get; set; }
 		public string NameOverride { get; set; }
@@ -291,7 +289,7 @@ namespace Embeddinator {
 		DefaultValueWrapper,
 	}
 
-	public class ProcessedConstructor : ProcessedMemberWithParams {
+	public class ProcessedConstructor : ProcessedMemberWithParameters {
 		public ConstructorInfo Constructor { get; private set; }
 
 		public bool Unavailable { get; set; }

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -178,7 +178,6 @@ namespace Embeddinator {
 		public MethodInfo Method { get; private set; }
 		public bool IsOperator { get; set; }
 		public string NameOverride { get; set; }
-		public ParameterInfo[] Parameters { get; private set; }
 
 		public string BaseName {
 			get {
@@ -304,7 +303,6 @@ namespace Embeddinator {
 			}
 		}
 		public ConstructorType ConstructorType { get; set; }
-		public ParameterInfo[] Parameters { get; private set; }
 
 		public ProcessedConstructor (ConstructorInfo constructor, Processor processor) : base (processor)
 		{

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -93,7 +93,7 @@ namespace Embeddinator {
 			ObjCName = ObjC.NameGenerator.GetObjCName (Type);
 		}
 
-		public bool SignatureExists (ProcessedMemberBase p)
+		public bool SignatureExists (ProcessedMemberWithParams p)
 		{
 			foreach (var pc in Constructors) {
 				if (p.ObjCSignature == pc.ObjCSignature)
@@ -113,11 +113,7 @@ namespace Embeddinator {
 	public abstract class ProcessedMemberBase {
 
 		protected Processor Processor;
-
 		public bool FallBackToTypeName { get; set; }
-
-		public string ObjCSignature { get; set; }
-		public string MonoSignature { get; set; }
 
 		public ProcessedMemberBase (Processor processor)
 		{
@@ -152,22 +148,36 @@ namespace Embeddinator {
 		DefaultValueWrapper,
 	}
 
-	public class ProcessedMethod : ProcessedMemberBase {
-		public MethodInfo Method { get; private set; }
-		public bool IsOperator { get; set; }
-		public string NameOverride { get; set; }
-		public ParameterInfo[] Parameters { get; private set; }
+	public abstract class ProcessedMemberWithParams : ProcessedMemberBase {
+		public ProcessedMemberWithParams (Processor processor) : base (processor)
+		{
+		}
+
+		public ParameterInfo[] Parameters { get; protected set; }
+
+		public string ObjCSignature { get; set; }
+		public string MonoSignature { get; set; }
+		protected abstract void ComputeSignatures ();
 
 		int firstDefaultParameter;
-		public int FirstDefaultParameter {
-			get {
+		public int FirstDefaultParameter
+		{
+			get
+			{
 				return firstDefaultParameter;
 			}
-			set {
+			set
+			{
 				firstDefaultParameter = value;
 				ComputeSignatures ();
 			}
 		}
+	}
+
+	public class ProcessedMethod : ProcessedMemberWithParams {
+		public MethodInfo Method { get; private set; }
+		public bool IsOperator { get; set; }
+		public string NameOverride { get; set; }
 
 		public string BaseName {
 			get {
@@ -187,9 +197,8 @@ namespace Embeddinator {
 			FirstDefaultParameter = -1;
 		}
 
-		void ComputeSignatures ()
+		protected override void ComputeSignatures ()
 		{
-			// FIXME this is a quite crude hack waiting for a correct move of the signature code
 			ObjCSignature = GetObjcSignature ();
 			MonoSignature = GetMonoSignature ();
 		}
@@ -283,22 +292,8 @@ namespace Embeddinator {
 		DefaultValueWrapper,
 	}
 
-	public class ProcessedConstructor : ProcessedMemberBase {
+	public class ProcessedConstructor : ProcessedMemberWithParams {
 		public ConstructorInfo Constructor { get; private set; }
-
-		int firstDefaultParameter;
-		public int FirstDefaultParameter
-		{
-			get
-			{
-				return firstDefaultParameter;
-			}
-			set
-			{
-				firstDefaultParameter = value;
-				ComputeSignatures ();
-			}
-		}
 
 		public bool Unavailable { get; set; }
 		public string ObjCName
@@ -311,7 +306,6 @@ namespace Embeddinator {
 			}
 		}
 		public ConstructorType ConstructorType { get; set; }
-		public ParameterInfo[] Parameters { get; private set; }
 
 		public ProcessedConstructor (ConstructorInfo constructor, Processor processor) : base (processor)
 		{
@@ -320,9 +314,8 @@ namespace Embeddinator {
 			FirstDefaultParameter = -1;
 		}
 
-		void ComputeSignatures ()
+		protected override void ComputeSignatures ()
 		{
-			// FIXME this is a quite crude hack waiting for a correct move of the signature code
 			ObjCSignature = GetObjcSignature ();
 			MonoSignature = GetMonoSignature ();
 		}

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -160,8 +160,7 @@ namespace Embeddinator {
 		protected abstract void ComputeSignatures ();
 
 		int firstDefaultParameter;
-		public int FirstDefaultParameter
-		{
+		public int FirstDefaultParameter {
 			get {
 				return firstDefaultParameter;
 			}

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿using System;
+﻿﻿﻿﻿using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -126,8 +126,6 @@ namespace Embeddinator {
 			FirstDefaultParameter = -1;
 		}
 
-		public abstract void ComputeSignatures ();
-
 		// this format can be consumed by the linker xml files
 		// adapted from ikvm reflection and cecil source code
 		// FIXME: double check when we implement generics support
@@ -149,55 +147,6 @@ namespace Embeddinator {
 			sb.Append (')');
 			return sb.ToString();
 		}
-
-		// get a name that is safe to use from ObjC code
-
-		// HACK - This should take a ProcessedMemberBase and not much of this stuff - https://github.com/mono/Embeddinator-4000/issues/276
-		public void GetSignatures (string objName, string monoName, MemberInfo info, ParameterInfo[] parameters, bool isExtension, out string objcSignature, out string monoSignature)
-		{
-			// FIXME - GetSignatures likley should be specialized in subclasses
-			bool isOperator = (this is ProcessedMethod) ? ((ProcessedMethod)this).IsOperator : false;
-			var method = (info as MethodBase); // else it's a PropertyInfo
-											   // special case for setter-only - the underscore looks ugly
-			if ((method != null) && method.IsSpecialName)
-				objName = objName.Replace ("_", String.Empty);
-
-			var objc = new StringBuilder (objName);
-			var mono = new StringBuilder (monoName);
-
-			mono.Append ('(');
-
-			var end = FirstDefaultParameter == -1 ? parameters.Length : FirstDefaultParameter;
-			for (int n = 0; n < end; ++n) {
-				ParameterInfo p = parameters[n];
-
-				if (objc.Length > objName.Length) {
-					objc.Append (' ');
-					mono.Append (',');
-				}
-
-				string paramName = FallBackToTypeName ? NameGenerator.GetParameterTypeName (p.ParameterType) : p.Name;
-				if ((method != null) && (n > 0 || !isExtension)) {
-					if (n == 0) {
-						if (FallBackToTypeName || method.IsConstructor || (!method.IsSpecialName && !isOperator))
-							objc.Append (paramName.PascalCase ());
-					}
-					else
-						objc.Append (paramName.CamelCase ());
-				}
-
-				if (n > 0 || !isExtension) {
-					string ptname = NameGenerator.GetObjCParamTypeName (p, Processor.Types);
-					objc.Append (":(").Append (ptname).Append (")").Append (NameGenerator.GetExtendedParameterName (p, parameters));
-				}
-				mono.Append (NameGenerator.GetMonoName (p.ParameterType));
-			}
-
-			mono.Append (')');
-
-			objcSignature = objc.ToString ();
-			monoSignature = mono.ToString ();
-		}
 	}
 
 	public enum MethodType {
@@ -209,6 +158,7 @@ namespace Embeddinator {
 		public MethodInfo Method { get; private set; }
 		public bool IsOperator { get; set; }
 		public string NameOverride { get; set; }
+		public ParameterInfo[] Parameters { get; private set; }
 
 		public string BaseName {
 			get {
@@ -224,19 +174,73 @@ namespace Embeddinator {
 		{
 			Method = method;
 			MethodType = MethodType.Normal;
+			Parameters = method.GetParameters ();
 		}
 
-		public override void ComputeSignatures ()
+		public void ComputeSignatures ()
 		{
 			// FIXME this is a quite crude hack waiting for a correct move of the signature code
-			string objcsig;
-			string monosig;
-			GetSignatures (BaseName, Method.Name, Method, Method.GetParameters (), false, out objcsig, out monosig);
-			ObjCSignature = objcsig;
-			MonoSignature = monosig;
+			ObjCSignature = GetObjcSignature ();
+			MonoSignature = GetMonoSignature ();
 		}
 
 		public override string ToString () => ToString (Method);
+
+		public string GetMonoSignature (string name = null)
+		{
+			if (name == null)
+				name = BaseName;
+
+			var mono = new StringBuilder (name);
+
+			mono.Append ('(');
+
+			var end = FirstDefaultParameter == -1 ? Parameters.Length : FirstDefaultParameter;
+			for (int n = 0; n < end; ++n) {
+				if (n > 0)
+					mono.Append (',');
+				mono.Append (NameGenerator.GetMonoName (Parameters[n].ParameterType));
+			}
+
+			mono.Append (')');
+
+			return mono.ToString ();
+		}
+
+		public string GetObjcSignature (string objName = null, bool isExtension = false)
+		{
+			if (objName == null)
+				objName = BaseName;
+			if (Method.IsSpecialName)
+				objName = objName.Replace ("_", String.Empty);
+
+			var objc = new StringBuilder (objName);
+
+			var end = FirstDefaultParameter == -1 ? Parameters.Length : FirstDefaultParameter;
+			for (int n = 0; n < end; ++n) {
+				ParameterInfo p = Parameters[n];
+
+				if (objc.Length > objName.Length)
+					objc.Append (' ');
+
+				string paramName = FallBackToTypeName ? NameGenerator.GetParameterTypeName (p.ParameterType) : p.Name;
+				if (n > 0 || !isExtension) {
+					if (n == 0) {
+						if (FallBackToTypeName || Method.IsConstructor || (!Method.IsSpecialName && !IsOperator))
+							objc.Append (paramName.PascalCase ());
+					}
+					else
+						objc.Append (paramName.CamelCase ());
+				}
+
+				if (n > 0 || !isExtension) {
+					string ptname = NameGenerator.GetObjCParamTypeName (p, Processor.Types);
+					objc.Append (":(").Append (ptname).Append (")").Append (NameGenerator.GetExtendedParameterName (p, Parameters));
+				}
+			}
+
+			return objc.ToString ();
+		}
 	}
 
 	public class ProcessedProperty: ProcessedMemberBase {
@@ -253,11 +257,6 @@ namespace Embeddinator {
 			var s = Property.GetSetMethod ();
 			if (s != null)
 				SetMethod = new ProcessedMethod (s, Processor);
-		}
-
-		public override void ComputeSignatures ()
-		{
-			throw new NotImplementedException ();
 		}
 
 		public override string ToString () => Property.ToString ();
@@ -278,25 +277,74 @@ namespace Embeddinator {
 		public ConstructorInfo Constructor { get; private set; }
 
 		public bool Unavailable { get; set; }
-
+		public string ObjCName
+		{
+			get
+			{
+				if (Parameters.Length == 0 || FirstDefaultParameter == 0)
+					return "init";
+				return "initWith";
+			}
+		}
 		public ConstructorType ConstructorType { get; set; }
+		public ParameterInfo[] Parameters { get; private set; }
 
 		public ProcessedConstructor (ConstructorInfo constructor, Processor processor) : base (processor)
 		{
 			Constructor = constructor;
+			Parameters = Constructor.GetParameters ();
 		}
 
-		public override void ComputeSignatures ()
+		public void ComputeSignatures ()
 		{
 			// FIXME this is a quite crude hack waiting for a correct move of the signature code
-			string objcsig;
-			string monosig;
-			GetSignatures (Constructor.ParameterCount == 0 ? "init" : "initWith", Constructor.Name, Constructor, Constructor.GetParameters (), false, out objcsig, out monosig);
-			ObjCSignature = objcsig;
-			MonoSignature = monosig;
+			ObjCSignature = GetObjcSignature ();
+			MonoSignature = GetMonoSignature ();
 		}
 
 		public override string ToString () => ToString (Constructor);
+
+		public string GetMonoSignature ()
+		{
+			var mono = new StringBuilder (Constructor.Name);
+
+			mono.Append ('(');
+
+			var end = FirstDefaultParameter == -1 ? Parameters.Length : FirstDefaultParameter;
+			for (int n = 0; n < end; ++n) {
+				if (n > 0)
+					mono.Append (',');
+				mono.Append (NameGenerator.GetMonoName (Parameters[n].ParameterType));
+			}
+
+			mono.Append (')');
+
+			return mono.ToString ();
+		}
+
+		public string GetObjcSignature ()
+		{
+			var objc = new StringBuilder (ObjCName);
+
+			var end = FirstDefaultParameter == -1 ? Parameters.Length : FirstDefaultParameter;
+			for (int n = 0; n < end; ++n) {
+				ParameterInfo p = Parameters[n];
+
+				if (objc.Length > ObjCName.Length)
+					objc.Append (' ');
+
+				string paramName = FallBackToTypeName ? NameGenerator.GetParameterTypeName (p.ParameterType) : p.Name;
+				if (n == 0)
+					objc.Append (paramName.PascalCase ());
+				else
+					objc.Append (paramName.CamelCase ());
+
+				string ptname = NameGenerator.GetObjCParamTypeName (p, Processor.Types);
+				objc.Append (":(").Append (ptname).Append (")").Append (NameGenerator.GetExtendedParameterName (p, Parameters));
+			}
+
+			return objc.ToString ();
+		}
 	}
 
 	public class ProcessedFieldInfo : ProcessedMemberBase {
@@ -309,11 +357,6 @@ namespace Embeddinator {
 			Field = field;
 			TypeName = ObjC.NameGenerator.GetTypeName (Field.DeclaringType);
 			ObjCName = ObjC.NameGenerator.GetObjCName (Field.DeclaringType);
-		}
-
-		public override void ComputeSignatures ()
-		{
-			throw new NotImplementedException ();
 		}
 
 		// linker compatible signature


### PR DESCRIPTION
- Make ComputeSignatures an internal idea, triggered by property changes that invalidate signature