### PR TITLE
Extend unmangle type name method to respect F# naming features.

### DIFF
--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -442,6 +442,7 @@ namespace Embeddinator
                 $"-I\"{monoPath}\\include\\mono-2.0\"",
                 string.Join(" ", files.Select(file => "\""+ Path.GetFullPath(file) + "\"")),
                 $"\"{GetSgenLibPath(monoPath)}\"",
+                "/utf-8",
                 Options.Compilation.CompileSharedLibrary ? "/LD" : string.Empty,
                 $"/Fe{outputPath}"
             };

--- a/binder/Generators/AstGenerator.cs
+++ b/binder/Generators/AstGenerator.cs
@@ -6,6 +6,7 @@ using CppSharp.AST;
 using CppSharp.AST.Extensions;
 using CppSharp.Generators;
 using IKVM.Reflection;
+using System.Text.RegularExpressions;
 
 namespace Embeddinator.Generators
 {
@@ -120,8 +121,8 @@ namespace Embeddinator.Generators
 
         static string UnmangleTypeName(string name)
         {
-            return string.IsNullOrEmpty(name) ? string.Empty :
-                         name.Replace(new char[] {'`', '<', '>' }, "_");
+            return string.IsNullOrEmpty(name) ? string.Empty :  
+                Regex.Replace(name, @"[^\p{L}]+", "_");
         }
 
         public void HandleBaseType(IKVM.Reflection.Type type, Class @class)


### PR DESCRIPTION
Would be worth to add an test for this...

~In short, we assume that _no white-spaces_ are allowed in _declaration names_. Therefore every white-space is replaced with an underscore.~

F# allows to make really strange variable names through using two backticks:
```fsharp
let ``supercrazyvarname 2345$"§"&/%43)=%4ß?\`` = 1
```

Signed-off-by: realvictorprm <mueller.vpr@gmail.com>