### PR TITLE
[java] [c] improvements to method/field collisions

### DIFF
--- a/binder/Driver.cs
+++ b/binder/Driver.cs
@@ -82,6 +82,8 @@ namespace MonoEmbeddinator4000
                 new GenerateObjectTypesPass(),
                 new GenerateArrayTypes(),
                 new CheckIgnoredDeclsPass { CheckDecayedTypes = false },
+                new RenameDuplicatedDeclsPass(),
+                new CheckDuplicatedNamesPass(),
                 new FieldToGetterSetterPropertyPass()
             });
 
@@ -90,8 +92,6 @@ namespace MonoEmbeddinator4000
             Context.TranslationUnitPasses.Passes.AddRange(new TranslationUnitPass[]
             {
                 new CheckReservedKeywords(),
-                new RenameDuplicatedDeclsPass(),
-                new CheckDuplicatedNamesPass()
             });
 
             Context.RunPasses();

--- a/binder/Generators/AstGenerator.cs
+++ b/binder/Generators/AstGenerator.cs
@@ -565,16 +565,16 @@ namespace MonoEmbeddinator4000.Generators
             method.IsStatic = methodBase.IsStatic;
             method.IsVirtual = methodBase.IsVirtual;
             method.IsPure = methodBase.IsAbstract;
-            //method.IsFinal = methodBase.IsFinal;
+
             var accessMask = (methodBase.Attributes & MethodAttributes.MemberAccessMask);
             method.Access = ConvertMemberAttributesToAccessSpecifier(accessMask);
 
             //NOTE: if this is an explicit interface method, mark it public and modify the name
-            if (methodBase.IsExplicitInterfaceMethod())
+            if (!methodBase.DeclaringType.IsAndroidSubclass() && methodBase.IsExplicitInterfaceMethod())
             {
                 //We also need to check for collisions
                 string name = method.Name.Split('.').Last();
-                if (!methodBase.DeclaringType.GetMethods().Any(m => m.IsPublic && m.Name == name))
+                if (!methodBase.DeclaringType.GetMethods().Any(m => m.IsPublic && !m.IsStatic && m.Name == name))
                 {
                     method.Access = AccessSpecifier.Public;
                     method.OriginalName =

--- a/binder/Passes/RenameDuplicatedDecls.cs
+++ b/binder/Passes/RenameDuplicatedDecls.cs
@@ -12,12 +12,12 @@ namespace MonoEmbeddinator4000.Passes
             if (!VisitDeclaration(@class))
                 return false;
 
-            var functions = @class.Functions.ToList();
+            var members = @class.Declarations.Where(d => d is Field || d is Function).ToList();
 
-            foreach (var func in functions)
+            foreach (var member in members)
             {
-                var duplicates = functions.FindAll (f => func.Name == f.Name);
-                duplicates.Remove (func);
+                var duplicates = members.FindAll(f => member.Name == f.Name || member.Name == "get_" + f.Name || member.Name == "set_" + f.Name);
+                duplicates.Remove(member);
 
                 if (duplicates.Count == 0)
                     continue;
@@ -25,8 +25,8 @@ namespace MonoEmbeddinator4000.Passes
                 for (int i = 0; i < duplicates.Count; ++i)
                 {
                     var duplicate = duplicates[i];
-                    duplicate.Name = string.Format("{0}_{1}", duplicate.Name, i+1);
-                    Diagnostics.Debug("Renamed {0}", duplicate.QualifiedName);
+                    duplicate.Name = string.Format("{0}_{1}", duplicate.Name, i + 1);
+                    Diagnostics.Debug("Renamed {0} {1}", duplicate.GetType().Name.ToLowerInvariant(), duplicate.QualifiedName);
                 }
             }
 

--- a/tests/MonoEmbeddinator4000.Tests/Samples/Interfaces.cs
+++ b/tests/MonoEmbeddinator4000.Tests/Samples/Interfaces.cs
@@ -21,7 +21,9 @@ namespace Example
 
     public interface IConflict
     {
-        string Test { get; }
+        string TestProperty { get; }
+
+        string TestField { get; }
 
         void Hello();
     }
@@ -34,14 +36,21 @@ namespace Example
 
         public void Hello() { }
 
-        string IConflict.Test
+        string IConflict.TestProperty
         {
-            get { return "IConflict.Test"; }
+            get { return "IConflict.TestProperty"; }
         }
 
-        public static string Test
+        public static string TestProperty
         {
-            get { return "Test"; }
+            get { return "TestProperty"; }
         }
+
+        string IConflict.TestField
+        {
+            get { return "IConflict.TestField"; }
+        }
+
+        public static string TestField = "TestField";
     }
 }

--- a/tests/MonoEmbeddinator4000.Tests/Samples/Interfaces.cs
+++ b/tests/MonoEmbeddinator4000.Tests/Samples/Interfaces.cs
@@ -21,6 +21,8 @@ namespace Example
 
     public interface IConflict
     {
+        string Test { get; }
+
         void Hello();
     }
 
@@ -31,5 +33,15 @@ namespace Example
         void IConflict.Hello() { }
 
         public void Hello() { }
+
+        string IConflict.Test
+        {
+            get { return "IConflict.Test"; }
+        }
+
+        public static string Test
+        {
+            get { return "Test"; }
+        }
     }
 }


### PR DESCRIPTION
Types of things that would break:
- static field named the same as an explicitly implemented interface member
- static property named the same as an explicitly implemented interface member

Such as:
```csharp
public interface IConflict
{
    string TestProperty { get; }

    string TestField { get; }
}

public class Conflicted : IConflict
{
    string IConflict.TestProperty
    {
        get { return "IConflict.TestProperty"; }
    }

    public static string TestProperty
    {
        get { return "TestProperty"; }
    }

    string IConflict.TestField
    {
        get { return "IConflict.TestField"; }
    }

    public static string TestField = "TestField";
}
```

Changes:
- Reordered passes a bit, so `FieldToGetterSetterPropertyPass` runs after any renaming
- Account for `IsStatic` when checking explicit interfaces in `AstGenerator`
- `RenameDuplicatedDecls` works for fields and methods
- Test cases
- Applies to #438 