### PR TITLE
[android] enable arm64-v8a

### DIFF
--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -803,8 +803,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             var libName = $"lib{name}.so";
             var ndkPath = AndroidSdk.AndroidNdkPath;
 
-            //NOTE: "arm64-v8a" doesn't compile at the moment
-            foreach (var abi in new[] { "armeabi", "armeabi-v7a", "x86", "x86_64" })
+            foreach (var abi in new[] { "armeabi", "armeabi-v7a", "arm64-v8a", "x86", "x86_64" })
             {
                 string extra = string.Empty;
                 AndroidTargetArch targetArch;


### PR DESCRIPTION
This used to not work, but since we switched to using the prebuilt Android NDK toolchains it seems to work now

So now we get in the AAR:
```
adding: jni/arm64-v8a/libmanaged.so(in = 310832) (out= 70309)(deflated 77%)
```

@tritao try this on your phone with the Android tests you are working on, and let me know