### PR TITLE
Adding support for class type arrays, fix #496

### DIFF
--- a/binder/Generators/AstGenerator.cs
+++ b/binder/Generators/AstGenerator.cs
@@ -422,7 +422,7 @@ namespace Embeddinator.Generators
                 }
                 else if (managedType.IsArray)
                 {
-                    if (elementType.Type.IsClass() || Options.GeneratorKind == GeneratorKind.Java)
+                    if (Options.GeneratorKind == GeneratorKind.Java)
                         return new QualifiedType(new UnsupportedType { Description = managedType.FullName });
 
                     var array = new ArrayType

--- a/binder/Generators/C/CMarshal.cs
+++ b/binder/Generators/C/CMarshal.cs
@@ -66,6 +66,8 @@ namespace Embeddinator.Generators
 
             typePrinter.PrintScopeKind = TypePrintScopeKind.Qualified;
             var arrayElementName = array.Array.Type.Visit(typePrinter);
+            if (array.Array.Type.IsClass())
+                arrayElementName += "*";
             var elementSize = $"sizeof({arrayElementName})";
     
             var nativeArrayId = CGenerator.GenId($"{Context.ArgName}_native_array");
@@ -359,9 +361,12 @@ namespace Embeddinator.Generators
             string elementTypeName = elementType.Visit(typePrinter);
 
             var elementId = CGenerator.GenId($"{Context.ArgName}_array_element");
-            support.WriteLine("{0} {1} = g_array_index({2}.array, {0}, {3});",
-                elementTypeName, elementId, Context.ArgName, iteratorId);
-
+            if (elementType.IsClass())
+                support.WriteLine("{0}* {1} = &(g_array_index({2}.array, {0}, {3}));",
+                    elementTypeName, elementId, Context.ArgName, iteratorId);
+            else
+                support.WriteLine("{0} {1} = g_array_index({2}.array, {0}, {3});",
+                    elementTypeName, elementId, Context.ArgName, iteratorId);
             var ctx = new MarshalContext(Context.Context)
             {
                 ArgName = elementId,

--- a/binder/Generators/C/CMarshal.cs
+++ b/binder/Generators/C/CMarshal.cs
@@ -362,7 +362,7 @@ namespace Embeddinator.Generators
 
             var elementId = CGenerator.GenId($"{Context.ArgName}_array_element");
             if (elementType.IsClass())
-                support.WriteLine("{0}* {1} = &(g_array_index({2}.array, {0}, {3}));",
+                support.WriteLine("{0}* {1} = g_array_index({2}.array, {0}*, {3});",
                     elementTypeName, elementId, Context.ArgName, iteratorId);
             else
                 support.WriteLine("{0} {1} = g_array_index({2}.array, {0}, {3});",

--- a/binder/Generators/C/CMarshal.cs
+++ b/binder/Generators/C/CMarshal.cs
@@ -93,12 +93,13 @@ namespace Embeddinator.Generators
             
             if (CMarshalNativeToManaged.IsValueType(array.Array.Type))
             {
+                var addressId = $"mono_array_addr_with_size({arrayId}, {elementSizeId}, {iteratorId})";
                 if (array.Array.Type.IsClass())
-                    support.WriteLine("MonoObject* {0} = mono_value_box({1}.domain, {2}, mono_array_addr_with_size({3}, {4}, {5}));",
-                        elementId, CGenerator.GenId("mono_context"), elementClassId, arrayId, elementSizeId, iteratorId);
+                    support.WriteLine("MonoObject* {0} = mono_value_box({1}.domain, {2}, {3});",
+                        elementId, CGenerator.GenId("mono_context"), elementClassId, addressId);
                 else
-                    support.WriteLine("char* {0} = mono_array_addr_with_size({1}, {2}, {3});",
-                        elementId, arrayId, elementSizeId, iteratorId);
+                    support.WriteLine("char* {0} = {1};",
+                        elementId, addressId);
             }
             else
                 support.WriteLine("MonoObject* {0} = *(MonoObject**) mono_array_addr_with_size({1}, {2}, {3});",
@@ -407,9 +408,8 @@ namespace Embeddinator.Generators
                     support.WriteLine("char* {0} = {1};", srcId, marshal.Context.Return.ToString());
                     support.WriteLine("char* {0} = mono_array_addr_with_size({1}, {2}, {3});", 
                         ptrId, arrayId, elementSizeId, iteratorId);
-                    var subIteratorId = CGenerator.GenId("i");
                     support.WriteLine("memcpy({0}, {1}, {2});",
-                                      ptrId, srcId, elementSizeId);
+                        ptrId, srcId, elementSizeId);
                 }
                 else
                     support.WriteLine("mono_array_set({0}, {1}, {2}, {3});",

--- a/tests/common/Tests.C.cpp
+++ b/tests/common/Tests.C.cpp
@@ -428,6 +428,12 @@ TEST_CASE("Arrays.C", "[C][Arrays]") {
         Arrays_ValueHolder* value = g_array_index(valueHoldersArray.array, Arrays_ValueHolder*, i);
         REQUIRE(Arrays_ValueHolder_get_IntValue(value) == (i + 1));
     }
+    _Arrays_ValueHolderArray resultArray = Arrays_Arr_ValueHolderArrMethod_1(arr, valueHoldersArray);
+    REQUIRE(resultArray.array->len == 3);
+    for (uint32_t i = 0; i < resultArray.array->len; i++) {
+        Arrays_ValueHolder* value = g_array_index(resultArray.array, Arrays_ValueHolder*, i);
+        REQUIRE(Arrays_ValueHolder_get_IntValue(value) == (i + 1));
+    }
 }
 
 TEST_CASE("FSharpTypes.C", "[C][FSharp Types]") {

--- a/tests/common/Tests.C.cpp
+++ b/tests/common/Tests.C.cpp
@@ -420,6 +420,14 @@ TEST_CASE("Arrays.C", "[C][Arrays]") {
 
     Arrays_Enum _last = Arrays_Arr_EnumArrayLast(_enum);
     REQUIRE(_last == Arrays_Enum_C);
+    
+    Arrays_Arr* arr = Arrays_Arr_new();
+    _Arrays_ValueHolderArray valueHoldersArray = Arrays_Arr_get_ValueHolderArr(arr);
+    REQUIRE(valueHoldersArray.array->len == 3);
+    for (uint32_t i = 0; i < valueHoldersArray.array->len; i++) {
+        Arrays_ValueHolder* value = g_array_index(valueHoldersArray.array, Arrays_ValueHolder*, i);
+        REQUIRE(Arrays_ValueHolder_get_IntValue(value) == (i + 1));
+    }
 }
 
 TEST_CASE("FSharpTypes.C", "[C][FSharp Types]") {
@@ -427,6 +435,13 @@ TEST_CASE("FSharpTypes.C", "[C][FSharp Types]") {
     REQUIRE(strcmp(managed_UserRecord_get_UserDescription(userRecord), "Test") == 0);
     managed_UserRecord* defaultUserRecord = managed_FSharp_getDefaultUserRecord();
     REQUIRE(strcmp(managed_UserRecord_get_UserDescription(defaultUserRecord), "Cherry") == 0);
+    _Managed_UserRecordArray userRecordArray = managed_ArrayTest_getDefaultUserRecordArray(10);
+    uint32_t length = userRecordArray.array->len;
+    REQUIRE(length == 10);
+    for(uint32_t i = 0; i < length; i++){
+        managed_UserRecord* entry = g_array_index(userRecordArray.array, managed_UserRecord*, i);
+        REQUIRE(strcmp(managed_UserRecord_get_UserDescription(entry), "Cherry") == 0);
+    }
 }
 
 TEST_CASE("FSharpModules.C", "[C][FSharp Modules]") {

--- a/tests/common/Tests.C.cpp
+++ b/tests/common/Tests.C.cpp
@@ -434,6 +434,18 @@ TEST_CASE("Arrays.C", "[C][Arrays]") {
         Arrays_ValueHolder* value = g_array_index(resultArray.array, Arrays_ValueHolder*, i);
         REQUIRE(Arrays_ValueHolder_get_IntValue(value) == (i + 1));
     }
+    _Arrays_ValueTypeArray valueTypeArray = Arrays_Arr_ValueTypeArrMethod(arr);
+    REQUIRE(valueTypeArray.array->len == 3);
+    for (uint32_t i = 0; i < valueTypeArray.array->len; i++) {
+        Arrays_ValueType* value = g_array_index(valueTypeArray.array, Arrays_ValueType*, i);
+        REQUIRE(Arrays_ValueType_get_IntValue(value) == (i + 1));
+    }
+    _Arrays_ValueTypeArray resultValueTypeArray = Arrays_Arr_ValueTypeArrMethod_1(arr, valueTypeArray);
+    REQUIRE(resultValueTypeArray.array->len == 3);
+    for (uint32_t i = 0; i < resultValueTypeArray.array->len; i++) {
+        Arrays_ValueType* value = g_array_index(resultValueTypeArray.array, Arrays_ValueType*, i);
+        REQUIRE(Arrays_ValueType_get_IntValue(value) == (i + 1));
+    }
 }
 
 TEST_CASE("FSharpTypes.C", "[C][FSharp Types]") {
@@ -448,6 +460,19 @@ TEST_CASE("FSharpTypes.C", "[C][FSharp Types]") {
         managed_UserRecord* entry = g_array_index(userRecordArray.array, managed_UserRecord*, i);
         REQUIRE(strcmp(managed_UserRecord_get_UserDescription(entry), "Cherry") == 0);
     }
+    managed_UserRecord* resultUserRecord = managed_FSharp_useUserRecord(userRecord);
+    REQUIRE(strcmp(managed_UserRecord_get_UserDescription(resultUserRecord), "Test") == 0);
+    _Managed_UserStructArray userStructArray = managed_ArrayTest_getDefaultUserStructArray(10);
+    length = userStructArray.array->len;
+    REQUIRE(length == 10);
+    for (uint32_t i = 0; i < length; i++) {
+        managed_UserStruct* entry = g_array_index(userStructArray.array, managed_UserStruct*, i);
+        REQUIRE(strcmp(managed_UserStruct_get_UserDefinition(entry), "Fun!") == 0);
+    }
+    managed_UserStruct* userStruct = managed_FSharp_getDefaultUserStruct();
+    REQUIRE(strcmp(managed_UserStruct_get_UserDefinition(userStruct), "Fun!") == 0);
+    managed_UserStruct* resultUserStruct = managed_FSharp_useUserStruct(userStruct);
+    REQUIRE(strcmp(managed_UserStruct_get_UserDefinition(resultUserStruct), "Fun!") == 0);
 }
 
 TEST_CASE("FSharpModules.C", "[C][FSharp Modules]") {

--- a/tests/managed/arrays.cs
+++ b/tests/managed/arrays.cs
@@ -6,6 +6,7 @@ namespace Arrays {
 	public class Arr {
 		public string [] StringArrMethod () => new [] { "Hola", "Hello", "Bonjour" };
 		public ValueHolder [] ValueHolderArrMethod () => new [] { new ValueHolder (1), new ValueHolder (2), new ValueHolder (3) };
+		public ValueType [] ValueTypeArrMethod () => new [] { new ValueType (1), new ValueType (2), new ValueType (3) };
 		public bool [] BoolArrMethod () => new [] { true, false, true };
 		public char [] CharArrMethod () => new [] { 'a', 'b', '@' };
 		public double [] DoubleArrMethod () => new [] { 1.5, 5.1, 3.1416 };
@@ -24,6 +25,7 @@ namespace Arrays {
 		public string [] StringArr { get; } = new [] { "Hola", "Hello", "Bonjour" };
 		public int [] IntArr { get; } = new [] { int.MaxValue, int.MinValue, 0 };
 		public ValueHolder [] ValueHolderArr { get; } = new [] { new ValueHolder (1), new ValueHolder (2), new ValueHolder (3) };
+		public ValueType [] ValueTypeArr { get; } = new [] { new ValueType (1), new ValueType (2), new ValueType (3) };
 		public byte [] ByteArr { get; } = new byte [] { 0x0, 0x01, 0x02, 0x04, 0x08 };
 		public IMakeItUp [] InterfaceArr { get; } = new [] { Supplier.Create (), Supplier.Create (), Supplier.Create () };
 
@@ -40,6 +42,7 @@ namespace Arrays {
 		public float [] FloatArrMethod (float [] floatArr) => floatArr;
 		public double [] DoubleArrMethod (double [] doubleArr) => doubleArr;
 		public ValueHolder [] ValueHolderArrMethod (ValueHolder [] valhArr) => valhArr;
+		public ValueType[] ValueTypeArrMethod(ValueType [] valTypeArr) => valTypeArr;
 		public IMakeItUp [] InterfaceArrMethod (IMakeItUp [] interArr) => interArr;
 		public byte [] ByteArrMethod (byte [] byteArr) => byteArr;
 
@@ -88,4 +91,14 @@ namespace Arrays {
 			IntValue = intValue;
 		}
 	}
+
+	public struct ValueType {
+		public int IntValue;
+
+		public ValueType(int intValue)
+		{
+			IntValue = intValue;
+		}
+	}
+
 }

--- a/tests/managed/fsharp-shared/Hello.fs
+++ b/tests/managed/fsharp-shared/Hello.fs
@@ -10,15 +10,28 @@ module FSharp =
             "Hello from a nested F# module"
         
         let nestedConstant = "Hello from a nested F# module"
-    
+
     type UserRecord = {
         UserDescription : string
     }
 
+    [<Struct>]
+    type UserStruct =
+        member __.UserDefinition : string = "Fun!"
+
     let getDefaultUserRecord () =
         { UserDescription = "Cherry" }
+
+    let useUserRecord userRecord :UserRecord = userRecord
+
+    let getDefaultUserStruct () = UserStruct()
+
+    let useUserStruct userStruct :UserStruct = userStruct
 
     module ArrayTest =
         let getDefaultUserRecordArray count =
             [| for i in 0 .. (count - 1) -> getDefaultUserRecord () |]
+
+        let getDefaultUserStructArray count = 
+            [| for i in 0 .. (count - 1) -> getDefaultUserStruct () |]
     

--- a/tests/managed/fsharp-shared/Hello.fs
+++ b/tests/managed/fsharp-shared/Hello.fs
@@ -17,4 +17,8 @@ module FSharp =
 
     let getDefaultUserRecord () =
         { UserDescription = "Cherry" }
+
+    module ArrayTest =
+        let getDefaultUserRecordArray count =
+            [| for i in 0 .. (count - 1) -> getDefaultUserRecord () |]
     


### PR DESCRIPTION
This enables the generation of methods which use arrays with non-primitive types.

Includes tests for the new feature.