### PR TITLE
[android] support for Java binding projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,6 @@ xcuserdata/
 *.nupkg
 .cake/**
 !.cake/packages.config
+.vscode/
 Resource.designer.cs
 external/Xamarin.Android

--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -409,7 +409,7 @@ namespace MonoEmbeddinator4000
 
             var args = new List<string> {
                 string.Join(" ", javaFiles),
-                "-source 1.7 -target 1.7",
+                $"-source {XamarinAndroid.JavaVersion} -target {XamarinAndroid.JavaVersion}",
                 $"-bootclasspath \"{bootClassPath}\"",
                 $"-d {classesDir}",
             };

--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -426,7 +426,19 @@ namespace MonoEmbeddinator4000
                 var androidJar = Path.Combine(XamarinAndroid.PlatformDirectory, "android.jar");
                 var monoAndroidJar = XamarinAndroid.FindAssembly("mono.android.jar");
                 var delimiter = Platform.IsWindows ? ";" : ":";
-                args.Add("\"" + string.Join(delimiter, jnaJar, androidJar, monoAndroidJar) + "\"");
+                var classpath = new List<string> { jnaJar, androidJar, monoAndroidJar };
+
+                //Now we need to add any additional jars from binding projects to the classpath
+                var intermediateDir = Path.Combine(Options.OutputDir, "obj");
+                if (Directory.Exists(intermediateDir))
+                {
+                    foreach (var jar in Directory.GetFiles(intermediateDir, "*.jar", SearchOption.AllDirectories))
+                    {
+                        classpath.Add(jar);
+                    }
+                }
+
+                args.Add("\"" + string.Join(delimiter, classpath) + "\"");
             }
             else
             {

--- a/binder/Driver.cs
+++ b/binder/Driver.cs
@@ -49,6 +49,10 @@ namespace MonoEmbeddinator4000
         bool Parse()
         {
             var parser = new Parser();
+            foreach (var assembly in Project.Assemblies)
+            {
+                parser.AddAssemblyResolveDirectory(Path.GetDirectoryName(assembly));
+            }
             if (Options.Compilation.Platform == TargetPlatform.Android)
             {
                 foreach (var dir in XamarinAndroid.TargetFrameworkDirectories)

--- a/binder/Generators/AstGenerator.cs
+++ b/binder/Generators/AstGenerator.cs
@@ -713,17 +713,27 @@ namespace MonoEmbeddinator4000.Generators
 
         public static bool IsAndroidSubclass (this IKVM.Reflection.Type type)
         {
+            foreach (var @interface in type.GetInterfaces())
+            {
+                if (@interface.Assembly.IsAndroidAssembly())
+                    return true;
+            }
+
             do
             {
                 if (type == null)
                     return false;
-                if (type.Assembly.FullName.StartsWith("Mono.Android, ", StringComparison.Ordinal) ||
-                    type.Assembly.FullName.StartsWith("Java.Interop, ", StringComparison.Ordinal))
+                if (type.Assembly.IsAndroidAssembly())
                     return true;
 
                 type = type.BaseType;
 
             } while (true);
+        }
+
+        public static bool IsAndroidAssembly(this Assembly assembly)
+        {
+            return assembly.FullName.StartsWith("Mono.Android, ", StringComparison.Ordinal) || assembly.FullName.StartsWith("Java.Interop, ", StringComparison.Ordinal);
         }
     }
 }

--- a/binder/Utils/XamarinAndroid.cs
+++ b/binder/Utils/XamarinAndroid.cs
@@ -15,6 +15,7 @@ namespace MonoEmbeddinator4000
         public const string TargetFrameworkVersion = "v7.0";
         public const string MinSdkVersion = "9";
         public const string TargetSdkVersion = "25";
+        public const string JavaVersion = "1.8";
 
         static XamarinAndroid()
         {

--- a/binder/Utils/XamarinAndroid.cs
+++ b/binder/Utils/XamarinAndroid.cs
@@ -12,7 +12,7 @@ namespace MonoEmbeddinator4000
     /// </summary>
     static class XamarinAndroid
     {
-        public const string TargetFrameworkVersion = "v2.3";
+        public const string TargetFrameworkVersion = "v7.0";
         public const string MinSdkVersion = "9";
         public const string TargetSdkVersion = "25";
 
@@ -82,7 +82,8 @@ namespace MonoEmbeddinator4000
         {
             Combine(Path, "lib", "xbuild-frameworks", "MonoAndroid", "v1.0"),
             Combine(Path, "lib", "xbuild-frameworks", "MonoAndroid", "v1.0", "Facades"),
-            Combine(Path, "lib", "xbuild-frameworks", "MonoAndroid", TargetFrameworkVersion)
+            Combine(Path, "lib", "xbuild-frameworks", "MonoAndroid", TargetFrameworkVersion),
+            Combine(Path, "lib", "xbuild-frameworks", "MonoAndroid", "v2.3"), //Mono.Android.Export.dll is here
         });
 
         public static string[] TargetFrameworkDirectories

--- a/build.cake
+++ b/build.cake
@@ -68,6 +68,9 @@ Task("Clean")
     .Does(() =>
     {
         CleanDirectory(buildDir);
+        CleanDirectories(GetDirectories("./tests/**/obj"));
+        CleanDirectories(GetDirectories("./tests/**/bin"));
+        CleanDirectories(GetDirectories("./tests/android/**/build"));
     });
 
 Task("NuGet-Restore")

--- a/docs/getting-started-java-android.md
+++ b/docs/getting-started-java-android.md
@@ -3,7 +3,9 @@
 In addition to the requirements from our [Getting started with Java](getting-started-java.md) guide you'll also need:
 
 * Xamarin.Android 7.4.99 or later (build from [Jenkins](https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure/))
-* Android Studio 2.3.2 or later (with [Java 8](https://developer.android.com/guide/platform/j8-jack.html))
+* Android Studio 2.3.2 or later (with [Java 1.8](https://developer.android.com/guide/platform/j8-jack.html))
+
+*NOTE: the state of using Java 1.8 in Android Studio is currently in [flux](https://android-developers.googleblog.com/2017/03/future-of-java-8-language-feature.html) at the moment. At the time of writing, the options are to enable the Jack toolchain in your project or use a preview version of Android Studio.*
 
 As an overview, we will:
 * Clone Embeddinator-4000

--- a/docs/getting-started-java-android.md
+++ b/docs/getting-started-java-android.md
@@ -3,7 +3,7 @@
 In addition to the requirements from our [Getting started with Java](getting-started-java.md) guide you'll also need:
 
 * Xamarin.Android 7.4.99 or later (build from [Jenkins](https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure/))
-* Android Studio 2.3.2 or later
+* Android Studio 2.3.2 or later (with [Java 8](https://developer.android.com/guide/platform/j8-jack.html))
 
 As an overview, we will:
 * Clone Embeddinator-4000

--- a/docs/getting-started-java.md
+++ b/docs/getting-started-java.md
@@ -17,7 +17,7 @@ For Windows:
 
 For Android:
 * Xamarin.Android 7.4.99 or later (build from [Jenkins](https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure/))
-* Android Studio 2.3.2 or later
+* Android Studio 2.3.2 or later (with [Java 8](https://developer.android.com/guide/platform/j8-jack.html))
 
 Optionally you can install [Xamarin Studio](https://developer.xamarin.com/guides/cross-platform/xamarin-studio/) or the new [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/) to edit and compile your C# code. The rest of the getting started guide assume you'll be using **Visual Studio for Mac**.
 

--- a/docs/getting-started-java.md
+++ b/docs/getting-started-java.md
@@ -5,7 +5,7 @@ This is the getting started page for Java, which covers the basics for all suppo
 ## Requirements
 
 In order to use the embeddinator with Java you will need:
-* Java 1.7 or later
+* Java 1.8 or later
 * [Mono 5.0](http://www.mono-project.com/download/)
 
 For Mac:
@@ -17,7 +17,7 @@ For Windows:
 
 For Android:
 * Xamarin.Android 7.4.99 or later (build from [Jenkins](https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure/))
-* Android Studio 2.3.2 or later (with [Java 8](https://developer.android.com/guide/platform/j8-jack.html))
+* Android Studio 2.3.2 or later (with [Java 1.8](https://developer.android.com/guide/platform/j8-jack.html))
 
 Optionally you can install [Xamarin Studio](https://developer.xamarin.com/guides/cross-platform/xamarin-studio/) or the new [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/) to edit and compile your C# code. The rest of the getting started guide assume you'll be using **Visual Studio for Mac**.
 
@@ -39,7 +39,7 @@ argument to the embeddinator. Currently `macOS` and `Android` are supported. `Wi
 
 ### macOS and Windows
 
-For development, should be able to use any Java IDE that supports Java 1.7. You can even use Android Studio for this if desired, [see here](https://stackoverflow.com/questions/16626810/can-android-studio-be-used-to-run-standard-java-projects). You can use the JAR file output as you would any standard Java jar file.
+For development, should be able to use any Java IDE that supports Java 1.8. You can even use Android Studio for this if desired, [see here](https://stackoverflow.com/questions/16626810/can-android-studio-be-used-to-run-standard-java-projects). You can use the JAR file output as you would any standard Java jar file.
 
 ### Android
 

--- a/tests/android/.idea/misc.xml
+++ b/tests/android/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/tests/android/app/build.gradle
+++ b/tests/android/app/build.gradle
@@ -10,6 +10,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        jackOptions.enabled true
     }
     buildTypes {
         release {
@@ -19,6 +20,10 @@ android {
     }
     aaptOptions {
         noCompress 'dll'
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 

--- a/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
+++ b/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 import org.junit.*;
 import org.junit.runner.RunWith;
 import android.app.Activity;
+import android.support.v4.content.LocalBroadcastManager;
 import android.view.View;
 import android.widget.TextView;
 import android.content.*;
@@ -87,7 +88,8 @@ public class AndroidTests {
 
     @Test
     public void applicationContext() {
-        AndroidAssertions.applicationContext();
+        Context context = AndroidAssertions.applicationContext();
+        assertNotNull(context);
     }
 
     @Test
@@ -97,11 +99,13 @@ public class AndroidTests {
 
     @Test
     public void webRequest() {
-        AndroidAssertions.webRequest();
+        String html = AndroidAssertions.webRequest();
+        assertNotNull(html);
     }
 
     @Test
     public void callIntoSupportLibrary() {
-        AndroidAssertions.callIntoSupportLibrary();
+        LocalBroadcastManager manager = AndroidAssertions.callIntoSupportLibrary();
+        assertNotNull(manager);
     }
 }

--- a/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
+++ b/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
@@ -18,7 +18,7 @@ import mono.embeddinator.android.*;
 public class AndroidTests {
     //We need an activity for these tests
     @Rule
-    public ActivityTestRule rule = new ActivityTestRule<>(MainActivity.class);
+    public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class);
 
     @Test
     public void createView() throws Throwable {

--- a/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
+++ b/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
@@ -99,4 +99,9 @@ public class AndroidTests {
     public void webRequest() {
         AndroidAssertions.webRequest();
     }
+
+    @Test
+    public void callIntoSupportLibrary() {
+        AndroidAssertions.callIntoSupportLibrary();
+    }
 }

--- a/tests/managed/android/android.cs
+++ b/tests/managed/android/android.cs
@@ -73,11 +73,9 @@ namespace Android
     public class AndroidAssertions : Java.Lang.Object
     {
         [Export("applicationContext")]
-        public static void ApplicationContext()
+        public static Context ApplicationContext()
         {
-            var context = Application.Context;
-            if (context == null)
-                throw new Exception("Application.Context must not be null!");
+            return Application.Context;
         }
 
         [Export("asyncAwait")]
@@ -92,21 +90,16 @@ namespace Android
         }
 
         [Export("webRequest")]
-        public static void WebRequest()
+        public static string WebRequest()
         {
-            var client = new WebClient();
-
-            string html = client.DownloadString("https://www.google.com");
-            if (string.IsNullOrEmpty(html))
-                throw new Exception("String should not be blank!");
+            using (var client = new WebClient())
+                return client.DownloadString("https://www.google.com");
         }
 
         [Export("callIntoSupportLibrary")]
-        public static void CallIntoSupportLibrary()
+        public static LocalBroadcastManager CallIntoSupportLibrary()
         {
-            var manager = LocalBroadcastManager.GetInstance(Application.Context);
-            if (manager == null)
-                throw new Exception("LocalBroadcastManager should not be null!");
+            return LocalBroadcastManager.GetInstance(Application.Context);
         }
     }
 }

--- a/tests/managed/android/android.cs
+++ b/tests/managed/android/android.cs
@@ -5,6 +5,7 @@ using Android.App;
 using Android.Content;
 using Android.OS;
 using Android.Runtime;
+using Android.Support.V4.Content;
 using Android.Util;
 using Android.Widget;
 using Java.Interop;
@@ -98,6 +99,14 @@ namespace Android
             string html = client.DownloadString("https://www.google.com");
             if (string.IsNullOrEmpty(html))
                 throw new Exception("String should not be blank!");
+        }
+
+        [Export("callIntoSupportLibrary")]
+        public static void CallIntoSupportLibrary()
+        {
+            var manager = LocalBroadcastManager.GetInstance(Application.Context);
+            if (manager == null)
+                throw new Exception("LocalBroadcastManager should not be null!");
         }
     }
 }

--- a/tests/managed/android/managed-android.csproj
+++ b/tests/managed/android/managed-android.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props" Condition="Exists('..\..\..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -41,6 +42,27 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
     <Reference Include="Mono.Android.Export" />
+    <Reference Include="Xamarin.Android.Support.Annotations">
+      <HintPath>..\..\..\packages\Xamarin.Android.Support.Annotations.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Compat">
+      <HintPath>..\..\..\packages\Xamarin.Android.Support.Compat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.UI">
+      <HintPath>..\..\..\packages\Xamarin.Android.Support.Core.UI.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Core.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.Utils">
+      <HintPath>..\..\..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Core.Utils.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Media.Compat">
+      <HintPath>..\..\..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Media.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Fragment">
+      <HintPath>..\..\..\packages\Xamarin.Android.Support.Fragment.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Fragment.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v4">
+      <HintPath>..\..\..\packages\Xamarin.Android.Support.v4.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v4.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Resources\Resource.designer.cs" />
@@ -59,7 +81,18 @@
   <ItemGroup>
     <AndroidAsset Include="Assets\test.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="..\managed-shared.projitems" Label="Shared" Condition="Exists('..\managed-shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="..\CustomBuildActions.targets" />
+  <Import Project="..\..\..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets" Condition="Exists('..\..\..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets" Condition="Exists('..\..\..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets" Condition="Exists('..\..\..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets" Condition="Exists('..\..\..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.Utils.targets" Condition="Exists('..\..\..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.Utils.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Media.Compat.targets" Condition="Exists('..\..\..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Media.Compat.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.Android.Support.Fragment.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Fragment.targets" Condition="Exists('..\..\..\packages\Xamarin.Android.Support.Fragment.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Fragment.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.Android.Support.v4.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v4.targets" Condition="Exists('..\..\..\packages\Xamarin.Android.Support.v4.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v4.targets')" />
 </Project>

--- a/tests/managed/android/managed-android.csproj
+++ b/tests/managed/android/managed-android.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>managedandroid</RootNamespace>
     <AssemblyName>managed</AssemblyName>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>

--- a/tests/managed/android/packages.config
+++ b/tests/managed/android/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Xamarin.Android.Support.Annotations" version="25.3.1" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.Compat" version="25.3.1" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.Core.UI" version="25.3.1" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.Core.Utils" version="25.3.1" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.Fragment" version="25.3.1" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.Media.Compat" version="25.3.1" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.v4" version="25.3.1" targetFramework="monoandroid70" />
+  <package id="Xamarin.Build.Download" version="0.4.3" targetFramework="monoandroid70" />
+</packages>


### PR DESCRIPTION
If you are embedding an Android library project with a reference to the `Xamarin.Android.Support.v4` NuGet package, for example, the generated Java code did not compile. We need to add any jar files from binding projects to the `classpath` during Java compilation.

## Changes
- Embeddinator needs to include assembly directories in its search path for `IKVM.Reflection`.
- Java generator will skip over types implementing `IJavaObject` but aren't `Java.Lang.Object`
-  Jars from `library_project_imports` included in `classpath`.
- We are now using `TargetFrameworkVersion` of 7.0 instead of 2.3. This should cover a wider range of C# projects.
- This forces us to use Java 8, since `v7.0/mono.android.jar` is compiled for Java 8. I updated the docs to reflect this.
- I had to rearrange some of the MSBuild steps, so `library_project_imports` are extracted sooner: prior to Java compilation
- Added tests to verify this case

Fixes #427 