### PR TITLE
[android] latest Android Studio test project updates

### DIFF
--- a/tests/android/app/build.gradle
+++ b/tests/android/app/build.gradle
@@ -27,13 +27,13 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:25.4.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile 'com.google.android.gms:play-services-games:11.4.2'
-    compile 'junit:junit:4.12'
-    compile project(':managed')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.android.support:appcompat-v7:25.4.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.google.android.gms:play-services-games:11.4.2'
+    implementation 'junit:junit:4.12'
+    implementation project(':managed')
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 }

--- a/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
+++ b/tests/android/app/src/androidTest/java/mono/embeddinator/AndroidTests.java
@@ -125,6 +125,13 @@ public class AndroidTests {
     }
 
     @Test
+    public void sendActivity() {
+        Activity expected = rule.getActivity();
+        Activity actual = AndroidAssertions.sendActivity(expected);
+        assertSame(expected, actual);
+    }
+
+    @Test
     public void virtualCallback() throws Throwable {
         VirtualClass callback = new VirtualClass() {
             @Override

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tests/managed/android/android.cs
+++ b/tests/managed/android/android.cs
@@ -104,6 +104,14 @@ namespace Android
         {
             return LocalBroadcastManager.GetInstance(Application.Context);
         }
+
+        [Export("sendActivity")]
+        public static Activity SendActivity(Activity activity)
+        {
+            if (activity == null)
+                throw new Exception("Activity should not be null!");
+            return activity;
+        }
     }
 
     [Register("mono.embeddinator.android.JavaCallbacks")]


### PR DESCRIPTION
- Prompted to update gradle to 3.0.1
- Fixed warnings about deprecated `compile` and `androidTestCompile`
- New test case for #546 