### PR TITLE
[java] Implemented support for marshaling unsigned integer types.

### DIFF
--- a/tests/common/java/mono/embeddinator/Tests.java
+++ b/tests/common/java/mono/embeddinator/Tests.java
@@ -139,6 +139,22 @@ public class Tests {
         assertTrue(b.get());
         assertEquals(null, s.get());
 
+        Ref<UnsignedByte> refUChar = new Ref<UnsignedByte>(new UnsignedByte(1));
+        Parameters.refUnsignedCharPlusOne(refUChar);
+        assertEquals(2, refUChar.get().intValue());
+
+        Ref<UnsignedShort> refUShort = new Ref<UnsignedShort>(new UnsignedShort(1));
+        Parameters.refUnsignedShortPlusOne(refUShort);
+        assertEquals(2, refUShort.get().intValue());
+
+        Ref<UnsignedInt> refUInt = new Ref<UnsignedInt>(new UnsignedInt(1));
+        Parameters.refUnsignedIntPlusOne(refUInt);
+        assertEquals(2, refUInt.get().intValue());
+
+        Ref<UnsignedLong> refULong = new Ref<UnsignedLong>(new UnsignedLong(1));
+        Parameters.refUnsignedLongPlusOne(refULong);
+        assertEquals(2, refULong.get().intValue());
+
         Out<Integer> l = new Out<Integer>();
         Out<String> os = new Out<String>();
         Parameters.out(null, l, os);

--- a/tests/managed/methods.cs
+++ b/tests/managed/methods.cs
@@ -38,6 +38,26 @@ namespace Methods {
 			@string = @string == null ? "hello" : null;
 		}
 
+		public static void RefUnsignedCharPlusOne (ref byte val)
+		{
+			val++;
+		}
+
+		public static void RefUnsignedShortPlusOne (ref ushort val)
+		{
+			val++;
+		}
+
+		public static void RefUnsignedIntPlusOne (ref uint val)
+		{
+			val++;
+		}
+
+		public static void RefUnsignedLongPlusOne (ref ulong val)
+		{
+			val++;
+		}
+
 		public static void Out (string @string, out int length, out string upper)
 		{
 			length = @string == null ? 0 : @string.Length;


### PR DESCRIPTION
Managed type parameters like `ref byte val` were generating broken Java code.

These now are supported and generate working code.