### PR TITLE
Prototype of attribute based rename of bindings

### DIFF
--- a/objcgen/objcgenerator-postprocessor.cs
+++ b/objcgen/objcgenerator-postprocessor.cs
@@ -48,8 +48,7 @@ namespace ObjC {
 			string attributedName = FindBindingNameAttribute (method);
 			if (attributedName != null) {
 				processedMethod.NameOverride = attributedName;
-			}
-			else if (IsOperatorOrFriendlyVersion (method)) {
+			} else if (IsOperatorOrFriendlyVersion (method)) {
 				string nameOverride = OperatorOverloads.GetObjCName (processedMethod.Method.Name, processedMethod.Method.ParameterCount);
 				if (nameOverride != null)
 					processedMethod.NameOverride = nameOverride;
@@ -58,13 +57,14 @@ namespace ObjC {
 
 		private static string FindBindingNameAttribute (MemberInfo method)
 		{
-			CustomAttributeData bindingName = method.CustomAttributes.FirstOrDefault (x => x.AttributeType.Name == "BindingNameAttribute");
+			CustomAttributeData bindingName = method.CustomAttributes.FirstOrDefault (x => x.AttributeType.Name == "EmbeddinatorNameAttribute");
 			if (bindingName != null) {
 				PropertyInfo property = bindingName.AttributeType.GetProperty ("Name");
-				if (bindingName.ConstructorArguments.Count == 1) {
-					object attrValue = bindingName.ConstructorArguments[0].Value;
-					if (attrValue is string)
-						return (string)attrValue;
+				if (bindingName.ConstructorArguments.Count == 2) {
+					object nameValue = bindingName.ConstructorArguments[0].Value;
+					object languageValue = bindingName.ConstructorArguments[1].Value;
+					if (nameValue is string && languageValue is string && ((string)languageValue).Equals ("ObjC", StringComparison.OrdinalIgnoreCase))
+						return (string)nameValue;
 				}
 			}
 			return null;

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -753,33 +753,30 @@ namespace ObjC {
 
 		protected override void Generate (ProcessedProperty property)
 		{
-			PropertyInfo pi = property.Property;
-			var getter = pi.GetGetMethod ();
-			var setter = pi.GetSetMethod ();
+			var getter = property.GetMethod;
+			var setter = property.SetMethod;
 			// setter-only properties are handled as methods (and should not reach this code)
 			if (getter == null && setter != null)
 				throw new EmbeddinatorException (99, "Internal error `setter only`. Please file a bug report with a test case (https://github.com/mono/Embeddinator-4000/issues");
 
-			var name = pi.Name.CamelCase ();
-
 			headers.Write ("@property (nonatomic");
-			if (getter.IsStatic)
+			if (getter.Method.IsStatic)
 				headers.Write (", class");
 			if (setter == null)
 				headers.Write (", readonly");
-			var pt = pi.PropertyType;
+			var pt = property.Property.PropertyType;
 			var property_type = NameGenerator.GetTypeName (pt);
 			if (HasClass (pt))
 				property_type += " *";
 
 			var spacing = property_type [property_type.Length - 1] == '*' ? string.Empty : " ";
-			headers.WriteLine ($") {property_type}{spacing}{name};");
+			headers.WriteLine ($") {property_type}{spacing}{property.Name};");
 
-			ImplementMethod (getter, name, property.GetMethod, pi: pi);
+			ImplementMethod (getter.Method, property.GetterName, property.GetMethod, pi: property.Property);
 			if (setter == null)
 				return;
 
-			ImplementMethod (setter, "set" + pi.Name, property.SetMethod, pi: pi);
+			ImplementMethod (setter.Method, property.SetterName, property.SetMethod, pi: property.Property);
 		}
 
 		protected void Generate (ProcessedFieldInfo field)

--- a/objcgen/objcprocessor.cs
+++ b/objcgen/objcprocessor.cs
@@ -143,7 +143,7 @@ namespace ObjC {
 			}
 
 			switch (t.Name) {
-				case "BindingNameAttribute": // This is used to override naming during binding
+				case "EmbeddinatorNameAttribute": // This is used to override naming during binding
 					return false;
 			}
 

--- a/objcgen/objcprocessor.cs
+++ b/objcgen/objcprocessor.cs
@@ -142,6 +142,11 @@ namespace ObjC {
 				break;
 			}
 
+			switch (t.Name) {
+				case "BindingNameAttribute": // This is used to override naming during binding
+					return false;
+			}
+
 			var base_type = t.BaseType;
 			return (base_type == null) || base_type.Is ("System", "Object") ? true : IsSupported (base_type);
 		}

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -177,13 +177,21 @@ namespace Embeddinator {
 	public class ProcessedMethod : ProcessedMemberWithParameters {
 		public MethodInfo Method { get; private set; }
 		public bool IsOperator { get; set; }
-		public string NameOverride { get; set; }
+
+		string nameOverride;
+		public string NameOverride {
+			get { return nameOverride; }
+			set {
+				nameOverride = value;
+				ComputeSignatures ();
+			}
+		}
 
 		public string BaseName {
 			get {
 				if (NameOverride != null)
 					return NameOverride;
-				return IsOperator? Method.Name.Substring (3).CamelCase () : Method.Name.CamelCase ();
+				return IsOperator ? Method.Name.Substring (3).CamelCase () : Method.Name.CamelCase ();
 			}
 		}
 
@@ -280,8 +288,28 @@ namespace Embeddinator {
 
 		public override string ToString () => Property.ToString ();
 
+		public string Name => NameOverride != null ? NameOverride : Property.Name.CamelCase ();
+		public string NameOverride { get; set; }
+
 		public bool HasGetter => GetMethod != null;
 		public bool HasSetter => SetMethod != null;
+
+		public string GetterName {
+			get {
+				if (!HasGetter)
+					return null;
+				return NameOverride != null ? NameOverride : Property.Name.CamelCase ();
+			}
+		}
+
+		public string SetterName {
+			get {
+				if (!HasSetter)
+					return null;
+				return NameOverride != null ? NameOverride : "set" + Property.Name;
+			}
+		}
+
 		public ProcessedMethod GetMethod { get; private set; }
 		public ProcessedMethod SetMethod { get; private set; }
 	}

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -298,7 +298,7 @@ namespace Embeddinator {
 			get {
 				if (!HasGetter)
 					return null;
-				return NameOverride != null ? NameOverride : Property.Name.CamelCase ();
+				return (NameOverride ?? Property.Name).CamelCase ();
 			}
 		}
 
@@ -306,9 +306,10 @@ namespace Embeddinator {
 			get {
 				if (!HasSetter)
 					return null;
-				return NameOverride != null ? NameOverride : "set" + Property.Name;
+				return "set" + (NameOverride ?? Property.Name).PascalCase ();
 			}
 		}
+
 
 		public ProcessedMethod GetMethod { get; private set; }
 		public ProcessedMethod SetMethod { get; private set; }

--- a/tests/managed/managed-shared.projitems
+++ b/tests/managed/managed-shared.projitems
@@ -31,6 +31,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)overloads.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)nestedClasses.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)arrays.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)renamed.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)subscripts.tt">

--- a/tests/managed/renamed.cs
+++ b/tests/managed/renamed.cs
@@ -1,21 +1,23 @@
 ﻿using System;
 namespace Renamed
 {
-	public sealed class BindingNameAttribute : System.Attribute {
-	    public string Name;
+	public sealed class EmbeddinatorNameAttribute : System.Attribute {
+		public string Name;
+		public string Language;
 
-	    public BindingNameAttribute (string name)
-	    {
-		    Name = name;
-	    }
+		public EmbeddinatorNameAttribute (string name, string language = "ObjC")
+		{
+			Name = name;
+			Language = language;
+		}
 	}
 
 	public class WithItemsRenamed
 	{
-		[BindingName ("MyCustomClass")]
+		[EmbeddinatorName ("MyCustomClass")]
 		public bool Class { get; set; }
 		
-		[BindingName ("MyCustomHash")]
+		[EmbeddinatorName ("MyCustomHash")]
 		public int Hash () => 42;
 	}
 

--- a/tests/managed/renamed.cs
+++ b/tests/managed/renamed.cs
@@ -1,0 +1,22 @@
+﻿using System;
+namespace Renamed
+{
+	public sealed class BindingNameAttribute : System.Attribute {
+	    public string Name;
+
+	    public BindingNameAttribute (string name)
+	    {
+		    Name = name;
+	    }
+	}
+
+	public class WithItemsRenamed
+	{
+		[BindingName ("MyCustomClass")]
+		public bool Class { get; set; }
+		
+		[BindingName ("MyCustomHash")]
+		public int Hash () => 42;
+	}
+
+}

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -1313,6 +1313,12 @@
 	}
 }
 
+-(void)testRenamedViaAttributes {
+    Renamed_WithItemsRenamed * item = [[Renamed_WithItemsRenamed alloc] init];
+    XCTAssertEqual(42, [item MyCustomHash], "Renamed hash");
+    XCTAssertEqual(false, [item MyCustomClass], "Renamed class");
+}
+
 #pragma clang diagnostic pop
 
 @end


### PR DESCRIPTION
I've been kicking around the idea of using attributes looked up by name to control naming and the discussion here (https://github.com/mono/Embeddinator-4000/pull/363) made me curious how difficult it'd be.

It has these limitations:

- Only handle properties/methods right now, but should be trivial to extend.
- Requires declaring attribute and marking up your source assembly.

but it's rather compact/easy to implement.

Thoughts?