### PR TITLE
[mono_emebddinator.c] Fix get_current_executable_path() on Linux.

### DIFF
--- a/support/mono_embeddinator.c
+++ b/support/mono_embeddinator.c
@@ -157,7 +157,9 @@ static GString* get_current_executable_path()
 
     return (ret > 0) ? g_string_new(pathbuf) : 0;
 #else
-    g_assert_not_reached();
+    char pathbuf[1024];
+    ssize_t ret = readlink("/proc/self/exe", pathbuf, sizeof(pathbuf));
+    return ret > 0 ? g_string_new(pathbuf) : 0;
 #endif
 }
 


### PR DESCRIPTION
It can be implemented with /proc/self/exe.