### PR TITLE
Update Xamarin.Android.Tools to latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,10 @@ xcuserdata/
 *.dSYM.zip
 *.dSYM
 *.nupkg
+*.bak
 .cake/**
 !.cake/packages.config
 .vscode/
+.vs/
 Resource.designer.cs
 external/Xamarin.Android

--- a/binder/Compilation.cs
+++ b/binder/Compilation.cs
@@ -627,7 +627,7 @@ namespace Embeddinator
             var monoPath = Path.Combine(MonoSdkPath, "include", "mono-2.0");
             var name = Path.GetFileNameWithoutExtension(Project.Assemblies[0]);
             var libName = $"lib{name}.so";
-            var ndkPath = AndroidSdk.AndroidNdkPath;
+            var ndkPath = XamarinAndroid.AndroidSdk.AndroidNdkPath;
 
             foreach (var abi in new[] { "armeabi", "armeabi-v7a", "arm64-v8a", "x86", "x86_64" })
             {

--- a/binder/Utils/NdkUtils.cs
+++ b/binder/Utils/NdkUtils.cs
@@ -1,9 +1,10 @@
-﻿using CppSharp;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using CppSharp;
+using Embeddinator;
 using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
@@ -37,7 +38,7 @@ namespace Xamarin.Android.Tasks
             List<string> toolPaths = null;
             foreach (var platbase in toolchains)
             {
-                string path = Path.Combine(platbase, "prebuilt", AndroidSdk.AndroidNdkHostPlatform, "bin", GetNdkToolchainPrefix(arch) + tool + extension);
+                string path = Path.Combine(platbase, "prebuilt", XamarinAndroid.AndroidSdk.AndroidNdkHostPlatform, "bin", GetNdkToolchainPrefix(arch) + tool + extension);
                 if (File.Exists(path))
                     return path;
                 if (toolPaths == null)

--- a/binder/Utils/XamarinAndroid.cs
+++ b/binder/Utils/XamarinAndroid.cs
@@ -19,12 +19,7 @@ namespace Embeddinator
         public const int TargetSdkVersion = 24;
         public const string JavaVersion = "1.8";
 
-        static readonly AndroidSdkInfo androidSdk;
-
-        static XamarinAndroid ()
-        {
-            androidSdk = new AndroidSdkInfo (AndroidSdkLogger);
-        }
+        static readonly Lazy<AndroidSdkInfo> androidSdk = new Lazy<AndroidSdkInfo>(() => new AndroidSdkInfo(AndroidSdkLogger));
 
         static void AndroidSdkLogger (TraceLevel level, string message)
         {
@@ -42,7 +37,7 @@ namespace Embeddinator
             }
         }
 
-        public static AndroidSdkInfo AndroidSdk => androidSdk;
+        public static AndroidSdkInfo AndroidSdk => androidSdk.Value;
 
         static string GetMonoDroidPath()
         {
@@ -68,21 +63,15 @@ namespace Embeddinator
             return libPath;
         }
 
-        static Lazy<string> path = new Lazy<string>(GetMonoDroidPath);
+        static readonly Lazy<string> path = new Lazy<string>(GetMonoDroidPath);
 
-        public static string Path
-        {
-            get { return path.Value; }
-        }
+        public static string Path => path.Value;
 
-        static Lazy<string> libraryPath = new Lazy<string>(GetMonoDroidLibPath);
+        static readonly Lazy<string> libraryPath = new Lazy<string>(GetMonoDroidLibPath);
 
-        public static string LibraryPath
-        {
-            get { return libraryPath.Value; }
-        }
+        public static string LibraryPath => libraryPath.Value;
 
-        static Lazy<string[]> targetFrameworks = new Lazy<string[]>(() => new[]
+        static readonly Lazy<string[]> targetFrameworks = new Lazy<string[]>(() => new[]
         {
             Combine(Path, "lib", "xbuild-frameworks", "MonoAndroid", "v1.0"),
             Combine(Path, "lib", "xbuild-frameworks", "MonoAndroid", "v1.0", "Facades"),
@@ -90,10 +79,7 @@ namespace Embeddinator
             Combine(Path, "lib", "xbuild-frameworks", "MonoAndroid", "v2.3"), //Mono.Android.Export.dll is here
         });
 
-        public static string[] TargetFrameworkDirectories
-        {
-            get { return targetFrameworks.Value; }
-        }
+        public static string[] TargetFrameworkDirectories => targetFrameworks.Value;
 
         /// <summary>
         /// Finds a Xamarin.Android assembly in v1.0, v1.0/Facades, or TargetFrameworkVersion
@@ -111,11 +97,11 @@ namespace Embeddinator
             throw new FileNotFoundException("Unable to find assembly!", assemblyName);
         }
 
-        static Lazy<int> apiLevel = new Lazy<int> (() =>
+        static readonly Lazy<int> apiLevel = new Lazy<int> (() =>
         {
             for (int i = TargetSdkVersion; i > 0; i--)
             {
-                if (androidSdk.IsPlatformInstalled (i))
+                if (AndroidSdk.IsPlatformInstalled (i))
                     return i;
             }
 
@@ -125,22 +111,16 @@ namespace Embeddinator
         /// <summary>
         /// Right now we are choosing the max API level installed
         /// </summary>
-        public static int ApiLevel
-        {
-            get { return apiLevel.Value; }
-        }
+        public static int ApiLevel => apiLevel.Value;
 
-        static Lazy<string> platformDirectory = new Lazy<string>(() => AndroidSdk.GetPlatformDirectory(ApiLevel));
+        static readonly Lazy<string> platformDirectory = new Lazy<string>(() => AndroidSdk.GetPlatformDirectory(ApiLevel));
 
         /// <summary>
         /// Gets the platform directory based on the max API level installed
         /// </summary>
-        public static string PlatformDirectory
-        {
-            get { return platformDirectory.Value; }
-        }
+        public static string PlatformDirectory => platformDirectory.Value;
 
-        static Lazy<string> javaSdkPath = new Lazy<string>(() =>
+        static readonly Lazy<string> javaSdkPath = new Lazy<string>(() =>
         {
             // If we are running on macOS, invoke java_home to figure out Java path.
             if (Platform.IsMacOS)
@@ -153,13 +133,9 @@ namespace Embeddinator
             if (Platform.IsLinux)
             {
                 // Only available on Debian-based distros, set JAVA_HOME for other distros.
-                try
-                {
-                    var javaBin = Helpers.Invoke("update-alternatives", "--list java", null).StandardOutput.Trim();
-                    if (!string.IsNullOrEmpty(javaBin))
-                        return GetFullPath(Combine(GetDirectoryName(javaBin), "../.."));
-                }
-                finally { }
+                var javaBin = Helpers.Invoke("update-alternatives", "--list java", null).StandardOutput.Trim();
+                if (!string.IsNullOrEmpty(javaBin))
+                    return GetFullPath(Combine(GetDirectoryName(javaBin), "../.."));
             }
 
             if (string.IsNullOrEmpty(home))
@@ -168,12 +144,9 @@ namespace Embeddinator
             return string.Empty;
         });
 
-        public static string JavaSdkPath
-        {
-            get { return javaSdkPath.Value; }
-        }
+        public static string JavaSdkPath => javaSdkPath.Value;
 
-        static Lazy<string> msBuildPath = new Lazy<string>(() =>
+        static readonly Lazy<string> msBuildPath = new Lazy<string>(() =>
         {
             if (Platform.IsMacOS)
                 return "/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild";
@@ -190,9 +163,6 @@ namespace Embeddinator
             return "/usr/bin/msbuild";
         });
 
-        public static string MSBuildPath
-        {
-            get { return msBuildPath.Value; }
-        }
+        public static string MSBuildPath => msBuildPath.Value;
     }
 }

--- a/binder/Utils/XamarinAndroidBuild.cs
+++ b/binder/Utils/XamarinAndroidBuild.cs
@@ -110,9 +110,9 @@ namespace Embeddinator
             aapt.SetParameter("JavaDesignerOutputDirectory", outputDirectory);
             aapt.SetParameter("AssetDirectory", assetsDir);
             aapt.SetParameter("ResourceDirectory", resourceDir);
-            aapt.SetParameter("ToolPath", AndroidSdk.GetBuildToolsPaths().First());
+            aapt.SetParameter("ToolPath", XamarinAndroid.AndroidSdk.GetBuildToolsPaths().First());
             aapt.SetParameter("ToolExe", "aapt");
-            aapt.SetParameter("ApiLevel", XamarinAndroid.TargetSdkVersion);
+            aapt.SetParameter("ApiLevel", XamarinAndroid.TargetSdkVersion.ToString());
             aapt.SetParameter("ExtraArgs", "--output-text-symbols " + androidDir);
 
             //There is an extra /manifest/AndroidManifest.xml file created
@@ -187,8 +187,8 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             generateJavaStubs.SetParameter("ResolvedUserAssemblies", "@(ResolvedUserAssemblies)");
             generateJavaStubs.SetParameter("ManifestTemplate", manifestPath);
             generateJavaStubs.SetParameter("MergedAndroidManifestOutput", manifestPath);
-            generateJavaStubs.SetParameter("AndroidSdkPlatform", XamarinAndroid.TargetSdkVersion); //TODO: should be an option
-            generateJavaStubs.SetParameter("AndroidSdkDir", AndroidSdk.AndroidSdkPath);
+            generateJavaStubs.SetParameter("AndroidSdkPlatform", XamarinAndroid.TargetSdkVersion.ToString()); //TODO: should be an option
+            generateJavaStubs.SetParameter("AndroidSdkDir", XamarinAndroid.AndroidSdk.AndroidSdkPath);
             generateJavaStubs.SetParameter("OutputDirectory", outputDirectory);
             generateJavaStubs.SetParameter("ResourceDirectory", "$(MonoAndroidResDirIntermediate)");
             generateJavaStubs.SetParameter("AcwMapFile", "$(MonoAndroidIntermediate)acw-map.txt");
@@ -205,8 +205,8 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
             //GetAdditionalResourcesFromAssemblies Task, for JavaLibraryReferenceAttribute, etc.
             var getAdditionalResources = target.AddTask("GetAdditionalResourcesFromAssemblies");
-            getAdditionalResources.SetParameter("AndroidSdkDirectory", AndroidSdk.AndroidSdkPath);
-            getAdditionalResources.SetParameter("AndroidNdkDirectory", AndroidSdk.AndroidNdkPath);
+            getAdditionalResources.SetParameter("AndroidSdkDirectory", XamarinAndroid.AndroidSdk.AndroidSdkPath);
+            getAdditionalResources.SetParameter("AndroidNdkDirectory", XamarinAndroid.AndroidSdk.AndroidNdkPath);
             getAdditionalResources.SetParameter("Assemblies", "@(ResolvedUserAssemblies)");
             getAdditionalResources.SetParameter("CacheFile", Path.Combine(intermediateDir, ResourcePaths));
 

--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -100,7 +100,12 @@ workspace "Embeddinator-4000"
     kind "SharedLib"
     language "C#"
 
-    files { "../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/*.cs", "../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/*.cs" }
+    files
+    { 
+      "../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/*.cs",
+      "../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/*.cs",
+      "../external/MonoDroidSdk/*.cs"
+    }
     links
     {
       "System",

--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -93,13 +93,14 @@ workspace "Embeddinator-4000"
       "System.Xml.Linq",
       "Mono.Posix"
     }
+    location ("%{wks.location}/build/projects")
 
   managed_project "Xamarin.Android.Tools"
 
     kind "SharedLib"
     language "C#"
 
-    files { "../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/**.cs" }
+    files { "../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/*.cs", "../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/*.cs" }
     links
     {
       "System",
@@ -107,6 +108,7 @@ workspace "Embeddinator-4000"
       "System.Xml",
       "System.Xml.Linq"
     }
+    location ("%{wks.location}/build/projects")
 
 -- Override VS solution generation so we do not generate anything.
 premake.override(premake.vstudio.vs2005, "generateSolution", function(base, wks) end)

--- a/build/projects/Xamarin.Android.Tools.csproj
+++ b/build/projects/Xamarin.Android.Tools.csproj
@@ -43,47 +43,50 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/AndroidLogger.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/AndroidLogger.cs</Link>
+    <Compile Include="../../external/MonoDroidSdk/MonoDroidSdk.cs">
+      <Link>external/MonoDroidSdk/MonoDroidSdk.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/AndroidSdk.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/AndroidSdk.cs</Link>
+    <Compile Include="../../external/MonoDroidSdk/MonoDroidSdkBase.cs">
+      <Link>external/MonoDroidSdk/MonoDroidSdkBase.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/AndroidTargetArch.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/AndroidTargetArch.cs</Link>
+    <Compile Include="../../external/MonoDroidSdk/MonoDroidSdkUnix.cs">
+      <Link>external/MonoDroidSdk/MonoDroidSdkUnix.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/AndroidVersion.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/AndroidVersion.cs</Link>
+    <Compile Include="../../external/MonoDroidSdk/MonoDroidSdkWindows.cs">
+      <Link>external/MonoDroidSdk/MonoDroidSdkWindows.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/MonoDroidSdk.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/MonoDroidSdk.cs</Link>
+    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidAppManifest.cs">
+      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidAppManifest.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/OS.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/OS.cs</Link>
+    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs">
+      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/ProcessUtils.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/ProcessUtils.cs</Link>
+    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidTargetArch.cs">
+      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidTargetArch.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Properties/AssemblyInfo.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Properties/AssemblyInfo.cs</Link>
+    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersion.cs">
+      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersion.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/AndroidSdkBase.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/AndroidSdkBase.cs</Link>
+    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs">
+      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/AndroidSdkUnix.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/AndroidSdkUnix.cs</Link>
+    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/FileUtil.cs">
+      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/FileUtil.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/AndroidSdkWindows.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/AndroidSdkWindows.cs</Link>
+    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/OS.cs">
+      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/OS.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkBase.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkBase.cs</Link>
+    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs">
+      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkUnix.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkUnix.cs</Link>
+    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs">
+      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs</Link>
     </Compile>
-    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkWindows.cs">
-      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkWindows.cs</Link>
+    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs">
+      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs</Link>
+    </Compile>
+    <Compile Include="../../external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs">
+      <Link>external/Xamarin.Android.Tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/external/MonoDroidSdk/MonoDroidSdk.cs
+++ b/external/MonoDroidSdk/MonoDroidSdk.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+
+namespace Xamarin.Android.Tools
+{
+	public static class MonoDroidSdk
+	{
+		static MonoDroidSdkBase sdk;
+
+		public static string GetApiLevelForFrameworkVersion (string framework)
+		{
+			return GetSdk ().GetApiLevelForFrameworkVersion (framework);
+		}
+
+		public static string GetFrameworkVersionForApiLevel (string apiLevel)
+		{
+			return GetSdk ().GetFrameworkVersionForApiLevel (apiLevel);
+		}
+
+		public static bool IsSupportedFrameworkLevel (string apiLevel)
+		{
+			return GetSdk ().IsSupportedFrameworkLevel (apiLevel);
+		}
+
+		public static void Refresh (string runtimePath = null, string binPath = null, string bclPath = null)
+		{
+			if (OS.IsWindows) {
+				sdk = new MonoDroidSdkWindows ();
+			} else {
+				sdk = new MonoDroidSdkUnix ();
+			}
+
+			try {
+				sdk.Initialize (runtimePath, binPath, bclPath);
+			} catch (Exception ex) {
+				Console.WriteLine ("Error finding Xamarin.Android SDK: {0}", ex);
+			}
+		}
+
+		static MonoDroidSdkBase GetSdk ()
+		{
+			if (sdk == null) {
+				Refresh ();
+			}
+			return sdk;
+		}
+
+		public static string RuntimePath { get { return GetSdk ().RuntimePath; } }
+
+		public static string BinPath { get { return GetSdk ().BinPath; } }
+
+		public static string FrameworkPath { get { return GetSdk ().BclPath; } }
+
+		[Obsolete ("Do not use.")]
+		public static string JavaDocToMDocExe {
+			get { return Path.Combine (BinPath, OS.IsWindows ? "javadoc-to-mdoc.exe" : "javadoc-to-mdoc"); }
+		}
+	}
+}
+

--- a/external/MonoDroidSdk/MonoDroidSdkBase.cs
+++ b/external/MonoDroidSdk/MonoDroidSdkBase.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Linq;
+using System.IO;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace Xamarin.Android.Tools
+{
+	abstract class MonoDroidSdkBase
+	{
+		protected readonly static string DebugRuntime = "Mono.Android.DebugRuntime-debug.apk";
+		protected readonly static string ClassParseExe = "class-parse.exe";
+		protected readonly static string GeneratorScript = "generator";
+
+		// I can never remember the difference between SdkPath and anything else...
+		[Obsolete ("Do not use.")]
+		public string SdkPath { get; private set; }
+
+		// Contains mandroid
+		public string BinPath { get; private set; }
+
+		// Not actually shipped...
+		public string IncludePath { get; private set; }
+
+		// Contains Mono.Android.DebugRuntime-*.apk, platforms/*/*.apk.
+		public string RuntimePath { get; private set; }
+
+		// Root directory for XA libraries, contains designer dependencies
+		public string LibrariesPath { get; private set; }
+
+		// Contains mscorlib.dll
+		public string BclPath { get; private set; }
+
+		public int SharedRuntimeVersion { get; private set; }
+
+		// expectedRuntimePath: contains Mono.Android.DebugRuntime-*.apk
+		// binPath:     contains mandroid
+		// mscorlibDir: contains mscorlib.dll
+		public void Initialize (string expectedRuntimePath = null, string binPath = null, string bclPath = null)
+		{
+			var runtimePath = GetValidPath ("MonoAndroidToolsPath", expectedRuntimePath,  ValidateRuntime, () => FindRuntime ());
+			if (runtimePath != null) {
+				binPath = GetValidPath ("MonoAndroidBinPath", binPath, ValidateBin, () => FindBin (runtimePath));
+				bclPath = GetValidPath ("mscorlib.dll", bclPath, ValidateFramework, () => FindFramework (runtimePath));
+			} else {
+				if (expectedRuntimePath != null)
+					Console.WriteLine ("Runtime was not found at {0}", expectedRuntimePath);
+				binPath = bclPath = null;
+			}
+
+			if (runtimePath == null || binPath == null || bclPath == null) {
+				Reset ();
+				return;
+			}
+
+			RuntimePath = runtimePath;
+			#pragma warning disable 0618
+			SdkPath     = Path.GetFullPath (Path.Combine (runtimePath, "..", ".."));
+			#pragma warning restore 0618
+			BinPath     = binPath;
+			BclPath     = bclPath;
+			LibrariesPath = FindLibraries (runtimePath);
+
+			IncludePath = FindInclude (runtimePath);
+			if (IncludePath != null && !Directory.Exists (IncludePath))
+				IncludePath = null;
+
+			SharedRuntimeVersion = GetCurrentSharedRuntimeVersion ();
+			FindSupportedFrameworks ();
+		}
+
+		static string GetValidPath (string description, string path, Func<string, bool> validator, Func<string> defaultPath)
+		{
+			if (!string.IsNullOrEmpty (path)) {
+				if (Directory.Exists (path)) {
+					if (validator (path))
+						return path;
+					Console.WriteLine ("{0} path '{1}' is explicitly specified, but it was not valid; skipping.", description, path);
+				} else
+					Console.WriteLine ("{0} path '{1}' is explicitly specified, but it was not found; skipping.", description, path);
+			}
+			path = defaultPath ();
+			if (path != null && validator (path))
+				return path;
+			if (path != null)
+				Console.WriteLine ("{0} path is defaulted to '{1}', but it was not valid; skipping", description, path);
+			else
+				Console.WriteLine ("{0} path is not found and no default location is provided; skipping", description);
+			return null;
+		}
+
+		public void Reset ()
+		{
+			#pragma warning disable 0618
+			SdkPath = BinPath = IncludePath = RuntimePath = BclPath = null;
+			#pragma warning restore 0618
+			SharedRuntimeVersion = 0;
+		}
+
+		protected abstract string FindRuntime ();
+		protected abstract string FindFramework (string runtimePath);
+
+		// Check for platform-specific `mandroid` name
+		protected abstract bool ValidateBin (string binPath);
+
+		protected static bool ValidateRuntime (string loc)
+		{
+			return !string.IsNullOrWhiteSpace (loc) &&
+				(File.Exists (Path.Combine (loc, DebugRuntime)) ||    // Normal/expected
+				 File.Exists (Path.Combine (loc, ClassParseExe)) ||    // Normal/expected
+				 File.Exists (Path.Combine (loc, "Xamarin.Android.Common.targets"))); //VS on Windows
+		}
+
+		protected static bool ValidateFramework (string loc)
+		{
+			return loc != null && File.Exists (Path.Combine (loc, "mscorlib.dll"));
+		}
+
+		public string FindVersionFile ()
+		{
+			#pragma warning disable 0618
+			if (string.IsNullOrEmpty (SdkPath))
+				return null;
+			#pragma warning restore 0618
+			foreach (var loc in GetVersionFileLocations ()) {
+				if (File.Exists (loc)) {
+					return loc;
+				}
+			}
+			return null;
+		}
+
+		protected virtual IEnumerable<string> GetVersionFileLocations ()
+		{
+			#pragma warning disable 0618
+			yield return Path.Combine (SdkPath, "Version");
+			#pragma warning restore 0618
+		}
+
+		protected abstract string FindBin (string runtimePath);
+
+		protected abstract string FindInclude (string runtimePath);
+
+		protected abstract string FindLibraries (string runtimePath);
+
+		[Obsolete ("Do not use.")]
+		public string GetPlatformNativeLibPath (string abi)
+		{
+			return FindPlatformNativeLibPath (SdkPath, abi);
+		}
+
+		[Obsolete ("Do not use.")]
+		public string GetPlatformNativeLibPath (AndroidTargetArch arch)
+		{
+			return FindPlatformNativeLibPath (SdkPath, GetMonoDroidArchName (arch));
+		}
+
+		[Obsolete ("Do not use.")]
+		static string GetMonoDroidArchName (AndroidTargetArch arch)
+		{
+			switch (arch) {
+			case AndroidTargetArch.Arm:
+				return "armeabi";
+			case AndroidTargetArch.Mips:
+				return "mips";
+			case AndroidTargetArch.X86:
+				return "x86";
+			}
+			return null;
+		}
+
+		[Obsolete]
+		protected string FindPlatformNativeLibPath (string sdk, string arch)
+		{
+			return Path.Combine (sdk, "lib", arch);
+		}
+
+		static XmlReaderSettings GetSafeReaderSettings ()
+		{
+			//allow DTD but not try to resolve it from web
+			return new XmlReaderSettings {
+				CloseInput = true,
+				DtdProcessing = DtdProcessing.Ignore,
+				XmlResolver = null,
+			};
+		}
+
+		int GetCurrentSharedRuntimeVersion ()
+		{
+			string file = Path.Combine (RuntimePath, "Mono.Android.DebugRuntime-debug.xml");
+
+			return GetManifestVersion (file);
+		}
+
+		internal static int GetManifestVersion (string file)
+		{
+			// It seems that MfA 1.0 on Windows didn't include the xml files to get the runtime version.
+			if (!File.Exists (file))
+				return int.MaxValue;
+
+			try {
+				using (var r = XmlReader.Create (file, GetSafeReaderSettings())) {
+					if (r.MoveToContent () == XmlNodeType.Element && r.MoveToAttribute ("android:versionCode")) {
+						int value;
+						if (int.TryParse (r.Value, out value))
+							return value;
+						Console.WriteLine ("Cannot parse runtime version code: ({0})", r.Value);
+					}
+				}
+			} catch (Exception ex) {
+				Console.WriteLine ("Error trying to find shared runtime version", ex);
+			}
+			return int.MaxValue;
+		}
+
+		internal static Version ToVersion (string frameworkDir)
+		{
+			string version = Path.GetFileName (frameworkDir);
+			if (!version.StartsWith ("v", StringComparison.OrdinalIgnoreCase)) {
+				// wat?
+				return new Version ();
+			}
+			version = version.Substring (1);
+			Version v;
+			if (Version.TryParse (version, out v))
+				return v;
+			return new Version ();
+		}
+
+		void FindSupportedFrameworks ()
+		{
+			string bclDir           = MonoDroidSdk.FrameworkPath;
+			string frameworksDir    = Path.GetDirectoryName (bclDir);
+			foreach (var framework in Directory.EnumerateDirectories (frameworksDir).Select (ToVersion)) {
+				if (framework.Major == 0)
+					continue;
+				string apiLevel;
+				if (FrameworkToApiLevels.TryGetValue (framework, out apiLevel))
+					SupportedFrameworks.Add (framework, apiLevel);
+			}
+		}
+
+		readonly Dictionary<Version, string>  SupportedFrameworks = new Dictionary<Version, string> ();
+
+		static readonly Dictionary<Version, string> FrameworkToApiLevels = new Dictionary<Version, string> ();
+		static readonly Dictionary<Version, string> LegacyFrameworkToApiLevels = new Dictionary<Version, string> {
+			{ new Version (4, 5), "21" } // L Preview
+		};
+
+		public IEnumerable<string> GetSupportedApiLevels ()
+		{
+			return SupportedFrameworks.Select (e => e.Value);
+		}
+
+		public string GetApiLevelForFrameworkVersion (string framework)
+		{
+			Version v;
+			if (!Version.TryParse (framework.TrimStart ('v'), out v))
+				return null;
+			string apiLevel;
+			if (SupportedFrameworks.TryGetValue (v, out apiLevel)
+				|| FrameworkToApiLevels.TryGetValue (v, out apiLevel)
+				|| LegacyFrameworkToApiLevels.TryGetValue (v, out apiLevel))
+				return apiLevel;
+			return null;
+		}
+
+		public string GetFrameworkVersionForApiLevel (string apiLevel)
+		{
+			// API level 9 was discontinued immediately for 10, in the rare case we get it just upgrade the number
+			if (apiLevel == "9")
+				apiLevel = "10";
+			var maxFrameworkVersion = SupportedFrameworks.Concat (FrameworkToApiLevels)
+				.Where (e => e.Value == apiLevel)
+				.OrderByDescending (e => e.Key, Comparer<Version>.Default)
+				.Select (e => e.Key)
+				.FirstOrDefault ();
+			if (maxFrameworkVersion != null)
+				return "v" + maxFrameworkVersion;
+			return null;
+		}
+
+		/// <summary>
+		/// Determines if the given apiLevel is supported by an installed Framework
+		/// </summary>
+		public bool IsSupportedFrameworkLevel (string apiLevel)
+		{
+			return SupportedFrameworks.Any ((sf => sf.Value == apiLevel)); 
+		}
+	}
+}
+

--- a/external/MonoDroidSdk/MonoDroidSdkUnix.cs
+++ b/external/MonoDroidSdk/MonoDroidSdkUnix.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Xamarin.Android.Tools
+{
+	class MonoDroidSdkUnix : MonoDroidSdkBase
+	{
+		readonly static string[] RuntimeToFrameworkPaths = new[]{
+			Path.Combine ("..", "..", "..", ".xamarin.android", "lib", "xbuild-frameworks", "MonoAndroid"),
+			Path.Combine ("..", "xbuild-frameworks", "MonoAndroid"),
+			Path.Combine ("..", "mono", "2.1"),
+		};
+
+		readonly static string[] SearchPaths = {
+			"/Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/mandroid",
+			"/Developer/MonoAndroid/usr/lib/mandroid",
+			"/app/lib/mandroid",
+			"/opt/mono-android/lib/mandroid"
+		};
+
+		protected override string FindRuntime ()
+		{
+			string monoAndroidPath = Environment.GetEnvironmentVariable ("MONO_ANDROID_PATH");
+			if (!string.IsNullOrEmpty (monoAndroidPath)) {
+				string libMandroid = Path.Combine (monoAndroidPath, "lib", "mandroid");
+				if (Directory.Exists (libMandroid)) {
+					if (ValidateRuntime (libMandroid))
+						return libMandroid;
+					Console.WriteLine ("MONO_ANDROID_PATH points to {0}, but it is invalid.", monoAndroidPath);
+				} else
+					Console.WriteLine ("MONO_ANDROID_PATH points to {0}, but it does not exist.", monoAndroidPath);
+			}
+
+			// check also in the users folder
+			var personal = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+			var additionalSearchPaths = new [] {
+				// for Mono.Posix and Mono.Data.Sqlite builds in xamarin-android.
+				monoAndroidPath = Path.GetFullPath (Path.Combine (new Uri (GetType ().Assembly.CodeBase).LocalPath, "..", "..", "..", "..", "..", "lib", "mandroid")),
+				Path.Combine (personal, @".xamarin.android/lib/mandroid")
+			};
+
+			return additionalSearchPaths.Concat (SearchPaths).FirstOrDefault (ValidateRuntime);
+		}
+
+		protected override bool ValidateBin (string binPath)
+		{
+			return !string.IsNullOrWhiteSpace (binPath) &&
+				File.Exists (Path.Combine (binPath, GeneratorScript));
+		}
+
+		protected override string FindFramework (string runtimePath)
+		{
+			foreach (var relativePath in RuntimeToFrameworkPaths) {
+				var fullPath = Path.GetFullPath (Path.Combine (runtimePath, relativePath));
+				if (Directory.Exists (fullPath)) {
+					if (ValidateFramework (fullPath))
+						return fullPath;
+
+					// check to see if full path is the folder that contains each framework version, eg contains folders of the form v1.0, v2.3 etc
+					var subdirs = Directory.GetDirectories (fullPath, "v*").OrderBy (x => x).ToArray ();
+					foreach (var subdir in subdirs) {
+						if (ValidateFramework (subdir))
+							return subdir;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		protected override string FindBin (string runtimePath)
+		{
+			string binPath = Path.GetFullPath (Path.Combine (runtimePath, "..", "..", "bin"));
+			if (File.Exists (Path.Combine (binPath, GeneratorScript)))
+				return binPath;
+			return null;
+		}
+
+		protected override string FindInclude (string runtimePath)
+		{
+			string includeDir = Path.GetFullPath (Path.Combine (runtimePath, "..", "..", "include"));
+			if (Directory.Exists (includeDir))
+				return includeDir;
+			return null;
+		}
+
+		protected override string FindLibraries (string runtimePath)
+		{
+			return Path.GetFullPath (Path.Combine (runtimePath, ".."));
+		}
+
+		protected override IEnumerable<string> GetVersionFileLocations ()
+		{
+			yield return Path.GetFullPath (Path.Combine (RuntimePath, "..", "..", "Version"));
+			string sdkPath = Path.GetDirectoryName (Path.GetDirectoryName (RuntimePath));
+			if (Path.GetFileName (sdkPath) == "usr")
+				yield return Path.GetFullPath (Path.Combine (Path.GetDirectoryName (sdkPath), "Version"));
+		}
+	}
+}
+

--- a/external/MonoDroidSdk/MonoDroidSdkWindows.cs
+++ b/external/MonoDroidSdk/MonoDroidSdkWindows.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xamarin.Android.Tools
+{
+	class MonoDroidSdkWindows : MonoDroidSdkBase
+	{
+		static readonly string[] VisualStudioPaths = new[] {
+			Environment.GetEnvironmentVariable ("VSINSTALLDIR"),
+			Path.Combine (OS.ProgramFilesX86, "Microsoft Visual Studio", "2017", "Enterprise"),
+			Path.Combine (OS.ProgramFilesX86, "Microsoft Visual Studio", "2017", "Professional"),
+			Path.Combine (OS.ProgramFilesX86, "Microsoft Visual Studio", "2017", "Community"),
+			Path.Combine (OS.ProgramFilesX86), //VS older than 2017, MSBuild\Xamarin\Android is located in C:\Program Files (x86)\
+		};
+
+		protected override string FindRuntime ()
+		{
+			string monoAndroidPath = Environment.GetEnvironmentVariable ("MONO_ANDROID_PATH");
+			if (!string.IsNullOrEmpty (monoAndroidPath)) {
+				if (Directory.Exists (monoAndroidPath) && ValidateRuntime (monoAndroidPath))
+					return monoAndroidPath;
+			}
+
+			foreach (var vsPath in VisualStudioPaths) {
+				if (string.IsNullOrEmpty (vsPath))
+					continue;
+				var xamarinSdk = Path.Combine (vsPath, "MSBuild", "Xamarin", "Android");
+				if (Directory.Exists (xamarinSdk) && ValidateRuntime (xamarinSdk))
+					return xamarinSdk;
+			}
+			return OS.ProgramFilesX86 + @"\MSBuild\Novell";
+		}
+
+		static readonly string[] RuntimeToFrameworkPaths = new []{
+			Path.Combine ("..", "..", "..", "Common7", "IDE", "ReferenceAssemblies", "Microsoft", "Framework","MonoAndroid"),
+			Path.Combine ("..", "..", "..", "Reference Assemblies", "Microsoft", "Framework", "MonoAndroid"),
+			Path.Combine (OS.ProgramFilesX86, "Reference Assemblies", "Microsoft", "Framework", "MonoAndroid"),
+		};
+
+		protected override string FindFramework (string runtimePath)
+		{
+			foreach (var relativePath in RuntimeToFrameworkPaths) {
+				var fullPath = Path.GetFullPath (Path.Combine (runtimePath, relativePath));
+				if (Directory.Exists (fullPath)) {
+					if (ValidateFramework (fullPath))
+						return fullPath;
+
+					// check to see if full path is the folder that contains each framework version, eg contains folders of the form v1.0, v2.3 etc
+					var subdirs = Directory.GetDirectories (fullPath, "v*").OrderBy (x => x).ToArray ();
+					foreach (var subdir in subdirs) {
+						if (ValidateFramework (subdir))
+							return subdir;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		protected override string FindBin (string runtimePath)
+		{
+			return runtimePath;
+		}
+
+		protected override bool ValidateBin (string binPath)
+		{
+			return !string.IsNullOrWhiteSpace (binPath) &&
+				File.Exists (Path.Combine (binPath, "generator.exe"));
+		}
+
+		protected override string FindInclude (string runtimePath)
+		{
+			return Path.GetFullPath (Path.Combine (runtimePath, "include"));
+		}
+
+		protected override string FindLibraries (string runtimePath)
+		{
+			return Path.GetFullPath (runtimePath);
+		}
+
+		protected override IEnumerable<string> GetVersionFileLocations ()
+		{
+			yield return Path.GetFullPath (Path.Combine (RuntimePath, "Version"));
+		}
+	}
+}
+

--- a/tests/MonoEmbeddinator4000.Tests/Approvals/XamarinAndroidBuildTest.AndroidManifest.approved.txt
+++ b/tests/MonoEmbeddinator4000.Tests/Approvals/XamarinAndroidBuildTest.AndroidManifest.approved.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="hello">
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="25" />
+    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="24" />
     <application>
         <meta-data android:name="mono.embeddinator.classname" android:value="hello.Native_hello" />
         <provider android:name="mono.embeddinator.AndroidRuntimeProvider" android:exported="false" android:initOrder="2147483647" android:authorities="${applicationId}.mono.embeddinator.AndroidRuntimeProvider.__mono_init__" />

--- a/tests/MonoEmbeddinator4000.Tests/Approvals/XamarinAndroidBuildTest.AndroidManifestWithDots.approved.txt
+++ b/tests/MonoEmbeddinator4000.Tests/Approvals/XamarinAndroidBuildTest.AndroidManifestWithDots.approved.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="hello_with_dots">
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="25" />
+    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="24" />
     <application>
         <meta-data android:name="mono.embeddinator.classname" android:value="hello_with_dots.Native_hello_with_dots" />
         <provider android:name="mono.embeddinator.AndroidRuntimeProvider" android:exported="false" android:initOrder="2147483647" android:authorities="${applicationId}.mono.embeddinator.AndroidRuntimeProvider.__mono_init__" />

--- a/tests/MonoEmbeddinator4000.Tests/Approvals/XamarinAndroidBuildTest.AndroidManifestWithUpperCase.approved.txt
+++ b/tests/MonoEmbeddinator4000.Tests/Approvals/XamarinAndroidBuildTest.AndroidManifestWithUpperCase.approved.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="hello">
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="25" />
+    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="24" />
     <application>
         <meta-data android:name="mono.embeddinator.classname" android:value="hello.Native_HELLO" />
         <provider android:name="mono.embeddinator.AndroidRuntimeProvider" android:exported="false" android:initOrder="2147483647" android:authorities="${applicationId}.mono.embeddinator.AndroidRuntimeProvider.__mono_init__" />

--- a/tests/MonoEmbeddinator4000.Tests/XamarinAndroidTest.cs
+++ b/tests/MonoEmbeddinator4000.Tests/XamarinAndroidTest.cs
@@ -8,36 +8,6 @@ namespace Embeddinator.Tests
     [TestFixture]
     public class XamarinAndroidTest : CurrentDirectoryTest
     {
-        [SetUp]
-        public override void SetUp()
-        {
-            base.SetUp();
-
-            AndroidLogger.Error += AndroidLogger_Error;
-            AndroidLogger.Warning += AndroidLogger_Error;
-            AndroidLogger.Info += AndroidLogger_Info;
-        }
-
-        [TearDown]
-        public override void TearDown()
-        {
-            base.TearDown();
-
-            AndroidLogger.Error -= AndroidLogger_Error;
-            AndroidLogger.Warning -= AndroidLogger_Error;
-            AndroidLogger.Info -= AndroidLogger_Info;
-        }
-
-        void AndroidLogger_Error(string task, string message)
-        {
-            Assert.Fail("{0}: {1}", task, message);
-        }
-
-        void AndroidLogger_Info(string task, string message)
-        {
-            Console.WriteLine("{0}: {1}", task, message);
-        }
-
         [Test]
         public void PathExists()
         {


### PR DESCRIPTION
[Xamarin.Android.Tools](https://github.com/xamarin/xamarin-android-tools) is going to be shipped in a future version of Xamarin.Android. They've made several API changes up to this point, such as making `AndroidSdk` non-static, improved logging events, and removed `MonoDroidSdk`.

We should keep Embeddinator on the latest Xamarin.Android.Tools, as it has several fixes, and will continue to get fixes as more projects rely on it.

I included the source for the now absent `MonoDroidSdk` in `external/MonoDroidSdk`, as it was used for locating Xamarin.Android.

Other changes:
- `TargetSdkVersion` should be 24 to match "v7.0" - down the road we could add a command line switch for users to specify API level or bump to 26 and "v8.0"
- Added some `.gitignore` for Windows users
- Fixed paths in `premake.lua` for Xamarin.Android.Tools and Xamarin.MacDev