### PR TITLE
JavaTypePrinter: return JNA Pointer for any pointer type

### DIFF
--- a/binder/Generators/Java/JavaTypePrinter.cs
+++ b/binder/Generators/Java/JavaTypePrinter.cs
@@ -114,8 +114,11 @@ namespace MonoEmbeddinator4000.Generators
         public override TypePrinterResult VisitPointerType(PointerType pointer,
             TypeQualifiers quals)
         {
-            var pointee = pointer.Pointee;
-            return pointer.QualifiedPointee.Visit(this);
+            return new TypePrinterResult
+            {
+                Type = "com.sun.jna.Pointer",
+                TypeMap = pointer.QualifiedPointee.Visit (this).TypeMap 
+            };
         }
 
         public override TypePrinterResult VisitPrimitiveType(PrimitiveType primitive,


### PR DESCRIPTION
I'm almost sure that there should be more appropriate way to return a TypePrinterResult (especially with TypeMap) but this at least generates non-void return code.

This should fix https://github.com/mono/Embeddinator-4000/issues/571 (I still cannot compile the entire mscorlib.dll due to other issues).