### PR TITLE
Add required Mono.TextTransform dependency to packages.config

### DIFF
--- a/build/projects/packages.config
+++ b/build/projects/packages.config
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net46" />
+  <package id="Mono.TextTransform" version="1.0.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
When building, build will fail if this package is not present.  Adding a dependency to the package in nuget fixes the issue.

This issue was initially found on macOS High Sierra, Visual Studio for Mac Community Edition