### PR TITLE
[android] improvements to include JAR file dependencies

### DIFF
--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -231,9 +231,16 @@ namespace MonoEmbeddinator4000
                 XamarinAndroidBuild.ExtractJar(monoAndroidJar, classesDir);
 
                 //Look for other JAR file dependencies from the user's assemblies
-                foreach(var dependency in Directory.GetFiles(Path.Combine(Options.OutputDir, XamarinAndroidBuild.IntermediateDir), "*.jar", SearchOption.AllDirectories))
+                foreach(var assembly in Assemblies)
                 {
-                    XamarinAndroidBuild.ExtractJar(dependency, classesDir);
+                    var intermediateDir = Path.Combine(Options.OutputDir, XamarinAndroidBuild.IntermediateDir, Path.GetFileNameWithoutExtension(assembly.Location));
+                    if (Directory.Exists(intermediateDir))
+                    {
+                        foreach (var dependency in Directory.GetFiles(intermediateDir, "*.jar", SearchOption.AllDirectories))
+                        {
+                            XamarinAndroidBuild.ExtractJar(dependency, classesDir);
+                        }
+                    }
                 }
             }
 

--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -217,9 +217,10 @@ namespace MonoEmbeddinator4000
             }
 
             //Embed JNA into our jar file
+            //  If on Android, we do not need any native libraries
             var jnaJar = Path.Combine(FindDirectory("external"), "jna", "jna-4.4.0.jar");
             var filter = Options.Compilation.Platform == TargetPlatform.Android ?
-                         entry => !entry.Name.EndsWith(".so", StringComparison.Ordinal) :
+                         entry => entry.Name.EndsWith(".class", StringComparison.Ordinal) :
                          default(Func<ZipArchiveEntry, bool>);
             XamarinAndroidBuild.ExtractJar(jnaJar, classesDir, filter);
 

--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -217,105 +217,22 @@ namespace MonoEmbeddinator4000
             }
 
             //Embed JNA into our jar file
-            using (var stream = File.OpenRead(Path.Combine(FindDirectory("external"), "jna", "jna-4.4.0.jar")))
-            using (var zip = new ZipArchive(stream))
-            {
-                foreach (var entry in zip.Entries)
-                {
-                    //Skip META-INF
-                    if (entry.FullName.StartsWith("META-INF", StringComparison.Ordinal))
-                        continue;
-
-                    var entryPath = Path.Combine(classesDir, entry.FullName);
-
-                    if (string.IsNullOrEmpty(entry.Name))
-                    {
-                        if (!Directory.Exists(entryPath))
-                            Directory.CreateDirectory(entryPath);
-                    }
-                    else
-                    {
-                        //NOTE: *.so files on Android will be packaged in a different way
-                        if (Options.Compilation.Platform == TargetPlatform.Android && entry.Name.EndsWith(".so", StringComparison.Ordinal))
-                        {
-                            continue;
-                        }
-
-                        using (var zipEntryStream = entry.Open())
-                        using (var fileStream = File.Create(entryPath))
-                        {
-                            zipEntryStream.CopyTo(fileStream);
-                        }
-                    }
-                }
-            }
+            var jnaJar = Path.Combine(FindDirectory("external"), "jna", "jna-4.4.0.jar");
+            var filter = Options.Compilation.Platform == TargetPlatform.Android ?
+                         entry => !entry.Name.EndsWith(".so", StringComparison.Ordinal) :
+                         default(Func<ZipArchiveEntry, bool>);
+            XamarinAndroidBuild.ExtractJar(jnaJar, classesDir, filter);
 
             //Embed mono.android.jar into our jar file
             if (Options.Compilation.Platform == TargetPlatform.Android)
             {
-                using (var stream = File.OpenRead(XamarinAndroid.FindAssembly("mono.android.jar")))
-                using (var zip = new ZipArchive(stream))
-                {
-                    foreach (var entry in zip.Entries)
-                    {
-                        //Skip META-INF
-                        if (entry.FullName.StartsWith("META-INF", StringComparison.Ordinal))
-                            continue;
-
-                        var entryPath = Path.Combine(classesDir, entry.FullName);
-
-                        if (string.IsNullOrEmpty(entry.Name))
-                        {
-                            if (!Directory.Exists(entryPath))
-                                Directory.CreateDirectory(entryPath);
-                        }
-                        else
-                        {
-                            using (var zipEntryStream = entry.Open())
-                            using (var fileStream = File.Create(entryPath))
-                            {
-                                zipEntryStream.CopyTo(fileStream);
-                            }
-                        }
-                    }
-                }
+                var monoAndroidJar = XamarinAndroid.FindAssembly("mono.android.jar");
+                XamarinAndroidBuild.ExtractJar(monoAndroidJar, classesDir);
 
                 //Look for other JAR file dependencies from the user's assemblies
                 foreach(var dependency in Directory.GetFiles(Path.Combine(Options.OutputDir, XamarinAndroidBuild.IntermediateDir), "*.jar", SearchOption.AllDirectories))
                 {
-                    Diagnostics.Warning("Jar File: {0}", dependency);
-
-                    using (var stream = File.OpenRead(dependency))
-                    using (var zip = new ZipArchive(stream))
-                    {
-                        foreach (var entry in zip.Entries)
-                        {
-                            //Skip META-INF
-                            if (entry.FullName.StartsWith("META-INF", StringComparison.Ordinal))
-                                continue;
-
-                            var entryPath = Path.Combine(classesDir, entry.FullName);
-
-                            if (string.IsNullOrEmpty(entry.Name))
-                            {
-                                if (!Directory.Exists(entryPath))
-                                    Directory.CreateDirectory(entryPath);
-                            }
-                            else
-                            {
-                                //NOTE: not all JAR files have directory entries such as FormsViewGroup.jar
-                                var directoryPath = Path.GetDirectoryName(entryPath);
-                                if (!Directory.Exists(directoryPath))
-                                    Directory.CreateDirectory(directoryPath);
-
-                                using (var zipEntryStream = entry.Open())
-                                using (var fileStream = File.Create(entryPath))
-                                {
-                                    zipEntryStream.CopyTo(fileStream);
-                                }
-                            }
-                        }
-                    }
+                    XamarinAndroidBuild.ExtractJar(dependency, classesDir);
                 }
             }
 


### PR DESCRIPTION
If trying to run Embeddinator on a Xamarin.Forms app, you would have to include `FormsViewGroup.jar` manually to your Android Studio project. This PR enables you to pass `FormsViewGroup.dll` as input to Embeddinator so it will get included in the AAR package.

Changes:
- Look for JAR files from input .NET assemblies
- Refactored to create an `ExtractJar` method, since we do this a lot now
- Found we were including some native libraries from JNA that are not needed on Android. Removing them saved about 600K of file size from the AAR package