### PR TITLE
Fix build.cake for Linux. Usually there is no /usr/libexec/hava_home on Linux.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -20,7 +20,7 @@ if (IsRunningOnWindows())
     if (string.IsNullOrEmpty(javaHome))
         throw new Exception("Cannot find Java SDK: JAVA_HOME environment variable is not set.");
 }
-else
+else if (FileExists("/usr/libexec/java_home"))
 {
     using (var process = StartAndReturnProcess("/usr/libexec/java_home", new ProcessSettings { RedirectStandardOutput = true }))
     {
@@ -28,6 +28,10 @@ else
 
         javaHome = process.GetStandardOutput().First().Trim();
     }
+}
+else
+{
+    javaHome = EnvironmentVariable("JAVA_HOME");
 }
 
 var classPath = string.Join(IsRunningOnWindows() ? ";" : ":", new[]


### PR DESCRIPTION
This is not the only build failure I'm seeing, but this is obviously wrong.