### PR TITLE
Java - jar files are now usable within a Java project on MacOS

### DIFF
--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -401,9 +401,13 @@ namespace MonoEmbeddinator4000
                 File.Copy(output, Path.Combine(platformDir, libName), true);
 
                 //Copy .NET assemblies
+                var assembliesDir = Path.Combine(classesDir, "assemblies");
+                if (!Directory.Exists(assembliesDir))
+                    Directory.CreateDirectory(assembliesDir);
+
                 foreach (var assembly in Project.Assemblies)
                 {
-                    File.Copy(assembly, Path.Combine(classesDir, Path.GetFileName(assembly)), true);
+                    File.Copy(assembly, Path.Combine(assembliesDir, Path.GetFileName(assembly)), true);
                 }
             }
 

--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿﻿using System;
+﻿﻿﻿﻿﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -387,6 +387,25 @@ namespace MonoEmbeddinator4000
                 Path.Combine(Options.OutputDir, name + ".jar"),
                 $"-C {classesDir} ."
             };
+
+            // On desktop Java, we need a few more files included
+            if (Options.Compilation.Platform == TargetPlatform.MacOS)
+            {
+                //Copy native libs
+                var platformDir = Path.Combine(classesDir, "darwin");
+                if (!Directory.Exists(platformDir))
+                    Directory.CreateDirectory(platformDir);
+
+                var libName = $"lib{name}.dylib";
+                var output = Path.Combine(Options.OutputDir, libName);
+                File.Copy(output, Path.Combine(platformDir, libName), true);
+
+                //Copy .NET assemblies
+                foreach (var assembly in Project.Assemblies)
+                {
+                    File.Copy(assembly, Path.Combine(classesDir, Path.GetFileName(assembly)), true);
+                }
+            }
 
             var invocation = string.Join(" ", args);
             Invoke(jar, invocation);

--- a/support/java/Runtime.java
+++ b/support/java/Runtime.java
@@ -104,9 +104,10 @@ public final class Runtime {
         File assemblyFile = new File(assemblyPath + ".dll");
 
         if (!assemblyFile.exists()) {
-            InputStream stream = Runtime.class.getResourceAsStream("/" + library + ".dll");
+            String resourcePath = "/assemblies/" + library + ".dll";
+            InputStream stream = Runtime.class.getResourceAsStream(resourcePath);
             if (stream == null) {
-                pendingException.set(new RuntimeException("Unable to locate " + library + ".dll within jar file!"));
+                pendingException.set(new RuntimeException("Unable to locate " + resourcePath + " within jar file!"));
                 return;
             }
 

--- a/support/java/Runtime.java
+++ b/support/java/Runtime.java
@@ -107,15 +107,13 @@ public final class Runtime {
             String resourcePath = "/assemblies/" + library + ".dll";
             InputStream stream = Runtime.class.getResourceAsStream(resourcePath);
             if (stream == null) {
-                pendingException.set(new RuntimeException("Unable to locate " + resourcePath + " within jar file!"));
-                return;
+                throw new RuntimeException("Unable to locate " + resourcePath + " within jar file!");
             }
 
             try {
                 Files.copy(stream, assemblyFile.toPath());
             } catch (IOException e) {
-                pendingException.set(new RuntimeException(e));
-                return;
+                throw new RuntimeException(e);
             }
         }
 

--- a/support/java/RuntimeException.java
+++ b/support/java/RuntimeException.java
@@ -29,5 +29,21 @@
 package mono.embeddinator;
 
 public class RuntimeException extends java.lang.RuntimeException {
+    public RuntimeException() { }
 
+    public RuntimeException(String var1) {
+        super(var1);
+    }
+
+    public RuntimeException(String var1, Throwable var2) {
+        super(var1, var2);
+    }
+
+    public RuntimeException(Throwable var1) {
+        super(var1);
+    }
+
+    protected RuntimeException(String var1, Throwable var2, boolean var3, boolean var4) {
+        super(var1, var2, var3, var4);
+    }
 }

--- a/tests/common/Makefile
+++ b/tests/common/Makefile
@@ -58,14 +58,12 @@ JNA_CLASSPATH=../../external/jna/jna-4.4.0.jar
 JAVAC_FLAGS=-d mk/java -Xdiags:verbose -Xlint:deprecation
 
 java: compile_java
-	java -cp "$(subst :,$(PATH_SEPERATOR),mk/java:common.jar:$(JNA_CLASSPATH):$(JUNIT_CLASSPATH):.)" -D -Djna.dump_memory=true -Djna.library.path=c/ org.junit.runner.JUnitCore Tests
+	java -cp "$(subst :,$(PATH_SEPERATOR),mk/java:mk/java/managed.jar:$(JNA_CLASSPATH):$(JUNIT_CLASSPATH):.)" -D -Djna.dump_memory=true -Djna.library.path=c/ org.junit.runner.JUnitCore Tests
 
 compile_java:
-	$(EMBEDDINATOR_CMD) -gen=java -out=java $(PLATFORM_FLAG) -target=shared $(MANAGED_DLL)
 	mkdir -p mk/java
-	javac -cp "$(subst :,$(PATH_SEPERATOR),$(JNA_CLASSPATH):.)" $(JAVAC_FLAGS) $(JAVA_FILES)
-	jar cf common.jar -C mk/java .
-	javac -cp "$(subst :,$(PATH_SEPERATOR),$(JNA_CLASSPATH):$(JUNIT_CLASSPATH):common.jar)" $(JAVAC_FLAGS) Tests.java
+	$(EMBEDDINATOR_CMD) -gen=java -out=mk/java $(PLATFORM_FLAG) -target=shared $(MANAGED_DLL) -c
+	javac -cp "$(subst :,$(PATH_SEPERATOR),$(JNA_CLASSPATH):$(JUNIT_CLASSPATH):mk/java/managed.jar)" $(JAVAC_FLAGS) Tests.java
 
 run:
 	mk/bin/Debug/common.Tests


### PR DESCRIPTION
The changes here I discussed with @tritao, these are mainly to get desktop Java in a working state.

## Changes
- On MacOS, `darwin/libX.dylib` is packaged up in the jar file
- .NET assemblies are packaged into `/assemblies/` inside the jar file
- *For now*, `Runtime.java` extracts the assemblies to a temp directory for use. We should investigate if the runtime can load them directly from the jar.

You can find the sample I used to test [here](https://github.com/jonathanpeppers/Embeddinated-Android/blob/master/lib-java/src/main/java/com/xamarin/Main.java).