### PR TITLE
[android] fix for locating MSBuild on Windows

### DIFF
--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -428,8 +428,7 @@ namespace MonoEmbeddinator4000
 
         bool MSBuild(string project)
         {
-            var msbuild = Platform.IsWindows ? "MSBuild.exe" : "/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild";
-            var output = Invoke(msbuild, $"/nologo /verbosity:minimal {project}");
+            var output = Invoke(XamarinAndroid.MSBuildPath, $"/nologo /verbosity:minimal {project}");
             return output.ExitCode == 0;
         }
 

--- a/binder/Utils/XamarinAndroid.cs
+++ b/binder/Utils/XamarinAndroid.cs
@@ -1,7 +1,8 @@
 using System;
-using System.Linq;
 using System.IO;
+using System.Linq;
 using CppSharp;
+using Microsoft.Win32;
 using Xamarin.Android.Tools;
 using static System.IO.Path;
 
@@ -143,6 +144,28 @@ namespace MonoEmbeddinator4000
         public static string JavaSdkPath
         {
             get { return javaSdkPath.Value; }
+        }
+
+        static Lazy<string> msBuildPath = new Lazy<string>(() =>
+        {
+            if (Platform.IsMacOS)
+                return "/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild";
+
+            if (Platform.IsWindows)
+            {
+                using (var registryKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\MSBuild\ToolsVersions\4.0"))
+                {
+                    string path = registryKey.GetValue("MSBuildToolsPath", string.Empty).ToString();
+                    return Combine(path, "MSBuild.exe");
+                }
+            }
+
+            throw new NotImplementedException();
+        });
+
+        public static string MSBuildPath
+        {
+            get { return msBuildPath.Value; }
         }
     }
 }

--- a/binder/Utils/XamarinAndroid.cs
+++ b/binder/Utils/XamarinAndroid.cs
@@ -1,8 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using CppSharp;
-using Microsoft.Win32;
 using Xamarin.Android.Tools;
 using static System.IO.Path;
 
@@ -153,11 +153,11 @@ namespace MonoEmbeddinator4000
 
             if (Platform.IsWindows)
             {
-                using (var registryKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\MSBuild\ToolsVersions\4.0"))
-                {
-                    string path = registryKey.GetValue("MSBuildToolsPath", string.Empty).ToString();
-                    return Combine(path, "MSBuild.exe");
-                }
+                List<ToolchainVersion> toolchains;
+                if (!MSVCToolchain.GetMSBuildSdks(out toolchains))
+                    return "MSBuild.exe";
+
+                return Combine(toolchains.OrderByDescending(t => t.Version).Select(t => t.Directory).First(), "MSBuild.exe");
             }
 
             throw new NotImplementedException();

--- a/tests/MonoEmbeddinator4000.Tests/XamarinAndroidTest.cs
+++ b/tests/MonoEmbeddinator4000.Tests/XamarinAndroidTest.cs
@@ -113,5 +113,13 @@ namespace MonoEmbeddinator4000.Tests
             string file = Path.Combine(XamarinAndroid.PlatformDirectory, "android.jar");
             FileAssert.Exists(file);
         }
+
+        [Test]
+        public void MSBuild()
+        {
+            string msbuild = XamarinAndroid.MSBuildPath;
+            var output = Helpers.Invoke(msbuild, "/version");
+            Assert.AreEqual(0, output.ExitCode);
+        }
     }
 }


### PR DESCRIPTION
In updating the documentation for Embeddinator-4000, I found that `MSBuild.exe` was not found in `PATH` if trying to run Embeddinator as a post-build event inside Visual Studio.

A little research, and I found it is recommended to lookup the registry key `HKLM\SOFTWARE\Microsoft\MSBuild\ToolsVersions\4.0\MSBuildToolsPath` for finding `MSBuild.exe`.

This fix allows these commands to work inside VS:
```
set E4K_OUTPUT="$(SolutionDir)output"
if exist %E4K_OUTPUT% rmdir /S /Q %E4K_OUTPUT%
"$(SolutionDir)packages\Embeddinator-4000.0.2.0.80\tools\Embeddinator-4000.exe" "$(TargetPath)" --gen=Java --platform=Android --outdir=%E4K_OUTPUT% -c
```