### PR TITLE
Refactor GetObjcSignature / GetMonoSignature to be private and always use cache

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -306,7 +306,7 @@ namespace ObjC {
 					default_init |= pcount == 0;
 
 					var parameters = ctor.Parameters;
-					string name = ctor.ObjCName;
+					string name = ctor.BaseName;
 					string signature = ".ctor()";
 					if (parameters.Length > 0) {
 						name = ctor.ObjCSignature;
@@ -902,7 +902,6 @@ namespace ObjC {
 			method.IsExtension = isExtension;
 
 			string objcsig = method.ObjCSignature;
-			string monosig = method.GetMonoSignature (info.Name);
 
 			var builder = new MethodHelper (headers, implementation) {
 				AssemblySafeName = type.Assembly.GetName ().Name.Sanitize (),
@@ -911,7 +910,7 @@ namespace ObjC {
 				ReturnType = GetReturnType (type, info.ReturnType),
 				ManagedTypeName = type.FullName,
 				MetadataToken = info.MetadataToken,
-				MonoSignature = monosig,
+				MonoSignature = method.MonoSignature,
 				ObjCSignature = objcsig,
 				ObjCTypeName = managed_type_name,
 				IsValueType = type.IsValueType,
@@ -970,9 +969,9 @@ namespace ObjC {
 				}
 			}
 
-			string name = method != null ? method.BaseName : ctor.ObjCName;
-			string objcsig = method != null ? method.ObjCSignature : ctor.ObjCSignature;
-			string monosig = method != null ? method.MonoSignature : ctor.MonoSignature;
+			string name = member.BaseName;
+			string objcsig = member.ObjCSignature;
+			string monosig = member.MonoSignature;
 
 			var type = mb.DeclaringType;
 

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -309,8 +309,8 @@ namespace ObjC {
 					string name = ctor.ObjCName;
 					string signature = ".ctor()";
 					if (parameters.Length > 0) {
-						name = ctor.GetObjcSignature ();
-						signature = ctor.GetMonoSignature ();
+						name = ctor.ObjCSignature;
+						signature = ctor.MonoSignature;
 					}
 
 					if (ctor.Unavailable) {
@@ -895,8 +895,13 @@ namespace ObjC {
 		{
 			var type = info.DeclaringType;
 			var managed_type_name = NameGenerator.GetObjCName (type);
+
+			if (method.NameOverride == null)
+				method.NameOverride = name;
 			
-			string objcsig = method.GetObjcSignature (name, isExtension);
+			method.IsExtension = isExtension;
+
+			string objcsig = method.ObjCSignature;
 			string monosig = method.GetMonoSignature (info.Name);
 
 			var builder = new MethodHelper (headers, implementation) {
@@ -966,8 +971,8 @@ namespace ObjC {
 			}
 
 			string name = method != null ? method.BaseName : ctor.ObjCName;
-			string objcsig = method != null ? method.GetObjcSignature () : ctor.GetObjcSignature ();
-			string monosig = method != null ? method.GetMonoSignature () : ctor.GetMonoSignature ();
+			string objcsig = method != null ? method.ObjCSignature : ctor.ObjCSignature;
+			string monosig = method != null ? method.MonoSignature : ctor.MonoSignature;
 
 			var type = mb.DeclaringType;
 

--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -971,7 +971,6 @@ namespace ObjC {
 
 			string name = member.BaseName;
 			string objcsig = member.ObjCSignature;
-			string monosig = member.MonoSignature;
 
 			var type = mb.DeclaringType;
 

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -245,9 +245,8 @@ namespace Embeddinator {
 		{
 			string objName = BaseName;
 
-			if (Method.IsSpecialName) {
+			if (Method.IsSpecialName)
 				objName = objName.Replace ("_", String.Empty);
-			}
 
 			var objc = new StringBuilder (objName);
 

--- a/objcgen/processedtypes.cs
+++ b/objcgen/processedtypes.cs
@@ -156,6 +156,8 @@ namespace Embeddinator {
 		{
 		}
 
+		public abstract string BaseName { get; }
+
 		public ParameterInfo[] Parameters { get; protected set; }
 
 		string objCSignature;
@@ -193,7 +195,7 @@ namespace Embeddinator {
 		public string NameOverride { get; set; }
 		public string ManagedName { get; set; }
 
-		public string BaseName {
+		public override string BaseName {
 			get {
 				if (NameOverride != null)
 					return NameOverride;
@@ -221,12 +223,9 @@ namespace Embeddinator {
 
 		public override string ToString () => ToString (Method);
 
-		public string GetMonoSignature (string name = null)
+		string GetMonoSignature ()
 		{
-			if (name == null)
-				name = BaseName;
-
-			var mono = new StringBuilder (name);
+			var mono = new StringBuilder (Method.Name);
 
 			mono.Append ('(');
 
@@ -312,7 +311,7 @@ namespace Embeddinator {
 		public ConstructorInfo Constructor { get; private set; }
 
 		public bool Unavailable { get; set; }
-		public string ObjCName {
+		public override string BaseName {
 			get {
 				if (Parameters.Length == 0 || FirstDefaultParameter == 0)
 					return "init";
@@ -336,7 +335,7 @@ namespace Embeddinator {
 
 		public override string ToString () => ToString (Constructor);
 
-		public string GetMonoSignature ()
+		string GetMonoSignature ()
 		{
 			var mono = new StringBuilder (Constructor.Name);
 
@@ -356,13 +355,13 @@ namespace Embeddinator {
 
 		string GetObjcSignature ()
 		{
-			var objc = new StringBuilder (ObjCName);
+			var objc = new StringBuilder (BaseName);
 
 			var end = FirstDefaultParameter == -1 ? Parameters.Length : FirstDefaultParameter;
 			for (int n = 0; n < end; ++n) {
 				ParameterInfo p = Parameters[n];
 
-				if (objc.Length > ObjCName.Length)
+				if (objc.Length > BaseName.Length)
 					objc.Append (' ');
 
 				string paramName = FallBackToTypeName ? NameGenerator.GetParameterTypeName (p.ParameterType) : p.Name;


### PR DESCRIPTION
- https://github.com/mono/Embeddinator-4000/issues/365
- Also move cache to not be generated until first use, not at construct time. This should cut down on the number of "stale" cached signatures.
- Modifying types after requesting signatures will currently give you stale data. No easy way beyond wiring all properties to invalidate or adding a manual invalidate.
- Clean up GenerateDefaultValuesWrapper to use more bits from central base type instead of null checking two copies.