### PR TITLE
[java] improvements for Java on MacOS

### DIFF
--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -447,6 +447,27 @@ namespace MonoEmbeddinator4000
                 {
                     File.Copy(assembly, Path.Combine(assembliesDir, Path.GetFileName(assembly)), true);
                 }
+
+                //Copy any referenced assemblies such as mscorlib.dll
+                List<string> referencedAssemblies = new List<string>();
+                foreach (var assembly in Assemblies)
+                {
+                    foreach (var reference in assembly.GetReferencedAssemblies())
+                    {
+                        if (!referencedAssemblies.Contains(reference.Name))
+                            referencedAssemblies.Add(reference.Name);
+                    }
+                }
+
+                var monoPath = ManagedToolchain.FindMonoPath();
+                foreach (var reference in referencedAssemblies)
+                {
+                    var referencePath = Path.Combine(monoPath, "lib", "mono", "4.5", reference + ".dll");
+                    if (File.Exists(referencePath))
+                    {
+                        File.Copy(referencePath, Path.Combine(assembliesDir, reference + ".dll"), true);
+                    }
+                }
             }
 
             //Embed JNA into our jar file

--- a/support/java/Runtime.java
+++ b/support/java/Runtime.java
@@ -126,32 +126,33 @@ public final class Runtime {
         String assemblyPath = Utilities.combinePath(tmp, library);
         File assemblyFile = new File(assemblyPath + ".dll");
 
-        if (!assemblyFile.exists()) {
-            String resourcePath = "/assemblies/" + library + ".dll";
-            if (isRunningOnAndroid()) {
-                resourcePath = "/assets" + resourcePath;
-            }
-            InputStream input = Runtime.class.getResourceAsStream(resourcePath);
-            if (input == null) {
-                throw new RuntimeException("Unable to locate " + resourcePath + " within jar file!");
+        String resourcePath = "/assemblies/" + library + ".dll";
+        if (isRunningOnAndroid()) {
+            resourcePath = "/assets" + resourcePath;
+        }
+        InputStream input = Runtime.class.getResourceAsStream(resourcePath);
+        if (input == null) {
+            throw new RuntimeException("Unable to locate " + resourcePath + " within jar file!");
+        }
+
+        try {
+            OutputStream output = new FileOutputStream(assemblyFile);
+            try {
+                byte[] buffer = new byte[4 * 1024];
+                int read;
+                while ((read = input.read(buffer)) != -1) {
+                    output.write(buffer, 0, read);
+                }
+                output.flush();
+            } finally {
+                output.close();
+                input.close();
             }
 
-            try {
-                OutputStream output = new FileOutputStream(assemblyFile);
-                try {
-                    byte[] buffer = new byte[4 * 1024];
-                    int read;
-                    while ((read = input.read(buffer)) != -1) {
-                        output.write(buffer, 0, read);
-                    }
-                    output.flush();
-                } finally {
-                    output.close();
-                    input.close();
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            //NOTE: this file should be temporary
+            assemblyFile.deleteOnExit();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
         return assemblyPath;
     }

--- a/support/java/Runtime.java
+++ b/support/java/Runtime.java
@@ -103,10 +103,11 @@ public final class Runtime {
         runtimeLibrary.mono_embeddinator_set_assembly_path(assemblyPath);
 
         //NOTE: need to make sure mscorlib.dll is extracted & directory set
-        if (isRunningOnAndroid()) {
-            String monoPath = Utilities.combinePath(tmp, "mono", "4.5");
-            File monoFile = new File(monoPath);
+        String monoPath = Utilities.combinePath(tmp, "mono", "4.5");
+        File monoFile = new File(monoPath);
+        if (!monoFile.isDirectory()) {
             monoFile.mkdirs();
+            monoFile.deleteOnExit();
             extractAssembly(monoPath, "mscorlib");
         }
         

--- a/support/mono_embeddinator.c
+++ b/support/mono_embeddinator.c
@@ -90,15 +90,13 @@ int mono_embeddinator_init(mono_embeddinator_context_t* ctx, const char* domain)
     xamarin_initialize_embedded ();
     ctx->domain = mono_domain_get ();
 #else
-    #if defined (__ANDROID__)
-        if (path_override) {
-            GString* tmp = g_string_new(path_override->str);
-            gchar* sep = strrchr_seperator(tmp->str);
-            g_string_truncate(tmp, sep - tmp->str);
-            mono_set_dirs(tmp->str, tmp->str);
-            g_string_free(tmp, /*free_segment=*/ FALSE);
-        }
-    #endif
+    if (path_override) {
+        GString* tmp = g_string_new(path_override->str);
+        gchar* sep = strrchr_seperator(tmp->str);
+        g_string_truncate(tmp, sep - tmp->str);
+        mono_set_dirs(tmp->str, tmp->str);
+        g_string_free(tmp, /*free_segment=*/ FALSE);
+    }
     mono_config_parse(NULL);
     ctx->domain = mono_jit_init_version(domain, "v4.0.30319");
 #endif


### PR DESCRIPTION
### Mark .NET assemblies to be deleted on exit
- After a lot of research, I discovered that JNA actually extracts
native libraries from jar files into a temporary directory [see here](https://github.com/java-native-access/jna/blob/master/src/com/sun/jna/Native.java#L998)
- This makes it seem reasonable that we are doing the same with .NET
assemblies
- One improvement I saw from their implementation that could improve
ours: don’t use `File.exists()` and use `File.deleteOnExit()`
- This should extract/delete .NET assemblies on every run the same way
that JNA handles native libraries

### Package *all* .NET assemblies into jar file
- Turns out that desktop Java was loading `mscorlib.dll` from current
machine’s Mono installation
- Now we package mono assemblies into jar file
- Same logic is used for calling `mono_set_dirs` as Android