### PR TITLE
[android] fix for Mono.Cecil to resolve assemblies

### DIFF
--- a/binder/Utils/XamarinAndroidBuild.cs
+++ b/binder/Utils/XamarinAndroidBuild.cs
@@ -270,11 +270,13 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
         {
             var assembliesDir = Path.Combine(outputDirectory, "android", "assets", "assemblies");
             var jniDir = Path.Combine(outputDirectory, "android", "jni");
+            var resolver = new DefaultAssemblyResolver();
+            resolver.AddSearchDirectory(assembliesDir);
 
             foreach (var assemblyFile in Directory.GetFiles(assembliesDir, "*.dll"))
             {
                 var assemblyModified = false;
-                var assembly = AssemblyDefinition.ReadAssembly(assemblyFile);
+                var assembly = AssemblyDefinition.ReadAssembly(assemblyFile, new ReaderParameters { AssemblyResolver = resolver });
 
                 foreach (var module in assembly.Modules)
                 {


### PR DESCRIPTION
In testing E4K, I found certain projects could cause an exception if
Mono.Cecil needed to load a dependent assembly during
`XamarinAndroidBuild.ProcessAssemblies`.

The fix for this is to use the `DefaultAssemblyResolver` and add a
proper search path.