### PR TITLE
NameGenerator now honors the RegisterAttribute

### DIFF
--- a/objcgen/NameGenerator.cs
+++ b/objcgen/NameGenerator.cs
@@ -53,6 +53,12 @@ namespace ObjC {
 
 		public static string GetObjCName (Type t)
 		{
+			if (t.IsClass) {
+				var ra = t.GetCustomAttributesData ().SingleOrDefault (a => a.AttributeType.Name.Equals ("RegisterAttribute"));
+				if (ra != null) {
+					return ra.ConstructorArguments.First ().Value.ToString ();
+				}                
+			}
 			return t.FullName.Replace ('.', '_').Replace ("+", "_");
 		}
 


### PR DESCRIPTION
Resolves mono/Embeddinator-4000#481 by allowing users to override
the generated objc class name by decorating their managed class
with the RegisterAttribute.