### PR TITLE
[android] better selection of Android API level

### DIFF
--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -387,9 +387,7 @@ namespace MonoEmbeddinator4000
 
             if (Options.Compilation.Platform == TargetPlatform.Android)
             {
-                var maxVersion = AndroidSdk.GetInstalledPlatformVersions().Select(m => m.ApiLevel).Max();
-                var androidDir = AndroidSdk.GetPlatformDirectory(maxVersion);
-                bootClassPath = Path.Combine(androidDir, "android.jar");
+                bootClassPath = Path.Combine(XamarinAndroid.PlatformDirectory, "android.jar");
             }
 
             var javaFiles = files.Select(file => Path.GetFullPath(file)).ToList();
@@ -425,9 +423,7 @@ namespace MonoEmbeddinator4000
             var jnaJar = Path.Combine(Helpers.FindDirectory("external"), "jna", "jna-4.4.0.jar");
             if (Options.Compilation.Platform == TargetPlatform.Android)
             {
-                var maxVersion = AndroidSdk.GetInstalledPlatformVersions().Select(m => m.ApiLevel).Max();
-                var androidDir = AndroidSdk.GetPlatformDirectory(maxVersion);
-                var androidJar = Path.Combine(androidDir, "android.jar");
+                var androidJar = Path.Combine(XamarinAndroid.PlatformDirectory, "android.jar");
                 var monoAndroidJar = XamarinAndroid.FindAssembly("mono.android.jar");
                 var delimiter = Platform.IsWindows ? ";" : ":";
                 args.Add("\"" + string.Join(delimiter, jnaJar, androidJar, monoAndroidJar) + "\"");
@@ -858,7 +854,7 @@ namespace MonoEmbeddinator4000
                 }
 
                 var clangBin = NdkUtil.GetNdkClangBin(Path.Combine(ndkPath, "toolchains"), targetArch);
-                var systemInclude = NdkUtil.GetNdkPlatformIncludePath(ndkPath, targetArch, 24); //NOTE: 24 should be an option?
+                var systemInclude = NdkUtil.GetNdkPlatformIncludePath(ndkPath, targetArch, XamarinAndroid.ApiLevel);
                 var monoDroidPath = Path.Combine(XamarinAndroid.LibraryPath, abi);
                 var abiDir = Path.Combine(Options.OutputDir, "android", "jni", abi);
                 var outputPath = Path.Combine(abiDir, libName);

--- a/binder/Utils/XamarinAndroid.cs
+++ b/binder/Utils/XamarinAndroid.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.IO;
 using CppSharp;
 using Xamarin.Android.Tools;
@@ -103,6 +104,26 @@ namespace MonoEmbeddinator4000
             }
 
             throw new FileNotFoundException("Unable to find assembly!", assemblyName);
+        }
+
+        static Lazy<int> apiLevel = new Lazy<int>(() => AndroidSdk.GetInstalledPlatformVersions().Select(m => m.ApiLevel).Max());
+
+        /// <summary>
+        /// Right now we are choosing the max API level installed
+        /// </summary>
+        public static int ApiLevel
+        {
+            get { return apiLevel.Value; }
+        }
+
+        static Lazy<string> platformDirectory = new Lazy<string>(() => AndroidSdk.GetPlatformDirectory(ApiLevel));
+
+        /// <summary>
+        /// Gets the platform directory based on the max API level installed
+        /// </summary>
+        public static string PlatformDirectory
+        {
+            get { return platformDirectory.Value; }
         }
     }
 }

--- a/binder/Utils/XamarinAndroidBuild.cs
+++ b/binder/Utils/XamarinAndroidBuild.cs
@@ -130,7 +130,7 @@ namespace MonoEmbeddinator4000
             aapt.SetParameter("OutputImportDirectory", outputDirectory);
             aapt.SetParameter("ManifestFiles", manifestPath);
             aapt.SetParameter("ApplicationName", packageName);
-            aapt.SetParameter("JavaPlatformJarPath", Path.Combine(AndroidSdk.GetPlatformDirectory(AndroidSdk.GetInstalledPlatformVersions().Select(v => v.ApiLevel).Max()), "android.jar"));
+            aapt.SetParameter("JavaPlatformJarPath", Path.Combine(XamarinAndroid.PlatformDirectory, "android.jar"));
             aapt.SetParameter("JavaDesignerOutputDirectory", outputDirectory);
             aapt.SetParameter("AssetDirectory", assetsDir);
             aapt.SetParameter("ResourceDirectory", resourceDir);

--- a/tests/MonoEmbeddinator4000.Tests/XamarinAndroidTest.cs
+++ b/tests/MonoEmbeddinator4000.Tests/XamarinAndroidTest.cs
@@ -96,5 +96,19 @@ namespace MonoEmbeddinator4000.Tests
             string file = XamarinAndroid.FindAssembly("mono.android.jar");
             FileAssert.Exists(file);
         }
+
+        [Test]
+        public void PlatformDirectory()
+        {
+            string dir = XamarinAndroid.PlatformDirectory;
+            DirectoryAssert.Exists(dir);
+        }
+
+        [Test]
+        public void AndroidJar()
+        {
+            string file = Path.Combine(XamarinAndroid.PlatformDirectory, "android.jar");
+            FileAssert.Exists(file);
+        }
     }
 }


### PR DESCRIPTION
- Moved API level selection to `XamarinAndroid` class
- `CompileNDK` now works off the highest API level available instead of
hardcoding 24
- added some tests