### PR TITLE
Do not lookup Java SDK path on global Cake scope.

### DIFF
--- a/build/Tests.cake
+++ b/build/Tests.cake
@@ -191,8 +191,6 @@ string GetJavaSdkPath()
     return javaHome;
 }
 
-string javaHome = GetJavaSdkPath();
-
 var classPath = string.Join(IsRunningOnWindows() ? ";" : ":", new[]
 {
     "./external/junit/hamcrest-core-1.3.jar",
@@ -207,7 +205,7 @@ Task("Build-Java-Tests")
     {
         var output = mkDir + Directory("java");
         var tests = File("./tests/common/java/mono/embeddinator/Tests.java");
-        var javac = IsRunningOnLinux() ? "javac" : Directory(javaHome) + File("bin/javac");
+        var javac = IsRunningOnLinux() ? "javac" : Directory(GetJavaSdkPath()) + File("bin/javac");
         Exec(javac, $"-cp {classPath} -d {output} -Xdiags:verbose -Xlint:deprecation -Xlint:unchecked {tests}");
     });
 
@@ -215,7 +213,7 @@ Task("Run-Java-Tests")
     .IsDependentOn("Build-Java-Tests")
     .Does(() =>
     {
-        var java = IsRunningOnLinux() ? "java" : Directory(javaHome) + File("bin/java");
+        var java = IsRunningOnLinux() ? "java" : Directory(GetJavaSdkPath()) + File("bin/java");
         Exec(java, $"-cp {classPath} -Djna.dump_memory=true -Djna.nosys=true org.junit.runner.JUnitCore mono.embeddinator.Tests");
     });
 


### PR DESCRIPTION
Fixes https://github.com/mono/Embeddinator-4000/issues/564.