### PR TITLE
[tests] added PCL project

### DIFF
--- a/generator.sln
+++ b/generator.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "managed-macos-full", "tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "managed-macos-modern", "tests\managed\macos-modern\managed-macos-modern.csproj", "{1A66B3FB-3482-4981-B3E9-2658A8773E9A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "managed-pcl", "tests\managed\pcl\managed-pcl.csproj", "{43B5C8AC-74C4-4EB4-AF2D-C62E36F41379}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86
@@ -73,6 +75,10 @@ Global
 		{1A66B3FB-3482-4981-B3E9-2658A8773E9A}.Debug|x86.Build.0 = Debug|x86
 		{1A66B3FB-3482-4981-B3E9-2658A8773E9A}.Release|x86.ActiveCfg = Release|x86
 		{1A66B3FB-3482-4981-B3E9-2658A8773E9A}.Release|x86.Build.0 = Release|x86
+		{43B5C8AC-74C4-4EB4-AF2D-C62E36F41379}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{43B5C8AC-74C4-4EB4-AF2D-C62E36F41379}.Debug|x86.Build.0 = Debug|Any CPU
+		{43B5C8AC-74C4-4EB4-AF2D-C62E36F41379}.Release|x86.ActiveCfg = Release|Any CPU
+		{43B5C8AC-74C4-4EB4-AF2D-C62E36F41379}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{076A871B-0C13-47D8-8923-B9242995BFF8} = {21776062-DBDA-4408-BF22-9DCB2682DCBC}
@@ -84,5 +90,6 @@ Global
 		{73636472-C245-4F57-9229-1DB22D643DFD} = {21776062-DBDA-4408-BF22-9DCB2682DCBC}
 		{8846BDE1-3377-4BED-BAB4-820F5CDF6D37} = {21776062-DBDA-4408-BF22-9DCB2682DCBC}
 		{1A66B3FB-3482-4981-B3E9-2658A8773E9A} = {21776062-DBDA-4408-BF22-9DCB2682DCBC}
+		{43B5C8AC-74C4-4EB4-AF2D-C62E36F41379} = {21776062-DBDA-4408-BF22-9DCB2682DCBC}
 	EndGlobalSection
 EndGlobal

--- a/tests/android/Makefile
+++ b/tests/android/Makefile
@@ -6,10 +6,18 @@ compile:
 	cp -R ../common/java/ app/src/main/java
 	./gradlew assemble
 
+pcl-compile:
+	$(EMBEDDINATOR_CMD) -gen=java -out=mk -p=android -compile $(MANAGED_PCL_DLL)
+	cp mk/managed.aar managed/managed.aar
+	cp -R ../common/java/ app/src/main/java
+	./gradlew assemble
+
 install:
 	./gradlew installDebug
 
 run:
 	./gradlew connectedAndroidTest
+
+pcl-run: pcl-compile install run
 
 all: compile install run

--- a/tests/common/Shared.make
+++ b/tests/common/Shared.make
@@ -3,6 +3,7 @@ MAKEFLAGS += --no-builtin-rules
 EMBEDDINATOR_EXE=../../build/lib/Debug/MonoEmbeddinator4000.exe
 
 MANAGED_DLL=../managed/generic/bin/Debug/managed.dll
+MANAGED_PCL_DLL=../managed/pcl/bin/Debug/managed.dll
 
 BUILD_FLAGS=/v:minimal
 

--- a/tests/managed/exceptions.cs
+++ b/tests/managed/exceptions.cs
@@ -1,4 +1,7 @@
 using System;
+#if PCL
+using Console = System.Diagnostics.Debug;
+#endif
 
 namespace Exceptions {
 
@@ -7,7 +10,11 @@ namespace Exceptions {
 		// objc: exceptions are, mostly, terminal but it's _ok_ for `init` to return `nil`
 		public Throwers ()
 		{
+#if PCL
+			throw new Exception ("Not a finite number!");
+#else
 			throw new NotFiniteNumberException ();
+#endif
 		}
 	}
 

--- a/tests/managed/interfaces.cs
+++ b/tests/managed/interfaces.cs
@@ -71,7 +71,7 @@ namespace Interfaces {
 
 		public static IFormatProvider GetCulture (string name)
 		{
-			return System.Globalization.CultureInfo.GetCultureInfo (name);
+			return new System.Globalization.CultureInfo (name);
 		}
 
 		public static string Format (double value, IFormatProvider provider)

--- a/tests/managed/pcl/managed-pcl.csproj
+++ b/tests/managed/pcl/managed-pcl.csproj
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{43B5C8AC-74C4-4EB4-AF2D-C62E36F41379}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>managedpcl</RootNamespace>
+    <AssemblyName>managed</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;PCL;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <DefineConstants>PCL;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <Import Project="..\managed-shared.projitems" Label="Shared" Condition="Exists('..\managed-shared.projitems')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+</Project>

--- a/tests/managed/properties.cs
+++ b/tests/managed/properties.cs
@@ -6,6 +6,10 @@ public static class Platform {
 	// static get-only property
 	public static bool IsWindows {
 		get {
+#if PCL
+			//NOTE: maybe there is something more precise than this
+			return Environment.NewLine == "\r\n";
+#else
 			switch (Environment.OSVersion.Platform) {
 			case PlatformID.Win32NT:
 			case PlatformID.Win32S:
@@ -14,6 +18,7 @@ public static class Platform {
 				return true;
 			}
 			return false;
+#endif
 		}
 	}
 	


### PR DESCRIPTION
- Added a general test project for testing PCLs
- Only had to create a couple `#if` to support PCL
- Made `pcl-compile` and `pcl-run` make targets

This doesn't fix anything, but adds a test project for #407 

I investigated if #407 could be fixed without Xamarin.Android, but facade assemblies would need to be extracted along with `mscorlib.dll`. I will continue work on Xamarin.Android integration to fix this issue.