### PR TITLE
[android] fix for Application.Context

### DIFF
--- a/support/java/android/AndroidImpl.java
+++ b/support/java/android/AndroidImpl.java
@@ -12,6 +12,7 @@ public class AndroidImpl extends DesktopImpl {
 
     public AndroidImpl(Context context) {
         this.context = context;
+        mono.MonoPackageManager.Context = context;
     }
 
     @Override

--- a/support/java/android/MonoPackageManager.java
+++ b/support/java/android/MonoPackageManager.java
@@ -1,0 +1,6 @@
+package mono;
+
+/* This is used if Application.Context is invoked from C#, see: https://github.com/xamarin/xamarin-android/blob/master/src/Mono.Android/Android.App/Application.cs */
+public class MonoPackageManager {
+    public static android.content.Context Context;
+}

--- a/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
+++ b/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
@@ -10,7 +10,7 @@ import android.content.*;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import java.io.*;
-import managed_dll.Native_managed_dll;
+import managed_dll.*;
 import mono.embeddinator.testrunner.MainActivity;
 import mono.embeddinator.android.*;
 
@@ -84,5 +84,10 @@ public class AndroidTests {
         } finally {
             reader.close();
         }
+    }
+
+    @Test
+    public void applicationContext() {
+        AndroidAssertions.applicationContext();
     }
 }

--- a/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
+++ b/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
@@ -95,4 +95,9 @@ public class AndroidTests {
     public void asyncAwait() {
         AndroidAssertions.asyncAwait();
     }
+
+    @Test
+    public void webRequest() {
+        AndroidAssertions.webRequest();
+    }
 }

--- a/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
+++ b/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
@@ -90,4 +90,9 @@ public class AndroidTests {
     public void applicationContext() {
         AndroidAssertions.applicationContext();
     }
+
+    @Test
+    public void asyncAwait() {
+        AndroidAssertions.asyncAwait();
+    }
 }

--- a/tests/managed/android/android.cs
+++ b/tests/managed/android/android.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
 using Android.OS;
@@ -73,6 +74,17 @@ namespace Android
             var context = Application.Context;
             if (context == null)
                 throw new Exception("Application.Context must not be null!");
+        }
+
+        [Export("asyncAwait")]
+        public static async void AsyncAwait()
+        {
+            var looper = Looper.MyLooper();
+
+            await Task.Delay(1);
+
+            if (looper != Looper.MyLooper())
+                throw new Exception("We should be on the same thread!");
         }
     }
 }

--- a/tests/managed/android/android.cs
+++ b/tests/managed/android/android.cs
@@ -1,4 +1,5 @@
-﻿using Android.App;
+﻿using System;
+using Android.App;
 using Android.Content;
 using Android.OS;
 using Android.Runtime;
@@ -60,6 +61,18 @@ namespace Android
         public string GetText()
         {
             return Resources.GetString(R.String.hello);
+        }
+    }
+
+    [Register("mono.embeddinator.android.AndroidAssertions")]
+    public class AndroidAssertions : Java.Lang.Object
+    {
+        [Export("applicationContext")]
+        public static void ApplicationContext()
+        {
+            var context = Application.Context;
+            if (context == null)
+                throw new Exception("Application.Context must not be null!");
         }
     }
 }

--- a/tests/managed/android/android.cs
+++ b/tests/managed/android/android.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
@@ -8,6 +9,8 @@ using Android.Util;
 using Android.Widget;
 using Java.Interop;
 using R = managedandroid.Resource;
+
+[assembly: UsesPermission("android.permission.INTERNET")]
 
 namespace Android
 {
@@ -85,6 +88,16 @@ namespace Android
 
             if (looper != Looper.MyLooper())
                 throw new Exception("We should be on the same thread!");
+        }
+
+        [Export("webRequest")]
+        public static void WebRequest()
+        {
+            var client = new WebClient();
+
+            string html = client.DownloadString("https://www.google.com");
+            if (string.IsNullOrEmpty(html))
+                throw new Exception("String should not be blank!");
         }
     }
 }


### PR DESCRIPTION
Xamarin.Android has a static property `Application.Context` that calls into a Java `MonoPackageManager` class, see [here](https://github.com/xamarin/xamarin-android/blob/master/src/Mono.Android/Android.App/Application.cs).

We did not have this in Embeddinator, so any of the following would crash:
- Calling `Application.Context` directly
- Using async/await or `System.Threading.Tasks`
    - These use the context for synchronizing tasks back on the main thread

I discovered this when working on a sample: https://github.com/jamesmontemagno/embeddinator-weather/pull/3 

To fix this, I made a stub of `MonoPackageManager` in Embeddinator with a single field. Xamarin.Android's [version](https://github.com/xamarin/xamarin-android/blob/master/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java) does other things, but let's wait and see if we need it.

I also wrote a few other integration tests around this issue.