### PR TITLE
[android] Improvements to Resource.designer.dll generation

### DIFF
--- a/tests/MonoEmbeddinator4000.Tests/Approvals/ResourceDesignerTest.Anim.approved.txt
+++ b/tests/MonoEmbeddinator4000.Tests/Approvals/ResourceDesignerTest.Anim.approved.txt
@@ -11,26 +11,28 @@
 [assembly: Android.Runtime.ResourceDesignerAttribute("__embeddinator__.Resource", IsApplication=true)]
 
 namespace @__embeddinator__ {
-    using System;
     using Android.Runtime;
     
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
     public class Resource {
         
-        private static Int32 ReadFieldInt(IntPtr R, String fieldName) {
-            IntPtr fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "I");
+        private static int ReadFieldInt(System.IntPtr R, string fieldName) {
+            System.IntPtr fieldId;
+            fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "I");
             return JNIEnv.GetStaticIntField(R, fieldId);
         }
         
-        private static Int32[] ReadFieldArray(IntPtr R, String fieldName) {
-            IntPtr fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "[I");
-            IntPtr value = JNIEnv.GetStaticObjectField(R, fieldId);
-            return JNIEnv.GetArray<Int32>(value);
+        private static int[] ReadFieldArray(System.IntPtr R, string fieldName) {
+            System.IntPtr fieldId;
+            System.IntPtr value;
+            fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "[I");
+            value = JNIEnv.GetStaticObjectField(R, fieldId);
+            return JNIEnv.GetArray<int>(value);
         }
         
         public static void UpdateIdValues() {
-            IntPtr R;
+            System.IntPtr R;
             R = JNIEnv.FindClass("com.mono.embeddinator.R$anim");
             managedandroid.Resource.Animation.THIS_IS_CAPS = ReadFieldInt(R, "THIS_IS_CAPS");
             managedandroid.Resource.Animation.applicationName = ReadFieldInt(R, "applicationName");

--- a/tests/MonoEmbeddinator4000.Tests/Approvals/ResourceDesignerTest.Full.approved.txt
+++ b/tests/MonoEmbeddinator4000.Tests/Approvals/ResourceDesignerTest.Full.approved.txt
@@ -11,26 +11,28 @@
 [assembly: Android.Runtime.ResourceDesignerAttribute("__embeddinator__.Resource", IsApplication=true)]
 
 namespace @__embeddinator__ {
-    using System;
     using Android.Runtime;
     
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
     public class Resource {
         
-        private static Int32 ReadFieldInt(IntPtr R, String fieldName) {
-            IntPtr fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "I");
+        private static int ReadFieldInt(System.IntPtr R, string fieldName) {
+            System.IntPtr fieldId;
+            fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "I");
             return JNIEnv.GetStaticIntField(R, fieldId);
         }
         
-        private static Int32[] ReadFieldArray(IntPtr R, String fieldName) {
-            IntPtr fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "[I");
-            IntPtr value = JNIEnv.GetStaticObjectField(R, fieldId);
-            return JNIEnv.GetArray<Int32>(value);
+        private static int[] ReadFieldArray(System.IntPtr R, string fieldName) {
+            System.IntPtr fieldId;
+            System.IntPtr value;
+            fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "[I");
+            value = JNIEnv.GetStaticObjectField(R, fieldId);
+            return JNIEnv.GetArray<int>(value);
         }
         
         public static void UpdateIdValues() {
-            IntPtr R;
+            System.IntPtr R;
             R = JNIEnv.FindClass("com.mono.embeddinator.R$attr");
             managedandroid.Resource.Attribute.hello = ReadFieldInt(R, "hello");
             R = JNIEnv.FindClass("com.mono.embeddinator.R$id");

--- a/tests/MonoEmbeddinator4000.Tests/Approvals/ResourceDesignerTest.FullWithResourceFile.approved.txt
+++ b/tests/MonoEmbeddinator4000.Tests/Approvals/ResourceDesignerTest.FullWithResourceFile.approved.txt
@@ -11,26 +11,28 @@
 [assembly: Android.Runtime.ResourceDesignerAttribute("__embeddinator__.Resource", IsApplication=true)]
 
 namespace @__embeddinator__ {
-    using System;
     using Android.Runtime;
     
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
     public class Resource {
         
-        private static Int32 ReadFieldInt(IntPtr R, String fieldName) {
-            IntPtr fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "I");
+        private static int ReadFieldInt(System.IntPtr R, string fieldName) {
+            System.IntPtr fieldId;
+            fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "I");
             return JNIEnv.GetStaticIntField(R, fieldId);
         }
         
-        private static Int32[] ReadFieldArray(IntPtr R, String fieldName) {
-            IntPtr fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "[I");
-            IntPtr value = JNIEnv.GetStaticObjectField(R, fieldId);
-            return JNIEnv.GetArray<Int32>(value);
+        private static int[] ReadFieldArray(System.IntPtr R, string fieldName) {
+            System.IntPtr fieldId;
+            System.IntPtr value;
+            fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "[I");
+            value = JNIEnv.GetStaticObjectField(R, fieldId);
+            return JNIEnv.GetArray<int>(value);
         }
         
         public static void UpdateIdValues() {
-            IntPtr R;
+            System.IntPtr R;
             R = JNIEnv.FindClass("com.mono.embeddinator.R$attr");
             managedandroid.Resource.Attribute.hello = ReadFieldInt(R, "hello");
             R = JNIEnv.FindClass("com.mono.embeddinator.R$id");

--- a/tests/MonoEmbeddinator4000.Tests/Approvals/ResourceDesignerTest.String.approved.txt
+++ b/tests/MonoEmbeddinator4000.Tests/Approvals/ResourceDesignerTest.String.approved.txt
@@ -11,26 +11,28 @@
 [assembly: Android.Runtime.ResourceDesignerAttribute("__embeddinator__.Resource", IsApplication=true)]
 
 namespace @__embeddinator__ {
-    using System;
     using Android.Runtime;
     
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
     public class Resource {
         
-        private static Int32 ReadFieldInt(IntPtr R, String fieldName) {
-            IntPtr fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "I");
+        private static int ReadFieldInt(System.IntPtr R, string fieldName) {
+            System.IntPtr fieldId;
+            fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "I");
             return JNIEnv.GetStaticIntField(R, fieldId);
         }
         
-        private static Int32[] ReadFieldArray(IntPtr R, String fieldName) {
-            IntPtr fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "[I");
-            IntPtr value = JNIEnv.GetStaticObjectField(R, fieldId);
-            return JNIEnv.GetArray<Int32>(value);
+        private static int[] ReadFieldArray(System.IntPtr R, string fieldName) {
+            System.IntPtr fieldId;
+            System.IntPtr value;
+            fieldId = JNIEnv.GetStaticFieldID(R, fieldName, "[I");
+            value = JNIEnv.GetStaticObjectField(R, fieldId);
+            return JNIEnv.GetArray<int>(value);
         }
         
         public static void UpdateIdValues() {
-            IntPtr R;
+            System.IntPtr R;
             R = JNIEnv.FindClass("com.mono.embeddinator.R$string");
             managedandroid.Resource.String.THIS_IS_CAPS = ReadFieldInt(R, "THIS_IS_CAPS");
             managedandroid.Resource.String.applicationName = ReadFieldInt(R, "applicationName");

--- a/tests/MonoEmbeddinator4000.Tests/DriverTest.cs
+++ b/tests/MonoEmbeddinator4000.Tests/DriverTest.cs
@@ -209,6 +209,16 @@ namespace Embeddinator.Tests
             RunDriver("Interfaces");
         }
 
+        [Test, Category ("Slow")]
+        public void DuplicateMscorlibTypes()
+        {
+            options.Compilation.Platform = TargetPlatform.Android;
+            options.GeneratorKind = GeneratorKind.C;
+            RunDriver("mscorlib");
+            options.GeneratorKind = GeneratorKind.Java;
+            RunDriver("mscorlib");
+        }
+
         /// <summary>
         /// Validates we get native libraries from the assembly
         /// </summary>

--- a/tests/MonoEmbeddinator4000.Tests/MonoEmbeddinator4000.Tests.csproj
+++ b/tests/MonoEmbeddinator4000.Tests/MonoEmbeddinator4000.Tests.csproj
@@ -100,6 +100,7 @@
     <EmbeddedResource Include="Samples\Enums.cs" />
     <EmbeddedResource Include="Samples\Interfaces.cs" />
     <EmbeddedResource Include="Samples\Resource.Anim.cs" />
+    <EmbeddedResource Include="Samples\mscorlib.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/MonoEmbeddinator4000.Tests/Samples/mscorlib.cs
+++ b/tests/MonoEmbeddinator4000.Tests/Samples/mscorlib.cs
@@ -1,0 +1,8 @@
+﻿namespace System
+{
+    public class String { }
+
+    public class Int32 { }
+
+    public class IntPtr { }
+}


### PR DESCRIPTION
Fixes #582

- Added a test case to repro #582
- Improved upon `System.CodeDom` logic, to use more specific type names
via `CodeTypeReference` instead of strings
- no longer need `using System;`
- Improved upon the number of assemblies that `Resource.designer.dll`
references. We only need to reference input assemblies that contain
`Resource` classes generated by Xamarin.Android.
- Updated approval tests to match the new generated code