### PR TITLE
Add redirect for github page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://docs.microsoft.com/en-us/xamarin/tools/dotnet-embedding/index</title>
+<meta http-equiv="refresh" content="0; URL=https://docs.microsoft.com/en-us/xamarin/tools/dotnet-embedding/index">
+<link rel="canonical" href="https://docs.microsoft.com/en-us/xamarin/tools/dotnet-embedding/index">


### PR DESCRIPTION
- Fix broken https://mono.github.io/Embeddinator-4000/ link caused by https://github.com/mono/Embeddinator-4000/commit/0a04d250c968efd4a178ce54362ecb9e068a4b17