### PR TITLE
[c] [java] fix for properties of type UnsupportedType

### DIFF
--- a/binder/Generators/C/CHeaders.cs
+++ b/binder/Generators/C/CHeaders.cs
@@ -165,7 +165,7 @@ namespace MonoEmbeddinator4000.Generators
 
         public override bool VisitProperty(Property property)
         {
-            if (property.Field == null)
+            if (property.Field == null || property.Type is UnsupportedType)
                 return false;
 
             var getter = property.GetMethod;

--- a/binder/Generators/C/CSources.cs
+++ b/binder/Generators/C/CSources.cs
@@ -399,7 +399,7 @@ namespace MonoEmbeddinator4000.Generators
 
         public override bool VisitProperty(Property property)
         {
-            if (property.Field == null)
+            if (property.Field == null || property.Type is UnsupportedType)
                 return false;
 
             GenerateFieldGetter(property);

--- a/binder/Generators/Java/JavaSources.cs
+++ b/binder/Generators/Java/JavaSources.cs
@@ -422,7 +422,7 @@ namespace MonoEmbeddinator4000.Generators
 
         public override bool VisitProperty(Property property)
         {
-            if (property.Field == null)
+            if (property.Field == null || property.Type is UnsupportedType)
                 return false;
 
             var getter = property.GetMethod;

--- a/tests/MonoEmbeddinator4000.Tests/DriverTest.cs
+++ b/tests/MonoEmbeddinator4000.Tests/DriverTest.cs
@@ -167,5 +167,19 @@ namespace MonoEmbeddinator4000.Tests
             var aar = Path.Combine(options.OutputDir, "Hello.aar");
             Approvals.VerifyZipFile(aar);
         }
+
+        /// <summary>
+        /// NOTE: C and Java generators were failing on a subclass of EventArgs due to EventArgs.Empty
+        /// </summary>
+        [Test, Category("Slow")]
+        public void EventArgsEmpty()
+        {
+            options.Compilation.Platform = TargetPlatform.Android;
+            options.GeneratorKind = GeneratorKind.C;
+            options.Compilation.DebugMode = true;
+            RunDriver("EventArgsEmpty");
+            options.GeneratorKind = GeneratorKind.Java;
+            RunDriver("EventArgsEmpty");
+        }
     }
 }

--- a/tests/MonoEmbeddinator4000.Tests/MonoEmbeddinator4000.Tests.csproj
+++ b/tests/MonoEmbeddinator4000.Tests/MonoEmbeddinator4000.Tests.csproj
@@ -93,6 +93,7 @@
     <EmbeddedResource Include="Samples\Resource.String.cs" />
     <EmbeddedResource Include="Samples\Hello.cs" />
     <EmbeddedResource Include="Samples\HelloUpper.cs" />
+    <EmbeddedResource Include="Samples\EventArgsEmpty.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/MonoEmbeddinator4000.Tests/Samples/EventArgsEmpty.cs
+++ b/tests/MonoEmbeddinator4000.Tests/Samples/EventArgsEmpty.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace MonoEmbeddinator4000.Tests
+{
+    public class EventArgsEmpty : EventArgs
+    {
+    }
+}


### PR DESCRIPTION
In testing various libraries, I’ve discovered a subclass of
`System.EventArgs` always breaks the C and Java generators. The
property `EventArgs.Empty` ends up as an `UnsupportedType`, which in
turn prints an empty string for its type.

Skipping these properties is a solution for now, it is at least better
than hitting a C or Java compiler error.

Changes:
- Added integration test that reproduces the issue
- C generator skips `UnsupportedType` for headers & sources
- Java generator skips `UnsupportedType`

Applies to #438 