### PR TITLE
[android] callbacks from C# to Java

### DIFF
--- a/binder/Utils/XamarinAndroidBuild.cs
+++ b/binder/Utils/XamarinAndroidBuild.cs
@@ -171,6 +171,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
             var intermediateDir = Path.Combine(outputDirectory, "obj");
             var androidDir = Path.Combine(outputDirectory, "android");
+            var javaSourceDir = Path.Combine(outputDirectory, "src");
             var assetsDir = Path.Combine(androidDir, "assets");
             var resourceDir = Path.Combine(androidDir, "res");
             var manifestPath = Path.Combine(androidDir, "AndroidManifest.xml");
@@ -212,6 +213,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
             //Create ItemGroup of Android files
             var androidResources = target.AddItemGroup();
+            androidResources.AddItem("AndroidJavaSource", Path.Combine(intermediateDir, "*", "library_project_imports", "java", "**", "*.java"));
             androidResources.AddItem("AndroidAsset", @"%(ResolvedAssetDirectories.Identity)\**\*").Condition = "'@(ResolvedAssetDirectories)' != ''";
             androidResources.AddItem("AndroidResource", @"%(ResolvedResourceDirectories.Identity)\**\*").Condition = "'@(ResolvedAssetDirectories)' != ''";
 
@@ -224,6 +226,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             copy = target.AddTask("Copy");
             copy.SetParameter("SourceFiles", "@(AndroidResource)");
             copy.SetParameter("DestinationFiles", $"@(AndroidResource->'{resourceDir + Path.DirectorySeparatorChar}%(RecursiveDir)%(Filename)%(Extension)')");
+
+            //Copy Task, to copy AndroidJavaSource files
+            copy = target.AddTask("Copy");
+            copy.SetParameter("SourceFiles", "@(AndroidJavaSource)");
+            copy.SetParameter("DestinationFiles", $"@(AndroidJavaSource->'{javaSourceDir + Path.DirectorySeparatorChar}%(RecursiveDir)%(Filename)%(Extension)')");
 
             //XmlPoke to fix up AndroidManifest
             var xmlPoke = target.AddTask("XmlPoke");

--- a/docs/android-callbacks.md
+++ b/docs/android-callbacks.md
@@ -1,0 +1,266 @@
+# Callbacks on Android
+
+Calling to Java from C# is somewhat a *risky business*. That is to say there is a *pattern* for callbacks from C# to Java; however, it is more complicated than we would like.
+
+We'll cover the three options for doing callbacks that make the most sense for Java:
+- Abstract classes
+- Interfaces
+- Virtual methods
+
+## Abstract Classes
+
+This is the easiest route for callbacks, so I would recommend using `abstract` if you are just trying to get a callback working in the simplest form.
+
+Let's start with a C# class we would like Java to implement:
+```csharp
+[Register("mono.embeddinator.android.AbstractClass")]
+public abstract class AbstractClass : Java.Lang.Object
+{
+    public AbstractClass() { }
+
+    public AbstractClass(IntPtr handle, JniHandleOwnership transfer) : base(handle, transfer) { }
+
+    [Export("getText")]
+    public abstract string GetText();
+}
+```
+
+So let's identify the details that make this work:
+- `[Register]` generates a nice package name in Java--you will get an auto-generated package name without it.
+- Subclassing `Java.Lang.Object` signals Embeddinator to run the class through Xamarin.Android's Java generator.
+- Empty constructor: is the one you want Java to be using.
+- `(IntPtr, JniHandleOwnership)` constructor: is what Xamarin.Android will use for creating the C#-equivalent of Java objects.
+- `[Export]` is just needed if you want to make the method name different in Java, since the Java world likes to use lower case methods.
+
+Next let's make a C# method to test the scenario:
+```csharp
+[Register("mono.embeddinator.android.JavaCallbacks")]
+public class JavaCallbacks : Java.Lang.Object
+{
+    [Export("abstractCallback")]
+    public static string AbstractCallback(AbstractClass callback)
+    {
+        return callback.GetText();
+    }
+}
+```
+`JavaCallbacks` could be any class to test this, as long as it is a `Java.Lang.Object`.
+
+Now, run Embeddinator on your .NET assembly to generate an AAR. See the [Getting Started guide](getting-started-java-android.md) for details.
+
+After importing the AAR file into Android Studio, let's write a unit test:
+```java
+@Test
+public void abstractCallback() throws Throwable {
+    AbstractClass callback = new AbstractClass() {
+        @Override
+        public String getText() {
+            return "Java";
+        }
+    };
+
+    assertEquals("Java", callback.getText());
+    assertEquals("Java", JavaCallbacks.abstractCallback(callback));
+}
+```
+So we:
+- Implemented the `AbstractClass` in Java with an anonymous type
+- Made sure our instance returns `"Java"` from Java
+- Made sure our instance returns `"Java"` from C#
+- Added `throws Throwable`, since C# constructors are currently marked with `throws`
+
+If we ran this unit test as-is, it would fail with an error such as:
+```
+System.NotSupportedException: Unable to find Invoker for type 'Android.AbstractClass'. Was it linked away?
+```
+
+What is missing here is an `Invoker` type. This is a subclass of `AbstractClass` that forwards C# calls to Java. If a Java object enters the C# world and the equivalent C# type is abstract, then Xamarin.Android automatically looks for a C# type with the suffix `Invoker` for use within C# code.
+
+Xamarin.Android uses this `Invoker` pattern for Java binding projects among other things.
+
+Here is our implementation of `AbstractClassInvoker`:
+```csharp
+class AbstractClassInvoker : AbstractClass
+{
+    IntPtr class_ref, id_gettext;
+
+    public AbstractClassInvoker(IntPtr handle, JniHandleOwnership transfer) : base(handle, transfer)
+    {
+        IntPtr lref = JNIEnv.GetObjectClass(Handle);
+        class_ref = JNIEnv.NewGlobalRef(lref);
+        JNIEnv.DeleteLocalRef(lref);
+    }
+
+    protected override Type ThresholdType
+    {
+        get { return typeof(AbstractClassInvoker); }
+    }
+
+    protected override IntPtr ThresholdClass
+    {
+        get { return class_ref; }
+    }
+
+    public override string GetText()
+    {
+        if (id_gettext == IntPtr.Zero)
+            id_gettext = JNIEnv.GetMethodID(class_ref, "getText", "()Ljava/lang/String;");
+        IntPtr lref = JNIEnv.CallObjectMethod(Handle, id_gettext);
+        return GetObject<Java.Lang.String>(lref, JniHandleOwnership.TransferLocalRef)?.ToString();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (class_ref != IntPtr.Zero)
+            JNIEnv.DeleteGlobalRef(class_ref);
+        class_ref = IntPtr.Zero;
+
+        base.Dispose(disposing);
+    }
+}
+```
+
+There is quite a bit going on here, we:
+- Added a class with the suffix `Invoker` that subclasses `AbstractClass`
+- Added `class_ref` to hold the JNI reference to the Java class that subclasses our C# class
+- Added `id_gettext` to hold the JNI reference to the Java `getText` method
+- Included a `(IntPtr, JniHandleOwnership)` constructor
+- Implemented `ThresholdType` and `ThresholdClass` as a requirement for Xamarin.Android to know details about the `Invoker`
+- `GetText` needed to lookup the Java `getText` method with the appropriate JNI signature and call it
+- `Dispose` is just needed to clear the reference to `class_ref`
+
+After adding this class and generating a new AAR, our unit test passes. As you can see this pattern for callbacks is not *ideal*, but doable.
+
+For details on Java interop, see the amazing [Xamarin.Android documentation](https://developer.xamarin.com/guides/android/advanced_topics/java_integration_overview/working_with_jni/) on this subject.
+
+## Interfaces
+
+Interfaces are much the same as abstract classes, except for one detail: Xamarin.Android does not generate Java for them. This is because before Embeddinator-4000, there are not many scenarios where Java would implement a C# interface.
+
+Let's say we have the following C# interface:
+```csharp
+[Register("mono.embeddinator.android.IJavaCallback")]
+public interface IJavaCallback : IJavaObject
+{
+    [Export("send")]
+    void Send(string text);
+}
+```
+`IJavaObject` signals Embeddinator that this is a Xamarin.Android interface, but otherwise this is exactly the same as an `abstract` class.
+
+Since Xamarin.Android will not currently generate the Java code for this interface, add the following Java to your C# project:
+```java
+package mono.embeddinator.android;
+
+public interface IJavaCallback {
+    void send(String text);
+}
+```
+You can place the file anywhere, but make sure to set its build action to `AndroidJavaSource`. This will signal Embeddinator to copy it to the proper directory to get compiled into your AAR file.
+
+Next, the `Invoker` implementation will be quite the same:
+```csharp
+class IJavaCallbackInvoker : Java.Lang.Object, IJavaCallback
+{
+    IntPtr class_ref, id_send;
+
+    public IJavaCallbackInvoker(IntPtr handle, JniHandleOwnership transfer) : base(handle, transfer)
+    {
+        IntPtr lref = JNIEnv.GetObjectClass(Handle);
+        class_ref = JNIEnv.NewGlobalRef(lref);
+        JNIEnv.DeleteLocalRef(lref);
+    }
+
+    protected override Type ThresholdType
+    {
+        get { return typeof(IJavaCallbackInvoker); }
+    }
+
+    protected override IntPtr ThresholdClass
+    {
+        get { return class_ref; }
+    }
+
+    public void Send(string text)
+    {
+        if (id_send == IntPtr.Zero)
+            id_send = JNIEnv.GetMethodID(class_ref, "send", "(Ljava/lang/String;)V");
+        JNIEnv.CallVoidMethod(Handle, id_send, new JValue(new Java.Lang.String(text)));
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (class_ref != IntPtr.Zero)
+            JNIEnv.DeleteGlobalRef(class_ref);
+        class_ref = IntPtr.Zero;
+
+        base.Dispose(disposing);
+    }
+}
+```
+
+After generating an AAR file, in Android Studio we could write the following passing unit test:
+```java
+class ConcreteCallback implements IJavaCallback {
+    public String text;
+    @Override
+    public void send(String text) {
+        this.text = text;
+    }
+}
+
+@Test
+public void interfaceCallback() {
+    ConcreteCallback callback = new ConcreteCallback();
+    JavaCallbacks.interfaceCallback(callback, "Java");
+    assertEquals("Java", callback.text);
+}
+```
+
+## Virtual Methods
+
+Overriding a `virtual` in Java is possible, but not a great experience.
+
+Let's assume you have the following C# class:
+```csharp
+[Register("mono.embeddinator.android.VirtualClass")]
+public class VirtualClass : Java.Lang.Object
+{
+    public VirtualClass() { }
+
+    public VirtualClass(IntPtr handle, JniHandleOwnership transfer) : base(handle, transfer) { }
+
+    [Export("getText")]
+    public virtual string GetText() { return "C#"; }
+}
+```
+
+If you followed the `abstract` class example above, it would work except for one detail: _Xamarin.Android won't lookup the `Invoker`_.
+
+To fix this, modify the C# class to be `abstract`:
+```csharp
+public abstract class VirtualClass : Java.Lang.Object
+```
+This is not ideal, but it gets this scenario working. Xamarin.Android will pick up the `VirtualClassInvoker` and Java can use `@Override` on the method.
+
+## Callbacks in the Future
+
+There are a couple of things we could to do improve these scenarios:
+
+1. `throws Throwable` on C# constructors is fixed on this [PR](https://github.com/xamarin/java.interop/pull/170).
+1. Make the Java generator in Xamarin.Android support interfaces.
+    - This removes the need for adding Java source file with a build action of `AndroidJavaSource`.
+1. Make a way for Xamarin.Android to load an `Invoker` for virtual classes.
+    - This removes the need to mark the class in our `virtual` example `abstract`.
+1. Generate `Invoker` classes for Embeddinator automatically
+    - This is going to be complicated, but doable. Xamarin.Android is already doing something similar to this for Java binding projects.
+
+There is alot of work to be done here, but these enhancements to Embeddinator are possible.
+
+## Further Reading
+
+* [Getting Started on Android](getting-started-java-android.md)
+* [Preliminary Android Research](android-preliminary-research.md)
+* [Embeddinator Limitations](Limitations.md)
+* [Contributing to the open source project](Contributing.md)
+* [Error codes and descriptions](errors.md)

--- a/docs/getting-started-java-android.md
+++ b/docs/getting-started-java-android.md
@@ -197,6 +197,7 @@ Read more about Java integration with Xamarin.Android [here](https://developer.x
 
 ## Further Reading
 
+* [Callbacks on Android](android-callbacks.md)
 * [Preliminary Android Research](android-preliminary-research.md)
 * [Embeddinator Limitations](Limitations.md)
 * [Contributing to the open source project](Contributing.md)

--- a/docs/getting-started-java.md
+++ b/docs/getting-started-java.md
@@ -50,6 +50,7 @@ Android Studio is recommended for development, but other IDEs should work as lon
 ## Further Reading
 
 * [Getting Started on Android](getting-started-java-android.md)
+* [Callbacks on Android](android-callbacks.md)
 * [Preliminary Android Research](android-preliminary-research.md)
 * [Embeddinator Limitations](Limitations.md)
 * [Contributing to the open source project](Contributing.md)

--- a/tests/android/.idea/vcs.xml
+++ b/tests/android/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
+++ b/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
@@ -109,19 +109,44 @@ public class AndroidTests {
         assertNotNull(manager);
     }
 
-    String callbackResult;
+    @Test
+    public void virtualCallback() throws Throwable {
+        VirtualClass callback = new VirtualClass() {
+            @Override
+            public String getText() {
+                return "Java";
+            }
+        };
+
+        assertEquals("Java", callback.getText());
+        assertEquals("Java", JavaCallbacks.virtualCallback(callback));
+    }
+
+    @Test
+    public void abstractCallback() throws Throwable {
+        AbstractClass callback = new AbstractClass() {
+            @Override
+            public String getText() {
+                return "Java";
+            }
+        };
+
+        assertEquals("Java", callback.getText());
+        assertEquals("Java", JavaCallbacks.abstractCallback(callback));
+    }
+
+    class ConcreteCallback implements IJavaCallback {
+        public String text;
+        @Override
+        public void send(String text) {
+            this.text = text;
+        }
+    }
 
     @Test
     public void interfaceCallback() {
-        callbackResult = null;
-
-        JavaCallbacks.interfaceCallback(new IJavaCallback() {
-            @Override
-            public void send(String text) {
-                callbackResult = text;
-            }
-        }, "test");
-
-        assertEquals("test", callbackResult);
+        ConcreteCallback callback = new ConcreteCallback();
+        JavaCallbacks.interfaceCallback(callback, "test");
+        assertEquals("test", callback.text);
     }
 }

--- a/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
+++ b/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
@@ -108,4 +108,20 @@ public class AndroidTests {
         LocalBroadcastManager manager = AndroidAssertions.callIntoSupportLibrary();
         assertNotNull(manager);
     }
+
+    String callbackResult;
+
+    @Test
+    public void interfaceCallback() {
+        callbackResult = null;
+
+        JavaCallbacks.interfaceCallback(new IJavaCallback() {
+            @Override
+            public void send(String text) {
+                callbackResult = text;
+            }
+        }, "test");
+
+        assertEquals("test", callbackResult);
+    }
 }

--- a/tests/managed/android/Java/IJavaCallback.java
+++ b/tests/managed/android/Java/IJavaCallback.java
@@ -1,0 +1,5 @@
+package mono.embeddinator.android;
+
+public interface IJavaCallback {
+    void send(String text);
+}

--- a/tests/managed/android/android.cs
+++ b/tests/managed/android/android.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Net;
 using System.Threading.Tasks;
 using Android.App;
@@ -101,5 +101,22 @@ namespace Android
         {
             return LocalBroadcastManager.GetInstance(Application.Context);
         }
+    }
+
+    [Register("mono.embeddinator.android.JavaCallbacks")]
+    public class JavaCallbacks : Java.Lang.Object
+    {
+        [Export("interfaceCallback")]
+        public static void InterfaceCallback(IJavaCallback callback, string text)
+        {
+            callback.Send(text);
+        }
+    }
+
+    [Register("mono.embeddinator.android.IJavaCallback")]
+    public interface IJavaCallback : IJavaObject
+    {
+        [Export("send")]
+        void Send(string text);
     }
 }

--- a/tests/managed/android/android.cs
+++ b/tests/managed/android/android.cs
@@ -127,7 +127,7 @@ namespace Android
             return new IJavaCallbackInvoker(handle, transfer);
         }
 
-        IntPtr class_ref;
+        IntPtr class_ref, id_send;
 
         public IJavaCallbackInvoker(IntPtr handle, JniHandleOwnership transfer) : base(handle, transfer)
         {
@@ -145,8 +145,6 @@ namespace Android
         {
             get { return class_ref; }
         }
-
-        static IntPtr id_send;
 
         public void Send(string text)
         {

--- a/tests/managed/android/managed-android.csproj
+++ b/tests/managed/android/managed-android.csproj
@@ -77,12 +77,16 @@
   <ItemGroup>
     <Folder Include="Resources\layout\" />
     <Folder Include="Assets\" />
+    <Folder Include="Java\" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\test.txt" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidJavaSource Include="Java\IJavaCallback.java" />
   </ItemGroup>
   <Import Project="..\managed-shared.projitems" Label="Shared" Condition="Exists('..\managed-shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />


### PR DESCRIPTION
- Documented three options for callbacks: abstract classes, interfaces, and virtual methods
- Documented what we can do better in this area
- If a developer uses the `AndroidJavaSource` build action, Embeddinator will now include it to be compiled in the resulting AAR file
- Minor fix for VCS warning in Android Studio project
- Unit tests checking all three scenarios

Fixes #421 