### PR TITLE
[android] reference all assemblies for resource.designer.cs compilation

### DIFF
--- a/binder/Utils/ResourceDesignerGenerator.cs
+++ b/binder/Utils/ResourceDesignerGenerator.cs
@@ -229,7 +229,10 @@ namespace MonoEmbeddinator4000
             parameters.ReferencedAssemblies.Add(XamarinAndroid.FindAssembly("System.Runtime.dll"));
             parameters.ReferencedAssemblies.Add(XamarinAndroid.FindAssembly("Java.Interop.dll"));
             parameters.ReferencedAssemblies.Add(XamarinAndroid.FindAssembly("Mono.Android.dll"));
-            parameters.ReferencedAssemblies.Add(MainAssembly);
+            foreach (var assembly in Assemblies)
+            {
+                parameters.ReferencedAssemblies.Add(assembly.Location);
+            }
 
             var results = csc.CompileAssemblyFromDom(parameters, unit);
             if (results.Errors.HasErrors)


### PR DESCRIPTION
As there can be more than one Xamarin Android assemblies with resources as e4k input, so make sense to compile resource.designer.cs with all assemblies, not only main one.