### PR TITLE
[java] fixes for C# interfaces

### DIFF
--- a/binder/Generators/AstGenerator.cs
+++ b/binder/Generators/AstGenerator.cs
@@ -572,9 +572,14 @@ namespace MonoEmbeddinator4000.Generators
             //NOTE: if this is an explicit interface method, mark it public and modify the name
             if (methodBase.IsExplicitInterfaceMethod())
             {
-                method.Access = AccessSpecifier.Public;
-                method.OriginalName =
-                    method.Name = method.Name.Split('.').Last();
+                //We also need to check for collisions
+                string name = method.Name.Split('.').Last();
+                if (!methodBase.DeclaringType.GetMethods().Any(m => m.IsPublic && m.Name == name))
+                {
+                    method.Access = AccessSpecifier.Public;
+                    method.OriginalName =
+                        method.Name = name;
+                }
             }
 
             return method;

--- a/binder/Passes/InterfacesPass.cs
+++ b/binder/Passes/InterfacesPass.cs
@@ -64,7 +64,8 @@ namespace MonoEmbeddinator4000.Passes
 
             foreach (var method in methods)
             {
-                if (method.Name == "__getObject")
+                //NOTE: skip methods such as __getObject
+                if (method.IsImplicit)
                     continue;
 
                 var methodImpl = new Method(method)

--- a/binder/Passes/InterfacesPass.cs
+++ b/binder/Passes/InterfacesPass.cs
@@ -56,9 +56,17 @@ namespace MonoEmbeddinator4000.Passes
             var @base = new BaseClassSpecifier { Type = new TagType(@interface) };
             impl.Bases.Add(@base);
 
-            var methods = @interface.Declarations.Where(d => d is Method).Cast<Method>();
+            var methods = new List<Method>(@interface.Declarations.OfType<Method>());
+            foreach (var baseInterface in @interface.Bases)
+            {
+                methods.AddRange(baseInterface.Class.Declarations.OfType<Method>());
+            }
+
             foreach (var method in methods)
             {
+                if (method.Name == "__getObject")
+                    continue;
+
                 var methodImpl = new Method(method)
                 {
                     IsPure = false,

--- a/tests/MonoEmbeddinator4000.Tests/DriverTest.cs
+++ b/tests/MonoEmbeddinator4000.Tests/DriverTest.cs
@@ -192,5 +192,16 @@ namespace MonoEmbeddinator4000.Tests
             options.GeneratorKind = GeneratorKind.Java;
             RunDriver("Enums");
         }
+
+        [Test, Category("Slow")]
+        public void Interfaces()
+        {
+            options.Compilation.Platform = TargetPlatform.Android;
+            options.GeneratorKind = GeneratorKind.C;
+            options.Compilation.DebugMode = true;
+            RunDriver("Interfaces");
+            options.GeneratorKind = GeneratorKind.Java;
+            RunDriver("Interfaces");
+        }
     }
 }

--- a/tests/MonoEmbeddinator4000.Tests/MonoEmbeddinator4000.Tests.csproj
+++ b/tests/MonoEmbeddinator4000.Tests/MonoEmbeddinator4000.Tests.csproj
@@ -95,6 +95,7 @@
     <EmbeddedResource Include="Samples\HelloUpper.cs" />
     <EmbeddedResource Include="Samples\EventArgsEmpty.cs" />
     <EmbeddedResource Include="Samples\Enums.cs" />
+    <EmbeddedResource Include="Samples\Interfaces.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/MonoEmbeddinator4000.Tests/Samples/Interfaces.cs
+++ b/tests/MonoEmbeddinator4000.Tests/Samples/Interfaces.cs
@@ -29,5 +29,7 @@ namespace Example
         void IBase.Hello() { }
 
         void IConflict.Hello() { }
+
+        public void Hello() { }
     }
 }

--- a/tests/MonoEmbeddinator4000.Tests/Samples/Interfaces.cs
+++ b/tests/MonoEmbeddinator4000.Tests/Samples/Interfaces.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Example
+{
+    public interface IBase
+    {
+        void Hello();
+    }
+
+    public interface IMore : IBase
+    {
+        void World();
+    }
+}

--- a/tests/MonoEmbeddinator4000.Tests/Samples/Interfaces.cs
+++ b/tests/MonoEmbeddinator4000.Tests/Samples/Interfaces.cs
@@ -18,4 +18,16 @@ namespace Example
 
         void IMore.World() { }
     }
+
+    public interface IConflict
+    {
+        void Hello();
+    }
+
+    public class Conflicted : IBase, IConflict
+    {
+        void IBase.Hello() { }
+
+        void IConflict.Hello() { }
+    }
 }

--- a/tests/MonoEmbeddinator4000.Tests/Samples/Interfaces.cs
+++ b/tests/MonoEmbeddinator4000.Tests/Samples/Interfaces.cs
@@ -11,4 +11,11 @@ namespace Example
     {
         void World();
     }
+
+    public class MoreExplicit : IMore
+    {
+        void IBase.Hello() { }
+
+        void IMore.World() { }
+    }
 }


### PR DESCRIPTION
The following were generating invalid Java:
- C# interfaces extending a base interface
- C# methods that implement an interface explicitly

This broke things like:
- Many libraries have interface inheritance, especially things that extend `IDisposable`
- Xamarin.Forms has explicit interface methods on `VisualElement`, `Element`, and `BindableObject`

Changes:
- `InterfacesPass` needs to loop over any base interfaces
- `InterfacesPass` needs to include a check for `__getObject`, interface inheritance was causing this method to get generated multiple times
- Added `IsExplicitInterfaceMethod` extension method
- `AstGenerator` will now mark explicit interface methods as `public` and fix up the names -- *maybe not exactly ideal* but it works