### PR TITLE
[cake] delete unused Xamarin.Android files

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -157,6 +157,7 @@ Task("Run-C-Tests")
         Exec(binDir + File("common.Tests"));
     });
 
+//NOTE: this is a temporary task for downloading a Jenkins build of Xamarin.Android
 Task("Download-Xamarin-Android")
     .Does(() =>
     {
@@ -180,6 +181,18 @@ Task("Download-Xamarin-Android")
 
                 //Move bin/Release to final directory in ./external/Xamarin.Android
                 MoveDirectory(Directory(tempDir) + Directory("./bin/Release"), xamarinPath);
+
+                //There are some additional files we don't need for Embeddinator
+                //Removing them should make our distribution smaller 875.6MB -> 277.2MB (92.7MB compressed)
+                DeleteFiles(GetFiles("./external/Xamarin.Android/*"));
+                DeleteDirectory("./external/Xamarin.Android/bin", true);
+                DeleteDirectory("./external/Xamarin.Android/lib/mandroid", true);
+                foreach (var directory in GetDirectories("./external/Xamarin.Android/lib/xbuild-frameworks/MonoAndroid/*"))
+                {
+                    var name = directory.GetDirectoryName();
+                    if (!name.EndsWith("v1.0") && !name.EndsWith("v2.3") && !name.EndsWith("v7.0"))
+                        DeleteDirectory(directory, true);
+                }
             }
             finally
             {


### PR DESCRIPTION
- Right now for Android, we need to use a Jenkins build of
Xamarin.Android, so we have a Cake task that downloads and unzips
everything in the zip
- This is an improvement to delete unused files so if we make a preview
release, our bundled Xamarin.Android will not be quite so large