### PR TITLE
[objc] Support API with arrays of enums. Fix #561

### DIFF
--- a/objcgen/objcgenerator.cs
+++ b/objcgen/objcgenerator.cs
@@ -525,7 +525,8 @@ namespace Embeddinator.ObjC {
 			case TypeCode.UInt16:
 			case TypeCode.UInt32:
 			case TypeCode.UInt64:
-				var ctype = NameGenerator.GetTypeName (t);
+				var ut = t.IsEnum ? t.GetEnumUnderlyingType () : t;
+				var ctype = NameGenerator.GetTypeName (ut);
 				string ctypep;
 				if (typecode == TypeCode.SByte)
 					ctypep = "Char"; // GetTypeName returns signed char
@@ -1099,7 +1100,8 @@ namespace Embeddinator.ObjC {
 			case TypeCode.UInt16:
 			case TypeCode.UInt32:
 			case TypeCode.UInt64:
-				var ctype = NameGenerator.GetTypeName (t);
+				var dt = t.IsEnum ? t.GetEnumUnderlyingType () : t;
+				var ctype = NameGenerator.GetTypeName (dt);
 				string ctypep;
 				if (typecode == TypeCode.SByte)
 					ctypep = "Char"; // GetTypeName returns signed char

--- a/tests/managed/enums.cs
+++ b/tests/managed/enums.cs
@@ -42,5 +42,20 @@ namespace Enums {
 			i = i == IntEnum.Min ? IntEnum.Max : IntEnum.Min;
 			return ByteFlags.Bit5 | ByteFlags.Bit1;
 		}
+
+		public static int Count (IntEnum[] values)
+		{
+			return values == null ? 0 : values.Length;
+		}
+
+		// NSData is not ideal if `byte` is used as the underlying type
+		public static ByteEnum[] Bucket { get; set; }
+	}
+
+	public class github561 {
+		[Flags]
+		public enum ModeOfTransportW { Bus = 0b1, Tram = 0b10, Train = 0b100, }
+
+		public ModeOfTransportW[] ModesOfTransport { get; set; }
 	}
 }


### PR DESCRIPTION
This is not optimal, since an `NSArray` of enums can't be done
without turning everything into `NSNumber`.

However the current code does not compile and that's worse that
an suboptimal API.

Fix https://github.com/mono/Embeddinator-4000/issues/561