### PR TITLE
[c/swift] Prefix C generated type names  

### DIFF
--- a/binder/CLI.cs
+++ b/binder/CLI.cs
@@ -183,6 +183,8 @@ namespace Embeddinator
                 Generators.Insert(0, GeneratorKind.C);
             }
 
+            options.GeneratorKinds = Generators;
+
             var targetPlatform = ConvertToTargetPlatform(Platform);
             options.Compilation.Platform = targetPlatform;
 

--- a/binder/Driver.cs
+++ b/binder/Driver.cs
@@ -45,6 +45,7 @@ namespace Embeddinator
             if (!Options.Compilation.Platform.HasValue)
                 Options.Compilation.Platform = Platform.Host;
 
+            CGenerator.Options = options;
             Declaration.QualifiedNameSeparator = "_";
         }
 

--- a/binder/Generators/C/CGenerator.cs
+++ b/binder/Generators/C/CGenerator.cs
@@ -36,7 +36,9 @@ namespace Embeddinator.Generators
             if (Options.GeneratorKind == GeneratorKind.CPlusPlus)
                 return decl.Name;
 
-            return decl.QualifiedName;
+            var isSwiftTarget = Options.GeneratorKinds.Contains(GeneratorKind.Swift);
+
+            return (isSwiftTarget && !decl.IsImplicit) ? $"_{decl.QualifiedName}" : decl.QualifiedName;
         }
 
         public static string ObjectInstanceId => GenId("object");

--- a/binder/Generators/C/CGenerator.cs
+++ b/binder/Generators/C/CGenerator.cs
@@ -29,6 +29,16 @@ namespace Embeddinator.Generators
             return "__" + id.Replace('-', '_');
         }
 
+        public static Options Options;
+
+        public static string QualifiedName(Declaration decl)
+        {
+            if (Options.GeneratorKind == GeneratorKind.CPlusPlus)
+                return decl.Name;
+
+            return decl.QualifiedName;
+        }
+
         public static string ObjectInstanceId => GenId("object");
 
         public static string AssemblyId(TranslationUnit unit)
@@ -119,14 +129,6 @@ namespace Embeddinator.Generators
             return CGenerator.GenId(id);
         }
 
-        public string QualifiedName(Declaration decl)
-        {
-            if (Options.GeneratorKind == GeneratorKind.CPlusPlus)
-                return decl.Name;
-
-            return decl.QualifiedName;
-        }
-
         public CManagedToNativeTypePrinter CTypePrinter =>
                 CGenerator.GetCTypePrinter(Options.GeneratorKind);
 
@@ -162,9 +164,10 @@ namespace Embeddinator.Generators
             Write(")");
         }
 
-        public virtual string GenerateClassObjectAlloc(string type)
+        public virtual string GenerateClassObjectAlloc(Declaration decl)
         {
-            return $"({type}*) calloc(1, sizeof({type}))";
+            var typeName = decl.Visit(CTypePrinter);
+            return $"({typeName}*) calloc(1, sizeof({typeName}))";
         }
 
         public override bool VisitTypedefDecl(TypedefDecl typedef)

--- a/binder/Generators/C/CGenerator.cs
+++ b/binder/Generators/C/CGenerator.cs
@@ -180,7 +180,7 @@ namespace Embeddinator.Generators
             PushBlock();
 
             var typeName = typedef.Type.Visit(CTypePrinter);
-            WriteLine("typedef {0} {1};", typeName, typedef.Name);
+            WriteLine($"typedef {typeName} {typedef};");
 
             var newlineKind = NewLineKind.BeforeNextBlock;
 

--- a/binder/Generators/C/CHeaders.cs
+++ b/binder/Generators/C/CHeaders.cs
@@ -102,7 +102,7 @@ namespace Embeddinator.Generators
             PushBlock();
 
             var enumName = Options.GeneratorKind != GeneratorKind.CPlusPlus ?
-                @enum.QualifiedName : @enum.Name;
+                CGenerator.QualifiedName(@enum) : @enum.Name;
             
             Write($"typedef enum {enumName}");
 

--- a/binder/Generators/C/CHeaders.cs
+++ b/binder/Generators/C/CHeaders.cs
@@ -108,8 +108,7 @@ namespace Embeddinator.Generators
 
             if (Options.GeneratorKind == GeneratorKind.CPlusPlus)
             {
-                var typePrinter = CTypePrinter;
-                var typeName = typePrinter.VisitPrimitiveType(
+                var typeName = CTypePrinter.VisitPrimitiveType(
                     @enum.BuiltinType.Type, new TypeQualifiers());
 
                 if (@enum.BuiltinType.Type != PrimitiveType.Int)

--- a/binder/Generators/C/CMarshal.cs
+++ b/binder/Generators/C/CMarshal.cs
@@ -503,7 +503,7 @@ namespace Embeddinator.Generators
                 integerType, newArgName, Context.ArgName);
             Context.Return.Write("&{0}", newArgName);
             Context.SupportAfter.WriteLine("*{0} = ({1}) {2};", Context.ArgName,
-                @enum.QualifiedName, newArgName);
+                @enum.Visit(CTypePrinter), newArgName);
         }
 
         public override bool VisitPointerType(PointerType pointer,

--- a/binder/Generators/C/CSources.cs
+++ b/binder/Generators/C/CSources.cs
@@ -230,8 +230,8 @@ namespace Embeddinator.Generators
 
             if (method.IsConstructor)
             {
-                var alloc = GenerateClassObjectAlloc(@class.QualifiedName);
-                WriteLine($"{@class.QualifiedName}* {objectId} = {alloc};");
+                var alloc = GenerateClassObjectAlloc(@class);
+                WriteLine($"{@class.Visit(CTypePrinter)}* {objectId} = {alloc};");
 
                 var classId = $"class_{@class.QualifiedName}";
                 WriteLine("MonoObject* {0} = mono_object_new({1}.domain, {2});",

--- a/binder/Generators/C/CTypes.cs
+++ b/binder/Generators/C/CTypes.cs
@@ -29,8 +29,7 @@ namespace Embeddinator.Generators
 
         public override string VisitCILType(CILType type, TypeQualifiers quals)
         {
-            throw new System.NotImplementedException(
-                string.Format("Unhandled .NET type: {0}", type.Type));
+            throw new NotImplementedException($"Unhandled .NET type: {type.Type}");
         }
 
         public override string VisitClassDecl(Class @class)
@@ -93,7 +92,7 @@ namespace Embeddinator.Generators
             typeName = AsCIdentifier(typeName);
             typeName = StringHelpers.Capitalize(typeName);
 
-            return string.Format("{0}Array", typeName);
+            return $"{typeName}Array";
         }
 
         public override string VisitUnsupportedType(UnsupportedType type, TypeQualifiers quals)

--- a/binder/Generators/C/CTypes.cs
+++ b/binder/Generators/C/CTypes.cs
@@ -11,6 +11,12 @@ namespace Embeddinator.Generators
 
         public bool IsByRefParameter => param != null && (param.IsOut || param.IsInOut);
 
+        public override string VisitDeclaration(Declaration decl)
+        {
+            var name = base.VisitDeclaration(decl);
+            return CGenerator.QualifiedName(decl);
+        }
+
         public override string VisitDecayedType(DecayedType decayed,
             TypeQualifiers quals)
         {

--- a/binder/Generators/Java/JavaMarshal.cs
+++ b/binder/Generators/Java/JavaMarshal.cs
@@ -1,5 +1,4 @@
 ﻿﻿﻿using CppSharp.AST;
-using CppSharp.AST.Extensions;
 
 namespace Embeddinator.Generators
 {

--- a/binder/Generators/Java/JavaTypePrinter.cs
+++ b/binder/Generators/Java/JavaTypePrinter.cs
@@ -162,7 +162,6 @@ namespace Embeddinator.Generators
                 case PrimitiveType.Null: return JavaGenerator.IntPtrType;
                 case PrimitiveType.String: return "String";
                 case PrimitiveType.Decimal: return "java.math.BigDecimal";
-
             }
 
             throw new NotSupportedException();

--- a/binder/Generators/ObjC/ObjCSources.cs
+++ b/binder/Generators/ObjC/ObjCSources.cs
@@ -23,9 +23,9 @@ namespace Embeddinator.Generators
             this.GenerateObjCMethodSignature(method);
         }
 
-        public override string GenerateClassObjectAlloc(string type)
+        public override string GenerateClassObjectAlloc(Declaration decl)
         {
-            return $"[[{type} alloc]init]";
+            return $"[[{decl.Visit(CTypePrinter)} alloc]init]";
         }
 
         public override bool VisitClassDecl(Class @class)

--- a/binder/Options.cs
+++ b/binder/Options.cs
@@ -9,7 +9,7 @@ namespace Embeddinator
         /// <summary>
         /// The list of generators that will be targeted.
         /// </summary>
-        public IEnumerable<GeneratorKind> GeneratorKinds;
+        public IEnumerable<GeneratorKind> GeneratorKinds = new List<GeneratorKind>();
 
         /// <summary>
         /// The name of the library to be bound.

--- a/binder/Options.cs
+++ b/binder/Options.cs
@@ -1,9 +1,16 @@
+using System.Collections.Generic;
 using CppSharp;
+using CppSharp.Generators;
 
 namespace Embeddinator
 {
     public class Options : DriverOptions
     {
+        /// <summary>
+        /// The list of generators that will be targeted.
+        /// </summary>
+        public IEnumerable<GeneratorKind> GeneratorKinds;
+
         /// <summary>
         /// The name of the library to be bound.
         /// </summary>

--- a/binder/Passes/GenerateArrayTypes.cs
+++ b/binder/Passes/GenerateArrayTypes.cs
@@ -53,7 +53,7 @@ namespace Embeddinator.Passes
 
             var typedef = new TypedefDecl
             {
-                Name = string.Format("_{0}", typeName),
+                Name = $"_{typeName}",
                 Namespace = @namespace,
                 QualifiedType = new QualifiedType(new TagType(MonoEmbedArray))
             };

--- a/binder/Passes/GenerateObjectTypes.cs
+++ b/binder/Passes/GenerateObjectTypes.cs
@@ -100,7 +100,7 @@ namespace Embeddinator.Passes
         {
             var typedef = new TypedefDecl
             {
-                Name = @class.QualifiedName,
+                Name = CGenerator.QualifiedName(@class),
                 Namespace = TranslationUnit,
                 QualifiedType = new QualifiedType(new TagType(MonoEmbedObject))
             };


### PR DESCRIPTION
We need to do this because of Swift's lack of namespaces and global scope operators and it's the only way of disambiguating between C interop types and Swift generated types.