### PR TITLE
[android] setup NotifyTimeZoneChanges class

### DIFF
--- a/support/java/android/AndroidImpl.java
+++ b/support/java/android/AndroidImpl.java
@@ -17,6 +17,11 @@ public class AndroidImpl extends DesktopImpl {
 
     @Override
     public RuntimeLibrary initialize(String library) {
+        android.content.IntentFilter timezoneChangedFilter  = new android.content.IntentFilter (
+                android.content.Intent.ACTION_TIMEZONE_CHANGED
+        );
+        context.registerReceiver (new mono.android.app.NotifyTimeZoneChanges(), timezoneChangedFilter);
+
         System.loadLibrary("monodroid");
         System.loadLibrary(library);
         setAssemblyPrefix();

--- a/tests/common/java/mono/embeddinator/Tests.java
+++ b/tests/common/java/mono/embeddinator/Tests.java
@@ -324,5 +324,8 @@ public class Tests {
         assertEquals(Character.MIN_VALUE, Type_Char.getMin());
         assertEquals(Character.MAX_VALUE, Type_Char.getMax());
         assertEquals(0, Type_Char.getZero());
+
+        //Just validate this doesn't crash for now
+        assertNotNull(Type_DateTime.getNow());
     }
 }

--- a/tests/managed/types.cs
+++ b/tests/managed/types.cs
@@ -81,6 +81,14 @@ public static class Type_String
 	public static string NonEmptyString { get { return "Hello World"; } }
 }
 
+/// <summary>
+/// NOTE: DateTime types are not exposed, this is for verifying DateTime.Now works
+/// </summary>
+public static class Type_DateTime
+{
+    public static string Now { get { return DateTime.Now.ToString(); } }
+}
+
 // objc: this type won't be generated (Exception is not supported) but the generation will succeed (with warnings)
 public class MyException : Exception {
 }


### PR DESCRIPTION
In Xamarin.Android’s MonoPackageManager, there is some logic around
timezone changes we did not have setup in Embeddinator:
https://github.com/xamarin/xamarin-android/blob/master/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java#L29

I added a test case for `DateTime.Now` as a smoke test, but I think
this change only affects the case where a timezone changes on the
device while the application is running. 

I could not find a test in Xamarin.Android checking timezone changes.