### PR TITLE
[java] - embed JNA into our jar file

### DIFF
--- a/build/projects/MonoEmbeddinator4000.csproj
+++ b/build/projects/MonoEmbeddinator4000.csproj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../../binder/CLI.cs">

--- a/tests/common/Makefile
+++ b/tests/common/Makefile
@@ -54,16 +54,15 @@ compile_c_objc:
 
 JAVA_FILES=`find ../../support/java -name "*.java"` `find java -name "*.java"`
 JUNIT_CLASSPATH=../../external/junit/hamcrest-core-1.3.jar:../../external/junit/junit-4.12.jar
-JNA_CLASSPATH=../../external/jna/jna-4.4.0.jar
 JAVAC_FLAGS=-d mk/java -Xdiags:verbose -Xlint:deprecation
 
 java: compile_java
-	java -cp "$(subst :,$(PATH_SEPERATOR),mk/java:mk/java/managed.jar:$(JNA_CLASSPATH):$(JUNIT_CLASSPATH):.)" -D -Djna.dump_memory=true -Djna.library.path=c/ org.junit.runner.JUnitCore Tests
+	java -cp "$(subst :,$(PATH_SEPERATOR),mk/java:mk/java/managed.jar:$(JUNIT_CLASSPATH):.)" -D -Djna.dump_memory=true -Djna.library.path=c/ org.junit.runner.JUnitCore Tests
 
 compile_java:
 	mkdir -p mk/java
 	$(EMBEDDINATOR_CMD) -gen=java -out=mk/java $(PLATFORM_FLAG) -target=shared $(MANAGED_DLL) -c
-	javac -cp "$(subst :,$(PATH_SEPERATOR),$(JNA_CLASSPATH):$(JUNIT_CLASSPATH):mk/java/managed.jar)" $(JAVAC_FLAGS) Tests.java
+	javac -cp "$(subst :,$(PATH_SEPERATOR),$(JUNIT_CLASSPATH):mk/java/managed.jar)" $(JAVAC_FLAGS) Tests.java
 
 run:
 	mk/bin/Debug/common.Tests


### PR DESCRIPTION
- We don’t want developers to have to pull jna-4.4.0.jar into their
project
- This unzips it into our jar, so they just have to worry about a
single file
- Updated tests, so it is not using the jar from /external/jna