### PR TITLE
[Android] add MonoPackageManager.setContext

### DIFF
--- a/support/java/android/MonoPackageManager.java
+++ b/support/java/android/MonoPackageManager.java
@@ -3,4 +3,9 @@ package mono;
 /* This is used if Application.Context is invoked from C#, see: https://github.com/xamarin/xamarin-android/blob/master/src/Mono.Android/Android.App/Application.cs */
 public class MonoPackageManager {
     public static android.content.Context Context;
+
+    public static void setContext (android.content.Context context)
+    {
+        // Ignore; vestigial
+    }
 }

--- a/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
+++ b/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
@@ -175,4 +175,15 @@ public class AndroidTests {
     public void googlePlayServices() {
         assertNotNull(GooglePlayServices.createClient());
     }
+
+    @Test
+    public void monoPackageManagerContext() {
+        assertNotNull(mono.MonoPackageManager.Context);
+    }
+
+    @Test
+    public void monoPackageManagerSetContext() {
+        //Just make sure this compiles, and doesn't throw
+        mono.MonoPackageManager.setContext(null);
+    }
 }


### PR DESCRIPTION
As reported in #530, there are some cases where libraries use
`MonoPackageManager.setContext`, which has a “vestigial”
implementation/comment in Xamarin.Android.

I added this method and a couple quick tests for future validation.