### PR TITLE
[tests] NetStandard project wasn't referencing shared project

### DIFF
--- a/tests/managed/netstandard/managed-netstandard.csproj
+++ b/tests/managed/netstandard/managed-netstandard.csproj
@@ -4,4 +4,5 @@
     <AssemblyName>managed</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <Import Project="..\managed-shared.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
Relates to #518, but everything appeared to work on my Windows machine