### PR TITLE
[objc] Move `hash` support to the processor

### DIFF
--- a/objcgen/HashHelper.cs
+++ b/objcgen/HashHelper.cs
@@ -5,8 +5,12 @@ using Embeddinator;
 
 namespace ObjC {
 	public class HashHelper : MethodHelper {
-		public HashHelper (SourceWriter headers, SourceWriter implementation) : base (headers, implementation)
+		public HashHelper (ProcessedMethod method, SourceWriter headers, SourceWriter implementation) : base (headers, implementation)
 		{
+			AssemblySafeName = method.DeclaringType.Assembly.SafeName;
+			MetadataToken = method.Method.MetadataToken;
+			ObjCTypeName = method.DeclaringType.ObjCName;
+			ManagedTypeName = method.DeclaringType.TypeName;
 			MonoSignature = "GetHashCode()";
 			ObjCSignature = "hash";
 			ReturnType = "NSUInteger";

--- a/objcgen/generator.cs
+++ b/objcgen/generator.cs
@@ -24,7 +24,6 @@ namespace Embeddinator {
 			icomparable = op.icomparable;
 			iequatable = op.iequatable;
 			equals = op.equals;
-			hashes = op.hashes;
 
 			foreach (var a in Processor.Assemblies) {
 				Generate (a);
@@ -113,6 +112,5 @@ namespace Embeddinator {
 		public Dictionary<Type, MethodInfo> icomparable { get; private set; }
 		public Dictionary<Type, MethodInfo> iequatable { get; private set; }
 		public Dictionary<Type, MethodInfo> equals { get; private set; }
-		public Dictionary<Type, MethodInfo> hashes { get; private set; }
 	}
 }

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -482,18 +482,6 @@ namespace ObjC {
 				builder.WriteImplementation ();
 			}
 
-			if (hashes.TryGetValue (t, out m)) {
-				var builder = new HashHelper (headers, implementation) {
-					AssemblySafeName = aname,
-					MetadataToken = m.MetadataToken,
-					ObjCTypeName = managed_name,
-					ManagedTypeName = t.FullName,
-				};
-
-				builder.WriteHeaders ();
-				builder.WriteImplementation ();
-			}
-
 			tbuilder.EndHeaders ();
 			tbuilder.EndImplementation ();
 		}
@@ -1047,6 +1035,11 @@ namespace ObjC {
 			switch (method.MethodType) {
 			case MethodType.DefaultValueWrapper:
 				GenerateDefaultValuesWrapper (method);
+				break;
+			case MethodType.NSObjectProcotolHash:
+				var builder = new HashHelper (method, headers, implementation);
+				builder.WriteHeaders ();
+				builder.WriteImplementation ();
 				break;
 			default:
 				ImplementMethod (method.Method, method.BaseName, method);

--- a/objcgen/operatoroverloads.cs
+++ b/objcgen/operatoroverloads.cs
@@ -85,13 +85,13 @@ namespace Embeddinator
 			}
 		}
 
-		public static IEnumerable <MethodInfo> FindOperatorPairToIgnore (IEnumerable<MethodInfo> methods, IEnumerable <MethodInfo> equals)
+		public static IEnumerable <MethodInfo> FindOperatorPairToIgnore (IEnumerable<ProcessedMethod> methods, IEnumerable <MethodInfo> equals)
 		{
 			var matches = new Dictionary<OperatorInfo, List<MethodInfo>> ();
 			foreach (var method in methods) {
 				OperatorInfo info;
-				if (OperatorMappingNames.TryGetValue (method.Name, out info) && method.ParameterCount == info.ArgumentCount)
-					matches.AddValue (info, method);			
+				if (OperatorMappingNames.TryGetValue (method.Method.Name, out info) && method.Method.ParameterCount == info.ArgumentCount)
+					matches.AddValue (info, method.Method);
 			}
 
 			foreach (var match in matches) {

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -146,6 +146,7 @@ namespace Embeddinator {
 	public enum MethodType {
 		Normal,
 		DefaultValueWrapper,
+		NSObjectProcotolHash,
 	}
 
 	public abstract class ProcessedMemberWithParameters : ProcessedMemberBase {
@@ -185,6 +186,7 @@ namespace Embeddinator {
 		}
 
 		public MethodType MethodType { get; set; }
+		public ProcessedType DeclaringType { get; set; }
 
 		public ProcessedMethod (MethodInfo method, Processor processor) : base (processor)
 		{


### PR DESCRIPTION
One of many cases to cover. The move helps in many ways, including
making sure the `hash` method addition is done before dupe names are
processed (e.g. a .net method/property could be named `Hash`)