### PR TITLE
[java] Fixed generation conflict with properties and methods

### DIFF
--- a/binder/Passes/CheckDeclarationsPass.cs
+++ b/binder/Passes/CheckDeclarationsPass.cs
@@ -16,6 +16,11 @@ namespace Embeddinator.Passes
             // Remove get_ or set_ from names in case they are properties.
             var name = decl.Name.TrimStart("get_").TrimStart("set_");
 
+            // Do the same for method names starting with get or set since they
+            // might conflict with properties.
+            name = decl.Name.TrimStart("get").TrimStart("set").
+                             TrimStart("Get").TrimStart("Set");
+
             // Remove prefixes for explicit interface methods.
             name = name.Substring(decl.Name.LastIndexOf(".", StringComparison.Ordinal) + 1);
 

--- a/tests/managed/properties.cs
+++ b/tests/managed/properties.cs
@@ -55,6 +55,16 @@ namespace Properties {
 		public bool IsSecret {
 			get { return secret != 0; }
 		}
+
+		// conflict between property get() and get method
+		public Query Foo => new Query();
+		public Query GetFoo() => Foo;
+		public Query Get_Foo() => Foo;
+		public Query GeT_Foo() => Foo;
+
+		// conflict between property set() and set method
+		public Query Bar { get; set; }
+		public Query SetBar() => Bar;
 	}
 
 	public class DuplicateIndexedProperties {


### PR DESCRIPTION
Fixed generation conflict with properties and methods starting with get/set.

This was a regression caused by https://github.com/mono/Embeddinator-4000/pull/542

Fixes https://github.com/mono/Embeddinator-4000/issues/580.