### PR TITLE
[java] refactoring of Helpers and JavaSdkPath

### DIFF
--- a/binder/Utils/XamarinAndroid.cs
+++ b/binder/Utils/XamarinAndroid.cs
@@ -127,5 +127,22 @@ namespace MonoEmbeddinator4000
         {
             get { return platformDirectory.Value; }
         }
+
+        static Lazy<string> javaSdkPath = new Lazy<string>(() =>
+        {
+            // If we are running on macOS, invoke java_home to figure out Java path.
+            if (Platform.IsMacOS)
+                return Helpers.Invoke("/usr/libexec/java_home", null, null).StandardOutput.Trim();
+
+            string home = Environment.GetEnvironmentVariable("JAVA_HOME");
+            if (string.IsNullOrEmpty(home))
+                throw new Exception("Cannot find Java SDK: JAVA_HOME environment variable is not set.");
+            return home;
+        });
+
+        public static string JavaSdkPath
+        {
+            get { return javaSdkPath.Value; }
+        }
     }
 }

--- a/tests/MonoEmbeddinator4000.Tests/XamarinAndroidTest.cs
+++ b/tests/MonoEmbeddinator4000.Tests/XamarinAndroidTest.cs
@@ -51,6 +51,12 @@ namespace MonoEmbeddinator4000.Tests
         }
 
         [Test]
+        public void JavaSdkPathExists()
+        {
+            DirectoryAssert.Exists(XamarinAndroid.JavaSdkPath);
+        }
+
+        [Test]
         public void TargetFrameworkDirectories()
         {
             foreach (var dir in XamarinAndroid.TargetFrameworkDirectories)


### PR DESCRIPTION
- `Invoke` should probably be moved to `Helpers`
- Let’s do `using static MonoEmbeddinator4000.Helpers` throughout
`Compilation.cs`
- Fixed some string interpolation that could be removed
- `JavaSdkPath` moved to `XamarinAndroid` class
- `JavaSdkPath` is now only calculated once, previously
`/usr/libexec/java_home` would get executed three times for `-gen=Java
-platform=Android`. This also printed the Java path times three times
to the output…