### PR TITLE
[ObjC] Correctly marshall arrays of structrs

### DIFF
--- a/tests/managed/structs.cs
+++ b/tests/managed/structs.cs
@@ -38,4 +38,10 @@ namespace Structs {
 			return new Point (left.X - right.X, left.Y - right.Y);
 		}
 	}
+
+	public class Array 
+	{
+		public static Point [] Points => new Point [] { new Point (0, 0), new Point (1, 1), new Point (2, 2) };
+	}
+
 }

--- a/tests/objc-cli/libmanaged/Tests/Tests.m
+++ b/tests/objc-cli/libmanaged/Tests/Tests.m
@@ -270,6 +270,9 @@
 	Structs_Point* z = [Structs_Point zero];
 	XCTAssert ([z x] == 0.0f, "x 4");
 	XCTAssert ([z y] == 0.0f, "y 4");
+
+	NSArray<Structs_Point*>* points = [Structs_Array points];
+	XCTAssert ([points count] == 3, "count 0");
 }
 
 - (void) testEnums {

--- a/tests/objcgentest/xcodetemplate/macos/test/macTests.m
+++ b/tests/objcgentest/xcodetemplate/macos/test/macTests.m
@@ -44,11 +44,10 @@
     //managed_FSharp_UserRecord * resultUserRecord = [managed_FSharp useUserRecordUserRecord:userRecord];
     //XCTAssertEqualObjects(@"Test", [resultUserRecord userDescription]);
     
-    // https://github.com/mono/Embeddinator-4000/issues/631
-    //NSArray<managed_FSharp_UserStruct *> * userStructArray = [managed_FSharp_ArrayTest getDefaultUserStructArrayCount:10];
-    //XCTAssertEqual (10, [userRecordArray count]);
-    //for (managed_FSharp_UserStruct * entry in userStructArray)
-    //    XCTAssertEqualObjects(@"Fun!", [entry userDefinition]);
+    NSArray<managed_FSharp_UserStruct *> * userStructArray = [managed_FSharp_ArrayTest getDefaultUserStructArrayCount:10];
+    XCTAssertEqual (10, [userRecordArray count]);
+    for (managed_FSharp_UserStruct * entry in userStructArray)
+        XCTAssertEqualObjects(@"Fun!", [entry userDefinition]);
 
     managed_FSharp_UserStruct * userStruct = [managed_FSharp getDefaultUserStruct];
     XCTAssertEqualObjects(@"Fun!", [userStruct userDefinition]);


### PR DESCRIPTION
- https://github.com/mono/Embeddinator-4000/issues/636
- https://github.com/mono/Embeddinator-4000/issues/631
- Unlike single structs, which are boxed when we ask for them, arrays
must be handled special.
- We use mono_array_addr_with_size to get a pointer to the specific
element and then mono_value_box to box.
- This was discussed in https://github.com/mono/mono/issues/7808