### PR TITLE
[utils] FindDirectory should also find paths relative to exe

### DIFF
--- a/binder/Utils/Utils.cs
+++ b/binder/Utils/Utils.cs
@@ -76,12 +76,27 @@ namespace MonoEmbeddinator4000
 
         public static string FindDirectory(string dir)
         {
-            for (int i = 0; i <= 3; i++)
-            {
-                if (Directory.Exists(dir))
-                    return Path.GetFullPath(dir);
+            const int searchDepth = 3;
 
-                dir = Path.Combine("..", dir);
+            //Try searching from path of assembly
+            string assemblyDir = Path.GetDirectoryName(typeof(Helpers).Assembly.Location);
+            for (int i = 0; i <= searchDepth; i++)
+            {
+                string searchDir = Path.Combine(assemblyDir, dir);
+                if (Directory.Exists(searchDir))
+                    return Path.GetFullPath(searchDir);
+
+                assemblyDir = Path.Combine(assemblyDir, "..");
+            }
+
+            //Try searching from current directory
+            string currentDir = dir;
+            for (int i = 0; i <= searchDepth; i++)
+            {
+                if (Directory.Exists(currentDir))
+                    return Path.GetFullPath(currentDir);
+
+                currentDir = Path.Combine("..", currentDir);
             }
 
             throw new Exception($"Cannot find {Path.GetFileName(dir)}!");

--- a/tests/MonoEmbeddinator4000.Tests/HelpersTests.cs
+++ b/tests/MonoEmbeddinator4000.Tests/HelpersTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+
+namespace MonoEmbeddinator4000.Tests
+{
+    [TestFixture]
+    public class HelpersTests : TempFileTest
+    {
+        string currentDirectory;
+        string testDirectory;
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            currentDirectory = Environment.CurrentDirectory;
+
+            testDirectory = Path.Combine(Path.GetDirectoryName(GetType().Assembly.Location), "test");
+            if (!Directory.Exists(testDirectory))
+                Directory.CreateDirectory(testDirectory);
+            Environment.CurrentDirectory = testDirectory;
+
+            tempFiles = new List<string> { testDirectory };
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+
+            Environment.CurrentDirectory = currentDirectory;
+        }
+
+        [Test]
+        public void FindInCurrentDirectory()
+        {
+            Directory.CreateDirectory("foo");
+
+            DirectoryAssert.Exists(Helpers.FindDirectory("foo"));
+        }
+
+        [Test]
+        public void FindAboveCurrentDirectory()
+        {
+            Directory.CreateDirectory("foo");
+            Directory.CreateDirectory("bar");
+            Environment.CurrentDirectory = Path.Combine(Environment.CurrentDirectory, "bar");
+
+            DirectoryAssert.Exists(Helpers.FindDirectory("foo"));
+        }
+
+        [Test]
+        public void FindRelativeToAssembly()
+        {
+            Environment.CurrentDirectory = Path.GetTempPath();
+
+            DirectoryAssert.Exists(Helpers.FindDirectory("test"));
+        }
+    }
+}

--- a/tests/MonoEmbeddinator4000.Tests/MonoEmbeddinator4000.Tests.csproj
+++ b/tests/MonoEmbeddinator4000.Tests/MonoEmbeddinator4000.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Helpers\UniverseTest.cs" />
     <Compile Include="Helpers\TempFileTest.cs" />
     <Compile Include="Helpers\CurrentDirectoryTest.cs" />
+    <Compile Include="HelpersTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Samples\" />


### PR DESCRIPTION
- If distributed through NuGet, Embeddinator has trouble locating the
`external` or `support` directories, because it searches via the
current directory
- `FindDirectory` now searches from the exe path first, then tries the
current directory
- Added some quick “unit” tests