### PR TITLE
Restored: missing code for extension support on Mac + bitcode for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Generates target language bindings for interop with managed code.
 
       --gen=VALUE            target generator (C, C++, Obj-C, Java)
   -p, --platform=VALUE       target platform (iOS, macOS, Android, Windows)
+  -e, --extension            compiles as an extension safe api
+      --bitcode=VALUE        bitcode option (default, true, false)
   -o, --out, --outdir=VALUE  output directory
   -c, --compile              compiles the generated output
   -d, --debug                enables debug mode for generated native and

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -88,6 +88,10 @@ The dependency mentioned in the error message was found on the system, but it's 
 
 Could not create the symlink mentioned in the error message.
 
+<h3><a name="EM0017">EM0017: The bitcode option `X` is not valid.</h3>
+
+The tool does not support the bitcode option `X`. Use either default, true or false.
+
 <h3><a name="EM0026"/>EM0026 Could not parse the command line argument 'A': *</h3>
 
 The syntax given for the command line option `A` could not be parsed by the tool. It is likely incorrect, please check with the documentation or help for the correct syntax.

--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -36,13 +36,6 @@ namespace Embeddinator.ObjC
 		ObjectiveC,
 	}
 
-	public enum BitcodeOption
-	{
-		Default,
-		True,
-		False,
-	}
-
 	public static class Driver
 	{
 		public static Embedder CurrentEmbedder { get; private set; }

--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -59,6 +59,7 @@ namespace Embeddinator.ObjC
 			var os = new OptionSet {
 				{ "c|compile", "Compiles the generated output", v => embedder.CompileCode = true },
 				{ "e|extension", "Compiles the generated output as extension safe api", v => embedder.Extension = true },
+				{ "nobitcode", "Compiles the generated output without bitcode enabled", v => embedder.NoBitcode = true },
 				{ "d|debug", "Build the native library with debug information.", v => embedder.Debug = true },
 				{ "gen=", $"Target generator (default {embedder.TargetLanguage})", v => embedder.SetTarget (v) },
 				{ "abi=", "A comma-separated list of ABIs to compile. If not specified, all ABIs applicable to the selected platform will be built. Valid values (also depends on platform): i386, x86_64, armv7, armv7s, armv7k, arm64.", (v) =>

--- a/objcgen/driver.cs
+++ b/objcgen/driver.cs
@@ -36,6 +36,13 @@ namespace Embeddinator.ObjC
 		ObjectiveC,
 	}
 
+	public enum BitcodeOption
+	{
+		Default,
+		True,
+		False,
+	}
+
 	public static class Driver
 	{
 		public static Embedder CurrentEmbedder { get; private set; }
@@ -59,7 +66,7 @@ namespace Embeddinator.ObjC
 			var os = new OptionSet {
 				{ "c|compile", "Compiles the generated output", v => embedder.CompileCode = true },
 				{ "e|extension", "Compiles the generated output as extension safe api", v => embedder.Extension = true },
-				{ "nobitcode", "Compiles the generated output without bitcode enabled", v => embedder.NoBitcode = true },
+				{ "bitcode=", "Compiles the generated output with bitcode (default, true, false)", v => embedder.SetBitcode (v) },
 				{ "d|debug", "Build the native library with debug information.", v => embedder.Debug = true },
 				{ "gen=", $"Target generator (default {embedder.TargetLanguage})", v => embedder.SetTarget (v) },
 				{ "abi=", "A comma-separated list of ABIs to compile. If not specified, all ABIs applicable to the selected platform will be built. Valid values (also depends on platform): i386, x86_64, armv7, armv7s, armv7k, arm64.", (v) =>

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -313,19 +313,19 @@ namespace Embeddinator.ObjC
 					break;
 				case Platform.iOS:
 					build_infos = new BuildInfo[] {
-                        new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = iosBitcodeFlags, LinkerFlags = iosBitcodeFlags },
+					new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = iosBitcodeFlags, LinkerFlags = iosBitcodeFlags },
 					new BuildInfo { Sdk = "iPhoneSimulator", Architectures = new string [] { "i386", "x86_64" }, SdkName = "ios-simulator", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphonesimulator.sdk" },
 				};
 					break;
 				case Platform.tvOS:
 					build_infos = new BuildInfo[] {
-                        new BuildInfo { Sdk = "AppleTVOS", Architectures = new string [] { "arm64" }, SdkName = "tvos", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVOS.sdk", CompilerFlags = otherBitcodeFlags, LinkerFlags = otherBitcodeFlags },
+					new BuildInfo { Sdk = "AppleTVOS", Architectures = new string [] { "arm64" }, SdkName = "tvos", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVOS.sdk", CompilerFlags = otherBitcodeFlags, LinkerFlags = otherBitcodeFlags },
 					new BuildInfo { Sdk = "AppleTVSimulator", Architectures = new string [] { "x86_64" }, SdkName = "tvos-simulator", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVSimulator.sdk" },
 				};
 					break;
 				case Platform.watchOS:
 					build_infos = new BuildInfo[] {
-                        new BuildInfo { Sdk = "WatchOS", Architectures = new string [] { "armv7k" }, SdkName = "watchos", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchOS.sdk", CompilerFlags = otherBitcodeFlags, LinkerFlags = otherBitcodeFlags  },
+					new BuildInfo { Sdk = "WatchOS", Architectures = new string [] { "armv7k" }, SdkName = "watchos", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchOS.sdk", CompilerFlags = otherBitcodeFlags, LinkerFlags = otherBitcodeFlags  },
 					new BuildInfo { Sdk = "WatchSimulator", Architectures = new string [] { "i386" }, SdkName = "watchos-simulator", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchSimulator.sdk" },
 				};
 					break;

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -109,9 +109,9 @@ namespace Embeddinator.ObjC
 			}
 		}
 
-		public void SetBitcode(string value)
+		public void SetBitcode (string value)
 		{
-			switch (value.ToLowerInvariant())
+			switch (value.ToLowerInvariant ())
 			{
 				case "default":
 					BitcodeOption = null;
@@ -123,7 +123,7 @@ namespace Embeddinator.ObjC
 					BitcodeOption = false;
 					break;
 				default:
-				    throw new EmbeddinatorException(17, true, $"The bitcode option `{value}` is not valid.");
+				    throw new EmbeddinatorException (17, true, $"The bitcode option `{value}` is not valid.");
 			}
 		}
 
@@ -663,7 +663,7 @@ namespace Embeddinator.ObjC
 							mmp.Append ("-p "); // generate a plist
 							mmp.Append ($"--target-framework {GetTargetFramework ()} ");
 							string extensionFlag = Extension ? "-fapplication-extension" : "";
-                            mmp.Append ($"--link_flags={extensionFlag} -force_load {Utils.Quote (Path.GetFullPath (sdk_output_file))} ");
+							mmp.Append ($"--link_flags={extensionFlag} -force_load {Utils.Quote (Path.GetFullPath (sdk_output_file))} ");
 							if (!Utils.RunProcess ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin/mmp", mmp.ToString (), out exitCode))
 								return exitCode;
 

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -663,7 +663,8 @@ namespace Embeddinator.ObjC
 							mmp.Append ("-p "); // generate a plist
 							mmp.Append ($"--target-framework {GetTargetFramework ()} ");
 							string extensionFlag = Extension ? "-fapplication-extension" : "";
-							mmp.Append ($"--link_flags={extensionFlag} -force_load {Utils.Quote (Path.GetFullPath (sdk_output_file))} ");
+							string forceLoad = $"-force_load {Utils.Quote (Path.GetFullPath (sdk_output_file))}";
+							mmp.Append ($"--link_flags={Utils.Quote (extensionFlag + " " + forceLoad)}");
 							if (!Utils.RunProcess ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin/mmp", mmp.ToString (), out exitCode))
 								return exitCode;
 

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -497,7 +497,7 @@ namespace Embeddinator.ObjC
 							// Archive all the .o files into a .a
 							var archive_options = new StringBuilder ("ar cru ");
 							var static_ofile = Path.Combine (archOutputDirectory, output_file);
-							archive_options.Append (static_ofile).Append (" ");
+							archive_options.Append (Utils.Quote (static_ofile)).Append (" ");
 							lipo_files.Add (static_ofile);
 							foreach (var objfile in object_files)
 								archive_options.Append (objfile).Append (" ");
@@ -663,7 +663,7 @@ namespace Embeddinator.ObjC
 							mmp.Append ("-p "); // generate a plist
 							mmp.Append ($"--target-framework {GetTargetFramework ()} ");
 							string extensionFlag = Extension ? "-fapplication-extension" : "";
-							string forceLoad = $"-force_load {Path.GetFullPath (sdk_output_file)}";
+							string forceLoad = $"-force_load \\\"{Path.GetFullPath (sdk_output_file)}\\\"";
 							mmp.Append ($"--link_flags=\"{extensionFlag + " " + forceLoad}\"");
 							if (!Utils.RunProcess ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin/mmp", mmp.ToString (), out exitCode))
 								return exitCode;

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -123,7 +123,7 @@ namespace Embeddinator.ObjC
 					BitcodeOption = BitcodeOption.False;
 					break;
 				default:
-				throw new EmbeddinatorException(5, true, $"The bitcode option `{value}` is not valid.");
+				throw new EmbeddinatorException(17, true, $"The bitcode option `{value}` is not valid.");
 			}
 		}
 

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -654,7 +654,7 @@ namespace Embeddinator.ObjC
 							mmp.Append ("-p "); // generate a plist
 							mmp.Append ($"--target-framework {GetTargetFramework ()} ");
 							string extensionFlag = Extension ? "-fapplication-extension" : "";
-                            mmp.Append ($"--link_flags={extensionFlag} -force_load \"{Path.GetFullPath (sdk_output_file)}\" ");
+                            mmp.Append ($"--link_flags={extensionFlag} -force_load {Utils.Quote (Path.GetFullPath (sdk_output_file))} ");
 							if (!Utils.RunProcess ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin/mmp", mmp.ToString (), out exitCode))
 								return exitCode;
 

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -291,6 +291,15 @@ namespace Embeddinator.ObjC
 			}
 		}
 
+		string GetBitcodeFlag(bool defaultsToEnable)
+		{
+			const string option = "-fembed-bitcode";
+			if (BitcodeOption == null)
+				return defaultsToEnable? option : string.Empty;
+			else
+				return  BitcodeOption == true? option : string.Empty;
+		}
+
 		public int Compile ()
 		{
 			Console.WriteLine ("Compiling binding code...");
@@ -305,26 +314,26 @@ namespace Embeddinator.ObjC
 				case Platform.macOSModern:
 				case Platform.macOSSystem:
 					build_infos = new BuildInfo[] {
-					new BuildInfo { Sdk = "MacOSX", Architectures = new string [] { "i386", "x86_64" }, SdkName = "macosx", MinVersion = "10.7" },
-				};
+						new BuildInfo { Sdk = "MacOSX", Architectures = new string [] { "i386", "x86_64" }, SdkName = "macosx", MinVersion = "10.7" },
+					};
 					break;
 				case Platform.iOS:
 					build_infos = new BuildInfo[] {
-                    new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = BitcodeOption == null || BitcodeOption == false ? "" : "-fembed-bitcode", LinkerFlags = BitcodeOption == null || BitcodeOption == false ? "" : "-fembed-bitcode" },
-					new BuildInfo { Sdk = "iPhoneSimulator", Architectures = new string [] { "i386", "x86_64" }, SdkName = "ios-simulator", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphonesimulator.sdk" },
-				};
+						new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: false), LinkerFlags = GetBitcodeFlag(defaultsToEnable: false) },
+						new BuildInfo { Sdk = "iPhoneSimulator", Architectures = new string [] { "i386", "x86_64" }, SdkName = "ios-simulator", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphonesimulator.sdk" },
+					};
 					break;
 				case Platform.tvOS:
 					build_infos = new BuildInfo[] {
-                    new BuildInfo { Sdk = "AppleTVOS", Architectures = new string [] { "arm64" }, SdkName = "tvos", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVOS.sdk", CompilerFlags = BitcodeOption == null || BitcodeOption == true ? "-fembed-bitcode" : "", LinkerFlags = BitcodeOption == null || BitcodeOption == true ? "-fembed-bitcode" : "" },
-					new BuildInfo { Sdk = "AppleTVSimulator", Architectures = new string [] { "x86_64" }, SdkName = "tvos-simulator", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVSimulator.sdk" },
-				};
+						new BuildInfo { Sdk = "AppleTVOS", Architectures = new string [] { "arm64" }, SdkName = "tvos", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVOS.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: true), LinkerFlags = GetBitcodeFlag(defaultsToEnable: true) },
+						new BuildInfo { Sdk = "AppleTVSimulator", Architectures = new string [] { "x86_64" }, SdkName = "tvos-simulator", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVSimulator.sdk" },
+					};
 					break;
 				case Platform.watchOS:
 					build_infos = new BuildInfo[] {
-                    new BuildInfo { Sdk = "WatchOS", Architectures = new string [] { "armv7k" }, SdkName = "watchos", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchOS.sdk", CompilerFlags = BitcodeOption == null || BitcodeOption == true ? "-fembed-bitcode" : "", LinkerFlags = BitcodeOption == null || BitcodeOption == true ? "-fembed-bitcode" : "" },
-					new BuildInfo { Sdk = "WatchSimulator", Architectures = new string [] { "i386" }, SdkName = "watchos-simulator", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchSimulator.sdk" },
-				};
+						new BuildInfo { Sdk = "WatchOS", Architectures = new string [] { "armv7k" }, SdkName = "watchos", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchOS.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: true), LinkerFlags = GetBitcodeFlag(defaultsToEnable: true) },
+						new BuildInfo { Sdk = "WatchSimulator", Architectures = new string [] { "i386" }, SdkName = "watchos-simulator", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchSimulator.sdk" },
+					};
 					break;
 				default:
 					throw ErrorHelper.CreateError (99, "Internal error: invalid platform {0}. Please file a bug report with a test case (https://github.com/mono/Embeddinator-4000/issues).", Platform);

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -390,9 +390,7 @@ namespace Embeddinator.ObjC
 					}
 
 					if (Extension)
-					{
-						common_options.Append("-fapplication-extension ");
-					}
+						common_options.Append ("-fapplication-extension ");
 
 					common_options.Append ("-fobjc-arc ");
 					common_options.Append ("-ObjC ");

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -663,8 +663,8 @@ namespace Embeddinator.ObjC
 							mmp.Append ("-p "); // generate a plist
 							mmp.Append ($"--target-framework {GetTargetFramework ()} ");
 							string extensionFlag = Extension ? "-fapplication-extension" : "";
-							string forceLoad = $"-force_load {Utils.Quote (Path.GetFullPath (sdk_output_file))}";
-							mmp.Append ($"--link_flags={Utils.Quote (extensionFlag + " " + forceLoad)}");
+							string forceLoad = $"-force_load {Path.GetFullPath (sdk_output_file)}";
+							mmp.Append ($"--link_flags=\"{extensionFlag + " " + forceLoad}\"");
 							if (!Utils.RunProcess ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin/mmp", mmp.ToString (), out exitCode))
 								return exitCode;
 

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -123,7 +123,7 @@ namespace Embeddinator.ObjC
 					BitcodeOption = false;
 					break;
 				default:
-				    throw new EmbeddinatorException (17, true, $"The bitcode option `{value}` is not valid.");
+					throw new EmbeddinatorException (17, true, $"The bitcode option `{value}` is not valid.");
 			}
 		}
 

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -43,6 +43,8 @@ namespace Embeddinator.ObjC
 
 		public bool Extension { get; set; }
 
+		public bool NoBitcode { get; set; }
+
 		public bool Shared { get { return CompilationTarget == CompilationTarget.SharedLibrary; } }
 
 		public bool EnableLinker { get; set; }
@@ -279,6 +281,8 @@ namespace Embeddinator.ObjC
 
 			BuildInfo[] build_infos;
 
+			string bitcodeFlags = NoBitCode ? null : "-fembed-bitcode";
+
 			switch (Platform) {
 				case Platform.macOS:
 				case Platform.macOSFull:
@@ -290,19 +294,19 @@ namespace Embeddinator.ObjC
 					break;
 				case Platform.iOS:
 					build_infos = new BuildInfo[] {
-					new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = "-fembed-bitcode", LinkerFlags = "-fembed-bitcode" },
+					new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = bitcodeFlags, LinkerFlags = bitcodeFlags },
 					new BuildInfo { Sdk = "iPhoneSimulator", Architectures = new string [] { "i386", "x86_64" }, SdkName = "ios-simulator", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphonesimulator.sdk" },
 				};
 					break;
 				case Platform.tvOS:
 					build_infos = new BuildInfo[] {
-					new BuildInfo { Sdk = "AppleTVOS", Architectures = new string [] { "arm64" }, SdkName = "tvos", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVOS.sdk", CompilerFlags = "-fembed-bitcode", LinkerFlags = "-fembed-bitcode" },
+					new BuildInfo { Sdk = "AppleTVOS", Architectures = new string [] { "arm64" }, SdkName = "tvos", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVOS.sdk", CompilerFlags = bitcodeFlags, LinkerFlags = bitcodeFlags },
 					new BuildInfo { Sdk = "AppleTVSimulator", Architectures = new string [] { "x86_64" }, SdkName = "tvos-simulator", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVSimulator.sdk" },
 				};
 					break;
 				case Platform.watchOS:
 					build_infos = new BuildInfo[] {
-					new BuildInfo { Sdk = "WatchOS", Architectures = new string [] { "armv7k" }, SdkName = "watchos", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchOS.sdk", CompilerFlags = "-fembed-bitcode", LinkerFlags = "-fembed-bitcode"  },
+					new BuildInfo { Sdk = "WatchOS", Architectures = new string [] { "armv7k" }, SdkName = "watchos", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchOS.sdk", CompilerFlags = bitcodeFlags, LinkerFlags = bitcodeFlags  },
 					new BuildInfo { Sdk = "WatchSimulator", Architectures = new string [] { "i386" }, SdkName = "watchos-simulator", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchSimulator.sdk" },
 				};
 					break;

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -388,6 +388,12 @@ namespace Embeddinator.ObjC
 							common_options.Append ("-DTOKENLOOKUP ");
 						}
 					}
+
+                    if (Extension)
+                    {
+                        common_options.Append("-fapplication-extension ");
+                    }
+
 					common_options.Append ("-fobjc-arc ");
 					common_options.Append ("-ObjC ");
 					common_options.Append ("-Wall ");
@@ -629,7 +635,8 @@ namespace Embeddinator.ObjC
 								mmp.Append ("--debug ");
 							mmp.Append ("-p "); // generate a plist
 							mmp.Append ($"--target-framework {GetTargetFramework ()} ");
-							mmp.Append ($"\"--link_flags=-force_load {Path.GetFullPath (sdk_output_file)}\" ");
+                            string extensionFlag = Extension ? "-fapplication-extension" : "";
+                            mmp.Append ($"\"--link_flags={extensionFlag} -force_load {Path.GetFullPath (sdk_output_file)}\" ");
 							if (!Utils.RunProcess ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin/mmp", mmp.ToString (), out exitCode))
 								return exitCode;
 

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -290,7 +290,7 @@ namespace Embeddinator.ObjC
 					break;
 				case Platform.iOS:
 					build_infos = new BuildInfo[] {
-					new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk" },
+					new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = "-fembed-bitcode", LinkerFlags = "-fembed-bitcode" },
 					new BuildInfo { Sdk = "iPhoneSimulator", Architectures = new string [] { "i386", "x86_64" }, SdkName = "ios-simulator", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphonesimulator.sdk" },
 				};
 					break;
@@ -389,10 +389,10 @@ namespace Embeddinator.ObjC
 						}
 					}
 
-                    if (Extension)
-                    {
-                        common_options.Append("-fapplication-extension ");
-                    }
+					if (Extension)
+					{
+						common_options.Append("-fapplication-extension ");
+					}
 
 					common_options.Append ("-fobjc-arc ");
 					common_options.Append ("-ObjC ");
@@ -635,8 +635,8 @@ namespace Embeddinator.ObjC
 								mmp.Append ("--debug ");
 							mmp.Append ("-p "); // generate a plist
 							mmp.Append ($"--target-framework {GetTargetFramework ()} ");
-                            string extensionFlag = Extension ? "-fapplication-extension" : "";
-                            mmp.Append ($"\"--link_flags={extensionFlag} -force_load {Path.GetFullPath (sdk_output_file)}\" ");
+							string extensionFlag = Extension ? "-fapplication-extension" : "";
+							mmp.Append ($"\"--link_flags={extensionFlag} -force_load {Path.GetFullPath (sdk_output_file)}\" ");
 							if (!Utils.RunProcess ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin/mmp", mmp.ToString (), out exitCode))
 								return exitCode;
 

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -43,7 +43,7 @@ namespace Embeddinator.ObjC
 
 		public bool Extension { get; set; }
 
-		public bool NoBitcode { get; set; }
+		public BitcodeOption BitcodeOption { get; set; }
 
 		public bool Shared { get { return CompilationTarget == CompilationTarget.SharedLibrary; } }
 
@@ -106,6 +106,24 @@ namespace Embeddinator.ObjC
 					break;
 				default:
 					throw new EmbeddinatorException (4, true, $"The target `{value}` is not valid.");
+			}
+		}
+
+		public void SetBitcode(string value)
+		{
+			switch (value.ToLowerInvariant())
+			{
+				case "default":
+					BitcodeOption = BitcodeOption.Default;
+					break;
+				case "true":
+					BitcodeOption = BitcodeOption.True;
+					break;
+				case "false":
+					BitcodeOption = BitcodeOption.False;
+					break;
+				default:
+				throw new EmbeddinatorException(5, true, $"The bitcode option `{value}` is not valid.");
 			}
 		}
 
@@ -281,7 +299,8 @@ namespace Embeddinator.ObjC
 
 			BuildInfo[] build_infos;
 
-			string bitcodeFlags = NoBitCode ? null : "-fembed-bitcode";
+            var iosBitcodeFlags = BitcodeOption == BitcodeOption.Default ? "" : ( BitcodeOption == BitcodeOption.True ? "-fembed-bitcode" : "" );
+            var otherBitcodeFlags = BitcodeOption == BitcodeOption.Default ? "-fembed-bitcode" : ( BitcodeOption == BitcodeOption.True ? "-fembed-bitcode" : "" );
 
 			switch (Platform) {
 				case Platform.macOS:
@@ -294,19 +313,19 @@ namespace Embeddinator.ObjC
 					break;
 				case Platform.iOS:
 					build_infos = new BuildInfo[] {
-					new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = bitcodeFlags, LinkerFlags = bitcodeFlags },
+                        new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = iosBitcodeFlags, LinkerFlags = iosBitcodeFlags },
 					new BuildInfo { Sdk = "iPhoneSimulator", Architectures = new string [] { "i386", "x86_64" }, SdkName = "ios-simulator", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphonesimulator.sdk" },
 				};
 					break;
 				case Platform.tvOS:
 					build_infos = new BuildInfo[] {
-					new BuildInfo { Sdk = "AppleTVOS", Architectures = new string [] { "arm64" }, SdkName = "tvos", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVOS.sdk", CompilerFlags = bitcodeFlags, LinkerFlags = bitcodeFlags },
+                        new BuildInfo { Sdk = "AppleTVOS", Architectures = new string [] { "arm64" }, SdkName = "tvos", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVOS.sdk", CompilerFlags = otherBitcodeFlags, LinkerFlags = otherBitcodeFlags },
 					new BuildInfo { Sdk = "AppleTVSimulator", Architectures = new string [] { "x86_64" }, SdkName = "tvos-simulator", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVSimulator.sdk" },
 				};
 					break;
 				case Platform.watchOS:
 					build_infos = new BuildInfo[] {
-					new BuildInfo { Sdk = "WatchOS", Architectures = new string [] { "armv7k" }, SdkName = "watchos", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchOS.sdk", CompilerFlags = bitcodeFlags, LinkerFlags = bitcodeFlags  },
+                        new BuildInfo { Sdk = "WatchOS", Architectures = new string [] { "armv7k" }, SdkName = "watchos", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchOS.sdk", CompilerFlags = otherBitcodeFlags, LinkerFlags = otherBitcodeFlags  },
 					new BuildInfo { Sdk = "WatchSimulator", Architectures = new string [] { "i386" }, SdkName = "watchos-simulator", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchSimulator.sdk" },
 				};
 					break;

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -291,13 +291,13 @@ namespace Embeddinator.ObjC
 			}
 		}
 
-		string GetBitcodeFlag(bool defaultsToEnable)
+		string GetBitcodeFlag (bool defaultsToEnable)
 		{
 			const string option = "-fembed-bitcode";
 			if (BitcodeOption == null)
-				return defaultsToEnable? option : string.Empty;
+				return defaultsToEnable ? option : string.Empty;
 			else
-				return  BitcodeOption == true? option : string.Empty;
+				return  BitcodeOption == true ? option : string.Empty;
 		}
 
 		public int Compile ()
@@ -314,26 +314,26 @@ namespace Embeddinator.ObjC
 				case Platform.macOSModern:
 				case Platform.macOSSystem:
 					build_infos = new BuildInfo[] {
-						new BuildInfo { Sdk = "MacOSX", Architectures = new string [] { "i386", "x86_64" }, SdkName = "macosx", MinVersion = "10.7" },
-					};
+					new BuildInfo { Sdk = "MacOSX", Architectures = new string [] { "i386", "x86_64" }, SdkName = "macosx", MinVersion = "10.7" },
+				};
 					break;
 				case Platform.iOS:
 					build_infos = new BuildInfo[] {
-						new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: false), LinkerFlags = GetBitcodeFlag(defaultsToEnable: false) },
-						new BuildInfo { Sdk = "iPhoneSimulator", Architectures = new string [] { "i386", "x86_64" }, SdkName = "ios-simulator", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphonesimulator.sdk" },
-					};
+					new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: false), LinkerFlags = GetBitcodeFlag(defaultsToEnable: false) },
+					new BuildInfo { Sdk = "iPhoneSimulator", Architectures = new string [] { "i386", "x86_64" }, SdkName = "ios-simulator", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphonesimulator.sdk" },
+				};
 					break;
 				case Platform.tvOS:
 					build_infos = new BuildInfo[] {
-						new BuildInfo { Sdk = "AppleTVOS", Architectures = new string [] { "arm64" }, SdkName = "tvos", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVOS.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: true), LinkerFlags = GetBitcodeFlag(defaultsToEnable: true) },
-						new BuildInfo { Sdk = "AppleTVSimulator", Architectures = new string [] { "x86_64" }, SdkName = "tvos-simulator", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVSimulator.sdk" },
-					};
+					new BuildInfo { Sdk = "AppleTVOS", Architectures = new string [] { "arm64" }, SdkName = "tvos", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVOS.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: true), LinkerFlags = GetBitcodeFlag(defaultsToEnable: true) },
+					new BuildInfo { Sdk = "AppleTVSimulator", Architectures = new string [] { "x86_64" }, SdkName = "tvos-simulator", MinVersion = "9.0", XamariniOSSDK = "Xamarin.AppleTVSimulator.sdk" },
+				};
 					break;
 				case Platform.watchOS:
 					build_infos = new BuildInfo[] {
-						new BuildInfo { Sdk = "WatchOS", Architectures = new string [] { "armv7k" }, SdkName = "watchos", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchOS.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: true), LinkerFlags = GetBitcodeFlag(defaultsToEnable: true) },
-						new BuildInfo { Sdk = "WatchSimulator", Architectures = new string [] { "i386" }, SdkName = "watchos-simulator", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchSimulator.sdk" },
-					};
+					new BuildInfo { Sdk = "WatchOS", Architectures = new string [] { "armv7k" }, SdkName = "watchos", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchOS.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: true), LinkerFlags = GetBitcodeFlag(defaultsToEnable: true) },
+					new BuildInfo { Sdk = "WatchSimulator", Architectures = new string [] { "i386" }, SdkName = "watchos-simulator", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchSimulator.sdk" },
+				};
 					break;
 				default:
 					throw ErrorHelper.CreateError (99, "Internal error: invalid platform {0}. Please file a bug report with a test case (https://github.com/mono/Embeddinator-4000/issues).", Platform);

--- a/tests/objcgentest/ManagedTest.cs
+++ b/tests/objcgentest/ManagedTest.cs
@@ -51,9 +51,9 @@ namespace ExecutionTests
 		}
 
 		[Test]
-		public void macOS_Extension ()
+		public void macOS_Extension_With_Spaces ()
 		{
-			RunManagedTests (Platform.macOSModern, debug: true, additionalArgs: "--extension");
+			RunManagedTests (Platform.macOSModern, debug: true, forceSpaces: true, additionalArgs: "--extension");
 		}
 
 		[Test]
@@ -148,7 +148,7 @@ namespace ExecutionTests
 			return File.ReadAllLines (path).Count ((v) => System.Text.RegularExpressions.Regex.IsMatch (v, "^\\s*-\\s*[(]\\s*void\\s*[)]\\s*test"));
 		}
 
-		void RunManagedTests (Platform platform, string test_destination = "", bool debug = true, string additionalArgs = "")
+		void RunManagedTests (Platform platform, string test_destination = "", bool debug = true, bool forceSpaces = false, string additionalArgs = "")
 		{
 			string dllname;
 			string dlldir;
@@ -210,10 +210,20 @@ namespace ExecutionTests
 
 			var tmpdir = Cache.CreateTemporaryDirectory ();
 			var configuration = debug ? "Debug" : "Release";
+
 			var dll_path = Path.Combine (XcodeProjectGenerator.TestsRootDirectory, "managed", dlldir, "bin", configuration, dllname);
 
 			// This will build all the managed.dll variants, which is easier than calculating the relative path _as the makefile sees it_ to pass as the target.
 			Asserts.RunProcess ("make", $"all CONFIG={configuration} -C {Utils.Quote (Path.Combine (XcodeProjectGenerator.TestsRootDirectory, "managed"))}", "build " + Path.GetFileName (dll_path));
+
+			if (forceSpaces) {
+				string dll_folder = Path.GetDirectoryName (dll_path);
+				Directory.CreateDirectory (Path.Combine (dll_folder, "with spaces"));
+				string dll_path_with_spaces = Path.Combine (dll_folder, "with spaces", Path.GetFileName (dll_path));
+				File.Copy (dll_path, dll_path_with_spaces, true);
+				dll_path = dll_path_with_spaces;
+			}
+
 
 			var outdir = tmpdir + "/out";
 			var projectName = "foo";

--- a/tests/objcgentest/ManagedTest.cs
+++ b/tests/objcgentest/ManagedTest.cs
@@ -223,7 +223,6 @@ namespace ExecutionTests
 				dll_path = dll_path_with_spaces;
 			}
 
-
 			var outdir = tmpdir + "/out";
 			var projectName = "foo";
 			var args = new List<string> ();

--- a/tests/objcgentest/ManagedTest.cs
+++ b/tests/objcgentest/ManagedTest.cs
@@ -51,6 +51,12 @@ namespace ExecutionTests
 		}
 
 		[Test]
+		public void macOS_Extension ()
+		{
+			RunManagedTests (Platform.macOSModern, debug: true, additionalArgs: "--extension");
+		}
+
+		[Test]
 		[TestCase (true)]
 		[TestCase (false)]
 		public void iOS_simulator (bool debug)
@@ -142,7 +148,7 @@ namespace ExecutionTests
 			return File.ReadAllLines (path).Count ((v) => System.Text.RegularExpressions.Regex.IsMatch (v, "^\\s*-\\s*[(]\\s*void\\s*[)]\\s*test"));
 		}
 
-		void RunManagedTests (Platform platform, string test_destination = "", bool debug = true)
+		void RunManagedTests (Platform platform, string test_destination = "", bool debug = true, string additionalArgs = "")
 		{
 			string dllname;
 			string dlldir;
@@ -220,6 +226,8 @@ namespace ExecutionTests
 			args.Add ("--target=framework");
 			args.Add ($"--platform={platform}");
 			args.Add ($"--abi={abi}");
+			if (additionalArgs.Length > 0)
+				args.Add (additionalArgs);
 			Asserts.Generate ("generate", args.ToArray ());
 
 			var framework_path = Path.Combine (outdir, Path.GetFileNameWithoutExtension (dll_path) + ".framework");

--- a/tests/objcgentest/ManagedTest.cs
+++ b/tests/objcgentest/ManagedTest.cs
@@ -210,7 +210,6 @@ namespace ExecutionTests
 
 			var tmpdir = Cache.CreateTemporaryDirectory ();
 			var configuration = debug ? "Debug" : "Release";
-
 			var dll_path = Path.Combine (XcodeProjectGenerator.TestsRootDirectory, "managed", dlldir, "bin", configuration, dllname);
 
 			// This will build all the managed.dll variants, which is easier than calculating the relative path _as the makefile sees it_ to pass as the target.


### PR DESCRIPTION
Looks like some of my previous pull requests are partially missing from latest objc

Ive created this pull request to add back in the partial missing lines for extension support + also enabling of bitcode for iOS

https://github.com/mono/Embeddinator-4000/pull/514

https://github.com/mono/Embeddinator-4000/pull/540