### PR TITLE
[c] [java] Fixes for hyphens in assembly names

### DIFF
--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -431,7 +431,7 @@ namespace MonoEmbeddinator4000
             var executableSuffix = Platform.IsWindows ? ".exe" : string.Empty;
             var jar = $"{Path.Combine(GetJavaSdkPath(), "bin", "jar" + executableSuffix)}";
             var classesDir = Path.Combine(Options.OutputDir, "classes");
-            var name = Path.GetFileNameWithoutExtension(Project.Assemblies[0]);
+            var name = Path.GetFileNameWithoutExtension(Project.Assemblies[0]).Replace('-', '_');
 
             var args = new List<string> {
                 "cf",
@@ -528,7 +528,7 @@ namespace MonoEmbeddinator4000
             var jar = $"{Path.Combine(GetJavaSdkPath(), "bin", "jar" + executableSuffix)}";
             var classesDir = Path.Combine(Options.OutputDir, "classes");
             var androidDir = Path.Combine(Options.OutputDir, "android");
-            var name = Path.GetFileNameWithoutExtension(Project.Assemblies[0]);
+            var name = Path.GetFileNameWithoutExtension(Project.Assemblies[0]).Replace('-', '_');
 
             var args = new List<string> {
                 "cvf",

--- a/binder/Generators/C/CGenerator.cs
+++ b/binder/Generators/C/CGenerator.cs
@@ -26,14 +26,14 @@ namespace MonoEmbeddinator4000.Generators
 
         public static string GenId(string id)
         {
-            return "__" + id;
+            return "__" + id.Replace('-', '_');
         }
 
         public static string ObjectInstanceId => GenId("object");
 
         public static string AssemblyId(TranslationUnit unit)
         {
-            return GenId(unit.FileName).Replace('.', '_');
+            return GenId(unit.FileName).Replace('.', '_').Replace('-', '_');
         }
 
         private static CppTypePrintFlavorKind GetTypePrinterFlavorKind(GeneratorKind kind)

--- a/binder/Generators/Java/JavaGenerator.cs
+++ b/binder/Generators/Java/JavaGenerator.cs
@@ -13,7 +13,7 @@ namespace MonoEmbeddinator4000.Generators
         public static string IntPtrType = "com.sun.jna.Pointer";
 
         public static string GetNativeLibPackageName(TranslationUnit unit) =>
-            unit.FileName.Replace('.', '_').ToLowerInvariant();
+            unit.FileName.Replace('.', '_').Replace('-', '_').ToLowerInvariant();
 
         public JavaTypePrinter TypePrinter;
 

--- a/binder/Generators/Java/JavaNative.cs
+++ b/binder/Generators/Java/JavaNative.cs
@@ -21,7 +21,7 @@ namespace MonoEmbeddinator4000.Generators
         }
 
         public static string GetNativeLibClassName(TranslationUnit unit) =>
-            $"Native_{unit.FileName.Replace('.', '_')}";
+            $"Native_{unit.FileName.Replace('.', '_').Replace('-', '_')}";
 
         public string ClassName => GetNativeLibClassName(TranslationUnit);
 

--- a/binder/premake5.lua
+++ b/binder/premake5.lua
@@ -12,6 +12,7 @@
     {
       "System",
       "System.Core",
+      "System.IO.Compression",
       "IKVM.Reflection",
       "CppSharp",
       "CppSharp.AST",


### PR DESCRIPTION
- When writing docs for Java/Android, I used the .NET example from the
ObjC side.
- Apparently an assembly named `hello-from-csharp` breaks things