### PR TITLE
Manually loading the monosgen-2.0 library to support API < 18

### DIFF
--- a/support/java/android/AndroidImpl.java
+++ b/support/java/android/AndroidImpl.java
@@ -22,7 +22,9 @@ public class AndroidImpl extends DesktopImpl {
         );
         context.registerReceiver (new mono.android.app.NotifyTimeZoneChanges(), timezoneChangedFilter);
 
+        // dependencies must be loaded prior to library in API < 18
         System.loadLibrary("monodroid");
+        System.loadLibrary("monosgen-2.0");
         System.loadLibrary(library);
         setAssemblyPrefix();
 


### PR DESCRIPTION
Fixes #615 