### PR TITLE
[android] update latest 15-4 stable branch of Xamarin.Android

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ environment:
 
 cache:
   - packages -> **\packages.config
-  - external\Xamarin.Android -> build.cake
+  - external\Xamarin.Android -> build\Android.cake
 
 #---------------------------------#
 #    build scripts                #

--- a/build/Android.cake
+++ b/build/Android.cake
@@ -19,8 +19,9 @@ Task("Download-Xamarin-Android")
         Console.WriteLine("Downloading Xamarin.Android SDK, this will take a while...");
 
         //We can also update this URL later from here: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure/
-        var artifact = "oss-xamarin.android_v7.4.99.16_Darwin-x86_64_master_e83c99c";
-        var url = $"https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/444/Azure/processDownloadRequest/xamarin-android/{artifact}.zip";
+        var artifact = "oss-xamarin.android_v8.0.0.37_Darwin-x86_64_HEAD_376f684";
+        var buildId = 682;
+        var url = $"https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/{buildId}/Azure/processDownloadRequest/xamarin-android/{artifact}.zip";
         var temp = DownloadFile(url);
         var tempDir = temp.GetDirectory() + "/" + artifact;
         try

--- a/support/java/android/AndroidImpl.java
+++ b/support/java/android/AndroidImpl.java
@@ -33,6 +33,14 @@ public class AndroidImpl extends DesktopImpl {
         String cacheDir     = context.getCacheDir ().getAbsolutePath ();
         String dataDir      = app.nativeLibraryDir;
         ClassLoader loader  = context.getClassLoader ();
+        java.io.File external0 = android.os.Environment.getExternalStorageDirectory ();
+        String externalDir = new java.io.File (
+                                external0,
+                                "Android/data/" + context.getPackageName () + "/files/.__override__").getAbsolutePath ();
+        String externalLegacyDir = new java.io.File (
+                                external0,
+                                "../legacy/Android/data/" + context.getPackageName () + "/files/.__override__").getAbsolutePath ();
+
 
         mono.android.Runtime.init (
                 language,
@@ -44,9 +52,10 @@ public class AndroidImpl extends DesktopImpl {
                         dataDir,
                 },
                 loader,
-                new java.io.File (
-                        android.os.Environment.getExternalStorageDirectory (),
-                        "Android/data/" + context.getPackageName () + "/files/.__override__").getAbsolutePath (),
+                new String[] {
+                        externalDir,
+                        externalLegacyDir
+                },
                 new String[] {
                         library + ".dll",
                         "Resource.designer.dll"


### PR DESCRIPTION
MSBuild tasks changed a bit:
- Aapt needs to conditionally run if there are no resources
- ResolveLibraryProjectImports had changes to required properties
- Using shorter names for intermediate directories

Other changes:
- Xamarin.Android’s mono.android.Runtime.init had API changes.
- URLs in cake script to download 15-4 build artifact from Jenkins
- AppVeyor cache should watch for `build\Android.cake` changes

After this PR, I'll look at getting API-26 support as the default.