### PR TITLE
[c] Rework array generation in C

### DIFF
--- a/binder/Generators/C/CHeaders.cs
+++ b/binder/Generators/C/CHeaders.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿﻿﻿using CppSharp;
+﻿﻿﻿﻿﻿﻿using CppSharp;
 using CppSharp.AST;
 using CppSharp.Generators;
 using CppSharp.Generators.AST;
@@ -31,6 +31,7 @@ namespace MonoEmbeddinator4000.Generators
 
             WriteInclude("glib.h");
             WriteInclude("mono_embeddinator.h");
+            WriteInclude("c-support.h");
 
             // Find dependent headers
             var referencedDecls = new GetReferencedDecls();

--- a/binder/Passes/GenerateArrayTypes.cs
+++ b/binder/Passes/GenerateArrayTypes.cs
@@ -1,4 +1,5 @@
 using CppSharp.AST;
+using CppSharp.AST.Extensions;
 using CppSharp.Passes;
 using MonoEmbeddinator4000.Generators;
 using System.Collections.Generic;
@@ -57,7 +58,8 @@ namespace MonoEmbeddinator4000.Passes
                 QualifiedType = new QualifiedType(new TagType(MonoEmbedArray))
             };
 
-            Declarations.Add(typedef);
+            if (!array.Type.IsPrimitiveType())
+                Declarations.Add(typedef);
 
             var typedefType = new TypedefType(typedef);
             var arrayType = new ManagedArrayType(array, typedefType);
@@ -99,6 +101,9 @@ namespace MonoEmbeddinator4000.Passes
 
         public override bool VisitFunctionDecl(Function function)
         {
+            if (function.TranslationUnit != TranslationUnit)
+                return false;
+
             QualifiedType newType;
 
             var retType = function.ReturnType;

--- a/support/c-support.h
+++ b/support/c-support.h
@@ -23,9 +23,33 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#pragma once
+
 #include "embeddinator.h"
 #include "glib.h"
 #include "mono-support.h"
+
+/**
+ * Arrays
+ */
+typedef struct MonoEmbedArray
+{
+    GArray* array;
+} MonoEmbedArray;
+
+typedef MonoEmbedArray _BoolArray;
+typedef MonoEmbedArray _CharArray;
+typedef MonoEmbedArray _SByteArray;
+typedef MonoEmbedArray _ByteArray;
+typedef MonoEmbedArray _Int16Array;
+typedef MonoEmbedArray _UInt16Array;
+typedef MonoEmbedArray _Int32Array;
+typedef MonoEmbedArray _UInt32Array;
+typedef MonoEmbedArray _Int64Array;
+typedef MonoEmbedArray _UInt64Array;
+typedef MonoEmbedArray _SingleArray;
+typedef MonoEmbedArray _DoubleArray;
+typedef MonoEmbedArray _StringArray;
 
 /**
  * Performs marshaling of a given MonoString to a GLib string.

--- a/support/embeddinator.h
+++ b/support/embeddinator.h
@@ -56,12 +56,6 @@
 #endif
 
 /**
- * Arrays
- */
-
-typedef struct MonoEmbedArray MonoEmbedArray;
-
-/**
  * Objects
  */
 

--- a/support/mono-support.h
+++ b/support/mono-support.h
@@ -80,7 +80,9 @@ typedef uint16_t gunichar2;
 /* This is copied from mono's header files */
 
 /* utils/mono-publib.h */
+#ifndef MONO_API
 #define MONO_API
+#endif
 typedef int32_t	mono_bool;
 typedef uint16_t mono_unichar2;
 

--- a/support/mono_embeddinator.h
+++ b/support/mono_embeddinator.h
@@ -166,12 +166,6 @@ typedef void (*mono_embeddinator_error_report_hook_t)(mono_embeddinator_error_t)
 MONO_EMBEDDINATOR_API
 void* mono_embeddinator_install_error_report_hook(mono_embeddinator_error_report_hook_t hook);
 
-
-struct MonoEmbedArray
-{
-    GArray* array;
-};
-
 struct MonoEmbedObject
 {
     MonoClass* _class;


### PR DESCRIPTION
This gives us cross-assembly array generation support aswell as leading to less duplicated code due to shared primitive array defintions.