### PR TITLE
[fsharp] update test projects

### DIFF
--- a/build/Tests.cake
+++ b/build/Tests.cake
@@ -1,5 +1,6 @@
 var managedDll = Directory("./tests/managed/generic/bin") + Directory(configuration) + File("managed.dll");
 var fsharpManagedDll = Directory("./tests/managed/fsharp-generic/bin") + Directory(configuration) + File("fsharpManaged.dll");
+var fsharpCoreDll = Directory("./tests/managed/fsharp-generic/bin") + Directory(configuration) + File("FSharp.Core.dll");
 
 /// ---------------------------
 /// Managed test projects
@@ -131,6 +132,8 @@ Task("Build-C-Tests")
             System.IO.Path.GetFileName(managedDll));
         System.IO.File.Copy(fsharpManagedDll, $"{mkDir}/bin/{configuration}/" +
             System.IO.Path.GetFileName(fsharpManagedDll));
+        System.IO.File.Copy(fsharpCoreDll, $"{mkDir}/bin/{configuration}/" +
+            System.IO.Path.GetFileName(fsharpCoreDll));
 
         if (IsRunningOnWindows())
         {

--- a/tests/managed/fsharp-android/fsharp-android.fsproj
+++ b/tests/managed/fsharp-android/fsharp-android.fsproj
@@ -13,7 +13,7 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/managed/fsharp-generic/fsharp-generic.fsproj
+++ b/tests/managed/fsharp-generic/fsharp-generic.fsproj
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>1d70c6b6-b63d-49f3-ac02-e6f93baa4377</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>managed</RootNamespace>
@@ -54,16 +53,11 @@
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core">
-      <Name>FSharp.Core</Name>
-      <AssemblyName>FSharp.Core.dll</AssemblyName>
-      <HintPath>..\..\..\packages\FSharp.Core.4.2.3\lib\net40\FSharp.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.3.1\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -72,4 +66,7 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/tests/managed/fsharp-generic/packages.config
+++ b/tests/managed/fsharp-generic/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.ValueTuple" version="4.3.1" targetFramework="net45" />
   <package id="FSharp.Core" version="4.0.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Test projects failing to build on Linux on TravisCI, perhaps this will
fix it? This seems to be happening since #616, but I think it is a change on
the TravisCI build bots.

Changes:
- FSharp Android project shouldn't have `AndroidUseLatestPlatformSdk` on
- We don't need `System.ValueTuple`
- The `Build-C-Tests` Cake task should also copy `FSharp.Core.dll` as using
the system one doesn't seem to be working reliably on TravisCI