### PR TITLE
[c] [java] fixes for C# enums

### DIFF
--- a/binder/Generators/AstGenerator.cs
+++ b/binder/Generators/AstGenerator.cs
@@ -209,6 +209,8 @@ namespace MonoEmbeddinator4000.Generators
                 @enum.AddItem(enumItem);
             }
 
+            ManagedNames[@enum] = type.FullName;
+
             return @enum;
         }
 

--- a/binder/Generators/Java/JavaMarshal.cs
+++ b/binder/Generators/Java/JavaMarshal.cs
@@ -74,7 +74,7 @@ namespace MonoEmbeddinator4000.Generators
             marshal = value;
 
             if (isEnum)
-                marshal = $"{@enum.Name}.fromOrdinal({value})";
+                marshal = $"{@enum.Visit(TypePrinter)}.fromOrdinal({value})";
 
             if (type == PrimitiveType.Bool)
                 marshal = $"{value} != 0";
@@ -158,7 +158,7 @@ namespace MonoEmbeddinator4000.Generators
 
         public override bool VisitEnumDecl(Enumeration @enum)
         {
-            Context.Return.Write($"{@enum.Name}.fromOrdinal({Context.ReturnVarName})");
+            Context.Return.Write($"{@enum.Visit(TypePrinter)}.fromOrdinal({Context.ReturnVarName})");
             return true;
         }
 

--- a/binder/Passes/GenerateObjectTypes.cs
+++ b/binder/Passes/GenerateObjectTypes.cs
@@ -43,6 +43,9 @@ namespace MonoEmbeddinator4000.Passes
             if (decl is TranslationUnit)
                 return false;
 
+            if (decl is Parameter || decl is Property)
+                return true;
+
             if (decl is Class || decl is Enumeration || decl is TypedefDecl)
                 Declarations.Add(decl);
 

--- a/tests/MonoEmbeddinator4000.Tests/DriverTest.cs
+++ b/tests/MonoEmbeddinator4000.Tests/DriverTest.cs
@@ -181,5 +181,16 @@ namespace MonoEmbeddinator4000.Tests
             options.GeneratorKind = GeneratorKind.Java;
             RunDriver("EventArgsEmpty");
         }
+
+        [Test, Category("Slow")]
+        public void Enums()
+        {
+            options.Compilation.Platform = TargetPlatform.Android;
+            options.GeneratorKind = GeneratorKind.C;
+            options.Compilation.DebugMode = true;
+            RunDriver("Enums");
+            options.GeneratorKind = GeneratorKind.Java;
+            RunDriver("Enums");
+        }
     }
 }

--- a/tests/MonoEmbeddinator4000.Tests/MonoEmbeddinator4000.Tests.csproj
+++ b/tests/MonoEmbeddinator4000.Tests/MonoEmbeddinator4000.Tests.csproj
@@ -94,6 +94,7 @@
     <EmbeddedResource Include="Samples\Hello.cs" />
     <EmbeddedResource Include="Samples\HelloUpper.cs" />
     <EmbeddedResource Include="Samples\EventArgsEmpty.cs" />
+    <EmbeddedResource Include="Samples\Enums.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/MonoEmbeddinator4000.Tests/Samples/Enums.cs
+++ b/tests/MonoEmbeddinator4000.Tests/Samples/Enums.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace MonoEmbeddinator4000.Tests.Samples
+{
+    public class Enums
+    {
+        public void SystemEnumParameter(StringComparison value) { }
+
+        public StringComparison SystemEnumProperty { get; set; }
+    }
+}


### PR DESCRIPTION
The following were generating invalid C and/or Java:
- C# method with an enum parameter from another assembly
- C# property that is an enum from another assembly

Changes:
- `AstGenerator.ManagedNames` should include enums
- `GenerateObjectTypes` should take parameters & properties into account
- Java - `Enum.fromOrdinal` should use full package name + type name

Applies to #438