### PR TITLE
[java] fix various warnings

### DIFF
--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -401,13 +401,23 @@ namespace MonoEmbeddinator4000
             RefreshAndroidSdk();
 
             var executableSuffix = Platform.IsWindows ? ".exe" : string.Empty;
-            var javac = $"{Path.Combine(GetJavaSdkPath(), "bin", "javac" + executableSuffix)}";
+            var javaSdk = GetJavaSdkPath();
+            var javac = $"{Path.Combine(javaSdk, "bin", "javac" + executableSuffix)}";
             var classesDir = Path.Combine(Options.OutputDir, "classes");
+            var bootClassPath = Path.Combine(javaSdk, "jre", "lib", "rt.jar");
+
+            if (Options.Compilation.Platform == TargetPlatform.Android)
+            {
+                var maxVersion = AndroidSdk.GetInstalledPlatformVersions().Select(m => m.ApiLevel).Max();
+                var androidDir = AndroidSdk.GetPlatformDirectory(maxVersion);
+                bootClassPath = Path.Combine(androidDir, "android.jar");
+            }
 
             var args = new List<string> {
                 string.Join(" ", files.Select(file => Path.GetFullPath(file))),
                 string.Join(" ", Directory.GetFiles(FindDirectory("support"), "*.java", SearchOption.AllDirectories)),
                 "-source 1.7 -target 1.7",
+                $"-bootclasspath {bootClassPath}",
                 $"-d {classesDir}",
             };
 

--- a/support/java/Runtime.java
+++ b/support/java/Runtime.java
@@ -54,7 +54,7 @@ public final class Runtime {
             public String string;
 
             @Override
-            protected List getFieldOrder() {
+            protected List<String> getFieldOrder() {
                 return Arrays.asList("type", "monoException", "string");
             }
         }
@@ -68,7 +68,7 @@ public final class Runtime {
             public NativeLong allocated_len = new NativeLong();
 
             @Override
-            protected List getFieldOrder() {
+            protected List<String> getFieldOrder() {
                 return Arrays.asList("str", "len", "allocated_len");
             }
         }

--- a/support/java/RuntimeException.java
+++ b/support/java/RuntimeException.java
@@ -42,8 +42,4 @@ public class RuntimeException extends java.lang.RuntimeException {
     public RuntimeException(Throwable var1) {
         super(var1);
     }
-
-    protected RuntimeException(String var1, Throwable var2, boolean var3, boolean var4) {
-        super(var1, var2, var3, var4);
-    }
 }


### PR DESCRIPTION
- This fixes a lot of the warnings printed when running `—gen=Java`
- For Java 1.7 support, use `-bootclasspath`. Needs to point at
`rt.jar` on desktop and `android.jar` on Android
- `Runtime.java` should use proper `List<String>` return type on
`getFieldOrder()`
- `RuntimeException.java` is implementing a ctor that does not exist in
Java 1.7