### PR TITLE
Cake build scripts

### DIFF
--- a/.cake/packages.config
+++ b/.cake/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.20.0" />
+</packages>

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ xcuserdata/
 *.dSYM.zip
 *.dSYM
 *.nupkg
+tools/

--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,5 @@ xcuserdata/
 *.dSYM.zip
 *.dSYM
 *.nupkg
-tools/
+.cake/**
+!.cake/packages.config

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/xamarin/Xamarin.MacDev.git
 [submodule "Xamarin.Android.Tools"]
 	path = external/Xamarin.Android.Tools
-	url = https://github.com/jonathanpeppers/xamarin-android-tools.git
+	url = https://github.com/xamarin/xamarin-android-tools.git

--- a/build.cake
+++ b/build.cake
@@ -13,13 +13,13 @@ Task("Clean")
 Task("Build-Binder")
     .Does(() =>
     {
-        MSBuild("./build/projects/MonoEmbeddinator4000.csproj", settings => settings.SetConfiguration(configuration));
+        MSBuild("./build/projects/MonoEmbeddinator4000.csproj", settings => settings.SetConfiguration(configuration).SetVerbosity(Verbosity.Minimal));
     });
 
 Task("Build-Managed")
     .Does(() =>
 {
-    MSBuild("./tests/managed/generic/managed-generic.csproj", settings => settings.SetConfiguration(configuration));
+    MSBuild("./tests/managed/generic/managed-generic.csproj", settings => settings.SetConfiguration(configuration).SetVerbosity(Verbosity.Minimal));
 });
 
 Task("Generate-C")

--- a/build.cake
+++ b/build.cake
@@ -1,0 +1,38 @@
+var target = Argument("target", "Default");
+var configuration = Argument("configuration", "Release");
+var buildDir = Directory("./build/lib") + Directory(configuration);
+
+Task("Clean")
+    .Does(() =>
+{
+    CleanDirectory(buildDir);
+});
+
+Task("Build-Binder")
+    .Does(() =>
+    {
+        MSBuild("./build/projects/MonoEmbeddinator4000.csproj", settings => settings.SetConfiguration(configuration));
+    });
+
+Task("Build-Managed")
+    .Does(() =>
+{
+    MSBuild("./tests/managed/generic/managed-generic.csproj", settings => settings.SetConfiguration(configuration));
+});
+
+Task("Generate-C")
+    .IsDependentOn("Build-Binder")
+    .IsDependentOn("Build-Managed")
+    .Does(() =>
+    {
+        var managedDll = Directory("tests/managed/generic/bin") + Directory(configuration) + File("managed.dll");
+        var output = buildDir + Directory("c");
+        var exitCode = StartProcess(buildDir + File("MonoEmbeddinator4000.exe"), $"-gen=c -out={output} -platform=Windows -compile -target=shared {managedDll}");
+        if (exitCode != 0)
+            throw new Exception("MonoEmbeddinator4000.exe failed!");
+    });
+
+Task("Default")
+    .IsDependentOn("Generate-C");
+
+RunTarget(target);

--- a/build.cake
+++ b/build.cake
@@ -37,11 +37,11 @@ string GetJavaClassPath()
     return string.Join(";", classPath);
 }
 
-void RunEmbeddinator(string generator, string platform = "Windows")
+void RunEmbeddinator(string generator, string outDir, string platform = "Windows")
 {
     DoInDirectory(buildDir, () =>
     {
-        Exec(embeddinator, $"-gen={generator} -out=c -platform={platform} -compile -target=shared {managedDll}");
+        Exec(embeddinator, $"-gen={generator} -out={outDir} -platform={platform} -compile -target=shared {managedDll}");
     });
 }
 
@@ -70,7 +70,7 @@ Task("Generate-C")
     .IsDependentOn("Build-Managed")
     .Does(() =>
     {
-        RunEmbeddinator("c");
+        RunEmbeddinator("c", "c");
     });
 
 Task("Generate-Java")
@@ -78,7 +78,7 @@ Task("Generate-Java")
     .IsDependentOn("Build-Managed")
     .Does(() =>
     {
-        RunEmbeddinator("Java");
+        RunEmbeddinator("Java", "java");
     });
 
 Task("Generate-Android")
@@ -86,7 +86,7 @@ Task("Generate-Android")
     .IsDependentOn("Build-Managed")
     .Does(() =>
     {
-        RunEmbeddinator("Java", "Android");
+        RunEmbeddinator("Java", "java", "Android");
     });
 
 Task("Build-Java-Tests")

--- a/build.cake
+++ b/build.cake
@@ -37,6 +37,14 @@ string GetJavaClassPath()
     return string.Join(";", classPath);
 }
 
+void RunEmbeddinator(string generator, string platform = "Windows")
+{
+    DoInDirectory(buildDir, () =>
+    {
+        Exec(embeddinator, $"-gen={generator} -out=c -platform={platform} -compile -target=shared {managedDll}");
+    });
+}
+
 Task("Clean")
     .Does(() =>
     {
@@ -62,10 +70,7 @@ Task("Generate-C")
     .IsDependentOn("Build-Managed")
     .Does(() =>
     {
-        DoInDirectory(buildDir, () =>
-        {
-            Exec(embeddinator, $"-gen=c -out=c -platform=Windows -compile -target=shared {managedDll}");
-        });
+        RunEmbeddinator("c");
     });
 
 Task("Generate-Java")
@@ -73,10 +78,15 @@ Task("Generate-Java")
     .IsDependentOn("Build-Managed")
     .Does(() =>
     {
-        DoInDirectory(buildDir, () =>
-        {
-            Exec(embeddinator, $"-gen=Java -out=java -platform=Windows -compile -target=shared {managedDll}");
-        });
+        RunEmbeddinator("Java");
+    });
+
+Task("Generate-Android")
+    .IsDependentOn("Build-Binder")
+    .IsDependentOn("Build-Managed")
+    .Does(() =>
+    {
+        RunEmbeddinator("Java", "Android");
     });
 
 Task("Build-Java-Tests")

--- a/build.cake
+++ b/build.cake
@@ -1,3 +1,5 @@
+#addin nuget:?package=Cake.DoInDirectory
+
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 var buildDir = Directory("./build/lib") + Directory(configuration);
@@ -25,11 +27,15 @@ Task("Generate-C")
     .IsDependentOn("Build-Managed")
     .Does(() =>
     {
-        var managedDll = Directory("tests/managed/generic/bin") + Directory(configuration) + File("managed.dll");
-        var output = buildDir + Directory("c");
-        var exitCode = StartProcess(buildDir + File("MonoEmbeddinator4000.exe"), $"-gen=c -out={output} -platform=Windows -compile -target=shared {managedDll}");
-        if (exitCode != 0)
-            throw new Exception("MonoEmbeddinator4000.exe failed!");
+        var managedDll = Directory("../../../tests/managed/generic/bin") + Directory(configuration) + File("managed.dll");
+
+        DoInDirectory(buildDir, () =>
+        {
+            var exitCode = StartProcess("MonoEmbeddinator4000.exe", $"-gen=c -out=c -platform=Windows -compile -target=shared {managedDll}");
+            if (exitCode != 0)
+                throw new Exception("MonoEmbeddinator4000.exe failed!");
+        });
+        
     });
 
 Task("Default")

--- a/build.cake
+++ b/build.cake
@@ -44,12 +44,14 @@ Task("Clean")
     });
 
 Task("Build-Binder")
+    .IsDependentOn("Clean")
     .Does(() =>
     {
         MSBuild("./build/projects/MonoEmbeddinator4000.csproj", settings => settings.SetConfiguration(configuration).SetVerbosity(Verbosity.Minimal));
     });
 
 Task("Build-Managed")
+    .IsDependentOn("Clean")
     .Does(() =>
     {
         MSBuild("./tests/managed/generic/managed-generic.csproj", settings => settings.SetConfiguration(configuration).SetVerbosity(Verbosity.Minimal));
@@ -67,7 +69,8 @@ Task("Generate-C")
     });
 
 Task("Generate-Java")
-    .IsDependentOn("Generate-C")
+    .IsDependentOn("Build-Binder")
+    .IsDependentOn("Build-Managed")
     .Does(() =>
     {
         DoInDirectory(buildDir, () =>

--- a/build.cake
+++ b/build.cake
@@ -5,12 +5,43 @@ var configuration = Argument("configuration", "Release");
 var buildDir = Directory("./build/lib") + Directory(configuration);
 var embeddinator = File("MonoEmbeddinator4000.exe");
 var managedDll = Directory("../../../tests/managed/generic/bin") + Directory(configuration) + File("managed.dll");
+var javaHome = EnvironmentVariable("JAVA_HOME");
+
+void Exec(string path, string args)
+{
+    Console.WriteLine(path + " " + args);
+
+    var exitCode = StartProcess(path, args);
+    if (exitCode != 0)
+        throw new Exception(path + " failed!");
+}
+
+string GetJavaTool(string name)
+{
+    if (string.IsNullOrEmpty(javaHome))
+        throw new Exception("Could not find JAVA_HOME!");
+
+    return Directory(javaHome) + Directory("bin") + File(name);
+}
+
+string GetJavaClassPath()
+{
+    var classPath = new[]
+    {
+        "./external/junit/hamcrest-core-1.3.jar",
+        "./external/junit/junit-4.12.jar",
+        buildDir + Directory("java"),
+        buildDir + File("java/managed.jar"),
+    };
+
+    return string.Join(";", classPath);
+}
 
 Task("Clean")
     .Does(() =>
-{
-    CleanDirectory(buildDir);
-});
+    {
+        CleanDirectory(buildDir);
+    });
 
 Task("Build-Binder")
     .Does(() =>
@@ -20,9 +51,9 @@ Task("Build-Binder")
 
 Task("Build-Managed")
     .Does(() =>
-{
-    MSBuild("./tests/managed/generic/managed-generic.csproj", settings => settings.SetConfiguration(configuration).SetVerbosity(Verbosity.Minimal));
-});
+    {
+        MSBuild("./tests/managed/generic/managed-generic.csproj", settings => settings.SetConfiguration(configuration).SetVerbosity(Verbosity.Minimal));
+    });
 
 Task("Generate-C")
     .IsDependentOn("Build-Binder")
@@ -31,9 +62,7 @@ Task("Generate-C")
     {
         DoInDirectory(buildDir, () =>
         {
-            var exitCode = StartProcess(embeddinator, $"-gen=c -out=c -platform=Windows -compile -target=shared {managedDll}");
-            if (exitCode != 0)
-                throw new Exception(embeddinator + " failed!");
+            Exec(embeddinator, $"-gen=c -out=c -platform=Windows -compile -target=shared {managedDll}");
         });
     });
 
@@ -43,10 +72,26 @@ Task("Generate-Java")
     {
         DoInDirectory(buildDir, () =>
         {
-            var exitCode = StartProcess(embeddinator, $"-gen=Java -out=java -platform=Windows -compile -target=shared {managedDll}");
-            if (exitCode != 0)
-                throw new Exception(embeddinator + " failed!");
+            Exec(embeddinator, $"-gen=Java -out=java -platform=Windows -compile -target=shared {managedDll}");
         });
+    });
+
+Task("Build-Java-Tests")
+    .IsDependentOn("Generate-Java")
+    .Does(() =>
+    {
+        var classPath = GetJavaClassPath();
+        var output = buildDir + Directory("java");
+        var tests = "./tests/common/java/mono/embeddinator/Tests.java";
+        Exec(GetJavaTool("javac"), $"-cp {classPath} -d {output} -Xdiags:verbose -Xlint:deprecation {tests}");
+    });
+
+Task("Run-Java-Tests")
+    .IsDependentOn("Build-Java-Tests")
+    .Does(() =>
+    {
+        var classPath = GetJavaClassPath();
+        Exec(GetJavaTool("java"), $"-cp {classPath} -D -Djna.dump_memory=true org.junit.runner.JUnitCore mono.embeddinator.Tests");
     });
 
 Task("Default")

--- a/build.cake
+++ b/build.cake
@@ -9,6 +9,8 @@ string javaHome;
 if (IsRunningOnWindows())
 {
     javaHome = EnvironmentVariable("JAVA_HOME");
+    if (string.IsNullOrEmpty(javaHome))
+        throw new Exception("Cannot find Java SDK: JAVA_HOME environment variable is not set.");
 }
 else
 {
@@ -19,8 +21,6 @@ else
         javaHome = process.GetStandardOutput().First().Trim();
     }
 }
-if (string.IsNullOrEmpty(javaHome))
-    throw new Exception("Could not find JAVA_HOME!");
 
 var classPath = string.Join(IsRunningOnWindows() ? ";" : ":", new[]
 {

--- a/build.cake
+++ b/build.cake
@@ -104,10 +104,10 @@ Task("Run-Java-Tests")
     .Does(() =>
     {
         var classPath = GetJavaClassPath();
-        Exec(GetJavaTool("java"), $"-cp {classPath} -D -Djna.dump_memory=true org.junit.runner.JUnitCore mono.embeddinator.Tests");
+        Exec(GetJavaTool("java"), $"-cp {classPath} -Djna.dump_memory=true org.junit.runner.JUnitCore mono.embeddinator.Tests");
     });
 
 Task("Default")
-    .IsDependentOn("Generate-Java");
+    .IsDependentOn("Generate-Android");
 
 RunTarget(target);

--- a/build.cake
+++ b/build.cake
@@ -5,44 +5,24 @@ var configuration = Argument("configuration", "Release");
 var buildDir = Directory("./build/lib") + Directory(configuration);
 var embeddinator = File("MonoEmbeddinator4000.exe");
 var managedDll = Directory("../../../tests/managed/generic/bin") + Directory(configuration) + File("managed.dll");
+
+//Java settings
 var javaHome = EnvironmentVariable("JAVA_HOME");
+if (string.IsNullOrEmpty(javaHome))
+    throw new Exception("Could not find JAVA_HOME!");
+var classPath = string.Join(";", new[]
+{
+    "./external/junit/hamcrest-core-1.3.jar",
+    "./external/junit/junit-4.12.jar",
+    buildDir + Directory("java"),
+    buildDir + File("java/managed.jar"),
+});
 
 void Exec(string path, string args)
 {
-    Console.WriteLine(path + " " + args);
-
     var exitCode = StartProcess(path, args);
     if (exitCode != 0)
         throw new Exception(path + " failed!");
-}
-
-string GetJavaTool(string name)
-{
-    if (string.IsNullOrEmpty(javaHome))
-        throw new Exception("Could not find JAVA_HOME!");
-
-    return Directory(javaHome) + Directory("bin") + File(name);
-}
-
-string GetJavaClassPath()
-{
-    var classPath = new[]
-    {
-        "./external/junit/hamcrest-core-1.3.jar",
-        "./external/junit/junit-4.12.jar",
-        buildDir + Directory("java"),
-        buildDir + File("java/managed.jar"),
-    };
-
-    return string.Join(";", classPath);
-}
-
-void RunEmbeddinator(string generator, string outDir, string platform = "Windows")
-{
-    DoInDirectory(buildDir, () =>
-    {
-        Exec(embeddinator, $"-gen={generator} -out={outDir} -platform={platform} -compile -target=shared {managedDll}");
-    });
 }
 
 Task("Clean")
@@ -70,7 +50,11 @@ Task("Generate-C")
     .IsDependentOn("Build-Managed")
     .Does(() =>
     {
-        RunEmbeddinator("c", "c");
+        DoInDirectory(buildDir, () =>
+        {
+            var platform = IsRunningOnWindows() ? "Windows" : "macOS";
+            Exec(embeddinator, $"-gen=c -out=c -platform={platform} -compile -target=shared {managedDll}");
+        });
     });
 
 Task("Generate-Java")
@@ -78,7 +62,11 @@ Task("Generate-Java")
     .IsDependentOn("Build-Managed")
     .Does(() =>
     {
-        RunEmbeddinator("Java", "java");
+        DoInDirectory(buildDir, () =>
+        {
+            var platform = IsRunningOnWindows() ? "Windows" : "macOS";
+            Exec(embeddinator, $"-gen=Java -out=java -platform={platform} -compile -target=shared {managedDll}");
+        });
     });
 
 Task("Generate-Android")
@@ -86,25 +74,28 @@ Task("Generate-Android")
     .IsDependentOn("Build-Managed")
     .Does(() =>
     {
-        RunEmbeddinator("Java", "java", "Android");
+        DoInDirectory(buildDir, () =>
+        {
+            Exec(embeddinator, $"-gen=c -out=c -platform=Android -compile -target=shared {managedDll}");
+        });
     });
 
 Task("Build-Java-Tests")
     .IsDependentOn("Generate-Java")
     .Does(() =>
     {
-        var classPath = GetJavaClassPath();
         var output = buildDir + Directory("java");
         var tests = "./tests/common/java/mono/embeddinator/Tests.java";
-        Exec(GetJavaTool("javac"), $"-cp {classPath} -d {output} -Xdiags:verbose -Xlint:deprecation {tests}");
+        var javac = Directory(javaHome) + File("bin/javac");
+        Exec(javac, $"-cp {classPath} -d {output} -Xdiags:verbose -Xlint:deprecation {tests}");
     });
 
 Task("Run-Java-Tests")
     .IsDependentOn("Build-Java-Tests")
     .Does(() =>
     {
-        var classPath = GetJavaClassPath();
-        Exec(GetJavaTool("java"), $"-cp {classPath} -Djna.dump_memory=true org.junit.runner.JUnitCore mono.embeddinator.Tests");
+        var java = Directory(javaHome) + File("bin/java");
+        Exec(java, $"-cp {classPath} -Djna.dump_memory=true org.junit.runner.JUnitCore mono.embeddinator.Tests");
     });
 
 Task("Default")

--- a/build.ps1
+++ b/build.ps1
@@ -45,7 +45,7 @@ Param(
     [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
-    [string]$Verbosity = "Verbose",
+    [string]$Verbosity = "Normal",
     [switch]$Experimental = $True,
     [Alias("DryRun","Noop")]
     [switch]$WhatIf,
@@ -150,6 +150,7 @@ if (!(Test-Path $NUGET_EXE)) {
 
 # Save nuget.exe path to environment to be available to child processed
 $ENV:NUGET_EXE = $NUGET_EXE
+$ENV:CAKE_PATHS_TOOLS = $TOOLS_DIR
 
 # Restore tools from NuGet?
 if(-Not $SkipToolPackageRestore.IsPresent) {

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,189 @@
+##########################################################################
+# This is the Cake bootstrapper script for PowerShell.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+<#
+
+.SYNOPSIS
+This is a Powershell script to bootstrap a Cake build.
+
+.DESCRIPTION
+This Powershell script will download NuGet if missing, restore NuGet tools (including Cake)
+and execute your Cake build script with the parameters you provide.
+
+.PARAMETER Script
+The build script to execute.
+.PARAMETER Target
+The build script target to run.
+.PARAMETER Configuration
+The build configuration to use.
+.PARAMETER Verbosity
+Specifies the amount of information to be displayed.
+.PARAMETER Experimental
+Tells Cake to use the latest Roslyn release.
+.PARAMETER WhatIf
+Performs a dry run of the build script.
+No tasks will be executed.
+.PARAMETER Mono
+Tells Cake to use the Mono scripting engine.
+.PARAMETER SkipToolPackageRestore
+Skips restoring of packages.
+.PARAMETER ScriptArgs
+Remaining arguments are added here.
+
+.LINK
+http://cakebuild.net
+
+#>
+
+[CmdletBinding()]
+Param(
+    [string]$Script = "build.cake",
+    [string]$Target = "Default",
+    [ValidateSet("Release", "Debug")]
+    [string]$Configuration = "Release",
+    [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
+    [string]$Verbosity = "Verbose",
+    [switch]$Experimental = $True,
+    [Alias("DryRun","Noop")]
+    [switch]$WhatIf,
+    [switch]$Mono,
+    [switch]$SkipToolPackageRestore,
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$ScriptArgs
+)
+
+[Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
+function MD5HashFile([string] $filePath)
+{
+    if ([string]::IsNullOrEmpty($filePath) -or !(Test-Path $filePath -PathType Leaf))
+    {
+        return $null
+    }
+
+    [System.IO.Stream] $file = $null;
+    [System.Security.Cryptography.MD5] $md5 = $null;
+    try
+    {
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        $file = [System.IO.File]::OpenRead($filePath)
+        return [System.BitConverter]::ToString($md5.ComputeHash($file))
+    }
+    finally
+    {
+        if ($file -ne $null)
+        {
+            $file.Dispose()
+        }
+    }
+}
+
+Write-Host "Preparing to run build script..."
+
+if(!$PSScriptRoot){
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
+$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
+$PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
+
+# Should we use mono?
+$UseMono = "";
+if($Mono.IsPresent) {
+    Write-Verbose -Message "Using the Mono based scripting engine."
+    $UseMono = "-mono"
+}
+
+# Should we use the new Roslyn?
+$UseExperimental = "";
+if($Experimental.IsPresent -and !($Mono.IsPresent)) {
+    Write-Verbose -Message "Using experimental version of Roslyn."
+    $UseExperimental = "-experimental"
+}
+
+# Is this a dry run?
+$UseDryRun = "";
+if($WhatIf.IsPresent) {
+    $UseDryRun = "-dryrun"
+}
+
+# Make sure tools folder exists
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
+    Write-Verbose -Message "Creating tools directory..."
+    New-Item -Path $TOOLS_DIR -Type directory | out-null
+}
+
+# Make sure that packages.config exist.
+if (!(Test-Path $PACKAGES_CONFIG)) {
+    Write-Verbose -Message "Downloading packages.config..."
+    try { (New-Object System.Net.WebClient).DownloadFile("http://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
+        Throw "Could not download packages.config."
+    }
+}
+
+# Try find NuGet.exe in path if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Trying to find nuget.exe in PATH..."
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_ -PathType Container) }
+    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
+    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
+        Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
+        $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
+    }
+}
+
+# Try download NuGet.exe if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Downloading NuGet.exe..."
+    try {
+        (New-Object System.Net.WebClient).DownloadFile($NUGET_URL, $NUGET_EXE)
+    } catch {
+        Throw "Could not download NuGet.exe."
+    }
+}
+
+# Save nuget.exe path to environment to be available to child processed
+$ENV:NUGET_EXE = $NUGET_EXE
+
+# Restore tools from NuGet?
+if(-Not $SkipToolPackageRestore.IsPresent) {
+    Push-Location
+    Set-Location $TOOLS_DIR
+
+    # Check for changes in packages.config and remove installed tools if true.
+    [string] $md5Hash = MD5HashFile($PACKAGES_CONFIG)
+    if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
+      ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
+        Write-Verbose -Message "Missing or changed package.config hash..."
+        Remove-Item * -Recurse -Exclude packages.config,nuget.exe
+    }
+
+    Write-Verbose -Message "Restoring tools from NuGet..."
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occured while restoring NuGet tools."
+    }
+    else
+    {
+        $md5Hash | Out-File $PACKAGES_CONFIG_MD5 -Encoding "ASCII"
+    }
+    Write-Verbose -Message ($NuGetOutput | out-string)
+    Pop-Location
+}
+
+# Make sure that Cake has been installed.
+if (!(Test-Path $CAKE_EXE)) {
+    Throw "Could not find Cake.exe at $CAKE_EXE"
+}
+
+# Start Cake
+Write-Host "Running build script..."
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+exit $LASTEXITCODE

--- a/build.ps1
+++ b/build.ps1
@@ -87,7 +87,7 @@ if(!$PSScriptRoot){
 }
 
 $TOOLS_DIR = Join-Path $PSScriptRoot ".cake"
-$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$NUGET_EXE = Join-Path $PSScriptRoot ".nuget/nuget.exe"
 $CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
 $NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"

--- a/build.ps1
+++ b/build.ps1
@@ -86,7 +86,7 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$TOOLS_DIR = Join-Path $PSScriptRoot ".cake"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
 $CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
 $NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+##########################################################################
+# This is the Cake bootstrapper script for Linux and OS X.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+# Define directories.
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+TOOLS_DIR=$SCRIPT_DIR/.cake
+NUGET_EXE=$SCRIPT_DIR/.nuget/nuget.exe
+CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
+PACKAGES_CONFIG=$TOOLS_DIR/packages.config
+PACKAGES_CONFIG_MD5=$TOOLS_DIR/packages.config.md5sum
+
+# Set Paths_Tools for Cake to install Addins in .cake/
+export CAKE_PATHS_TOOLS=$TOOLS_DIR
+
+# Define md5sum or md5 depending on Linux/OSX
+MD5_EXE=
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    MD5_EXE="md5 -r"
+else
+    MD5_EXE="md5sum"
+fi
+
+# Define default arguments.
+SCRIPT="build.cake"
+TARGET="Default"
+CONFIGURATION="Release"
+VERBOSITY="verbose"
+DRYRUN=
+SHOW_VERSION=false
+SCRIPT_ARGUMENTS=()
+
+# Parse arguments.
+for i in "$@"; do
+    case $1 in
+        -s|--script) SCRIPT="$2"; shift ;;
+        -t|--target) TARGET="$2"; shift ;;
+        -c|--configuration) CONFIGURATION="$2"; shift ;;
+        -v|--verbosity) VERBOSITY="$2"; shift ;;
+        -d|--dryrun) DRYRUN="-dryrun" ;;
+        --version) SHOW_VERSION=true ;;
+        --) shift; SCRIPT_ARGUMENTS+=("$@"); break ;;
+        *) SCRIPT_ARGUMENTS+=("$1") ;;
+    esac
+    shift
+done
+
+# Make sure the tools folder exist.
+if [ ! -d "$TOOLS_DIR" ]; then
+  mkdir "$TOOLS_DIR"
+fi
+
+# Make sure that packages.config exist.
+if [ ! -f "$TOOLS_DIR/packages.config" ]; then
+    echo "Downloading packages.config..."
+    curl -Lsfo "$TOOLS_DIR/packages.config" http://cakebuild.net/download/bootstrapper/packages
+    if [ $? -ne 0 ]; then
+        echo "An error occured while downloading packages.config."
+        exit 1
+    fi
+fi
+
+# Download NuGet if it does not exist.
+if [ ! -f "$NUGET_EXE" ]; then
+    echo "Downloading NuGet..."
+    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+    if [ $? -ne 0 ]; then
+        echo "An error occured while downloading nuget.exe."
+        exit 1
+    fi
+fi
+
+# Restore tools from NuGet.
+pushd "$TOOLS_DIR" >/dev/null
+if [ ! -f $PACKAGES_CONFIG_MD5 ] || [ "$( cat $PACKAGES_CONFIG_MD5 | sed 's/\r$//' )" != "$( $MD5_EXE $PACKAGES_CONFIG | awk '{ print $1 }' )" ]; then
+    find . -type d ! -name . | xargs rm -rf
+fi
+
+mono "$NUGET_EXE" install -ExcludeVersion
+if [ $? -ne 0 ]; then
+    echo "Could not restore NuGet packages."
+    exit 1
+fi
+
+$MD5_EXE $PACKAGES_CONFIG | awk '{ print $1 }' >| $PACKAGES_CONFIG_MD5
+
+popd >/dev/null
+
+# Make sure that Cake has been installed.
+if [ ! -f "$CAKE_EXE" ]; then
+    echo "Could not find Cake.exe at '$CAKE_EXE'."
+    exit 1
+fi
+
+# Start Cake
+if $SHOW_VERSION; then
+    exec mono "$CAKE_EXE" -version
+else
+    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
+fi

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ fi
 SCRIPT="build.cake"
 TARGET="Default"
 CONFIGURATION="Release"
-VERBOSITY="verbose"
+VERBOSITY="normal"
 DRYRUN=
 SHOW_VERSION=false
 SCRIPT_ARGUMENTS=()

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -36,6 +36,21 @@ Tests can be executed by running `make` from the `tests/common` directory.
 
 Or running the `tests/RunTestsuite.sh` shell script.
 
+### Cake
+
+We will slowly be moving our build scripts to Cake. We only have a few build targets setup so far.
+
+To run on Windows, open powershell and run:
+```
+.\build.ps1
+```
+To run on OS X:
+```
+./build.sh
+```
+
+To run a specific target, append `-t Generate-Android`, for example.
+
 ## Objective-C
 
 The work on the Objective-C generator occurs in the [`objc`](https://github.com/mono/Embeddinator-4000/tree/objc) branch. Here are the steps to build it from our repository/branch:

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.20.0" />
+</packages>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-    <package id="Cake" version="0.20.0" />
-</packages>


### PR DESCRIPTION
Our various `Makefiles` do not currently work well on windows, so @tritao and I are looking to start the process of migrating to Cake.

This PR includes:
- Just a few build targets `Generate-Android` is set to `Default`
- `Run-Java-Tests` works (except on Windows there is an issue compiling C)
- Windows & OS X bootstrap scripts for Cake
- Point `external/Xamarin.Android.Tools` back to official repo

Changes from standard Cake scripts:
- Using experimental flag for C# 6/Roslyn on Windows
- Using `.cake` instead of the `tools` directory
- Using `.nuget/nuget.exe` because we already have it there

From here, we can start adding more Cake tasks.