### PR TITLE
[java] better logic for finding path to Java

### DIFF
--- a/binder/Utils/XamarinAndroid.cs
+++ b/binder/Utils/XamarinAndroid.cs
@@ -141,10 +141,8 @@ namespace Embeddinator
                     return GetFullPath(Combine(GetDirectoryName(javaBin), "../.."));
             }
 
-            if (string.IsNullOrEmpty(home))
-                throw new Exception("Cannot find Java SDK: JAVA_HOME environment variable is not set.");
-
-            return string.Empty;
+            //Last resort use AndroidSdk, which requires the Android SDK but has logic for finding Java on all platforms
+            return AndroidSdk.JavaSdkPath;
         });
 
         public static string JavaSdkPath => javaSdkPath.Value;


### PR DESCRIPTION
One of the most common issues Windows developers face when using E4K is a message such as:

    Cannot find Java SDK: JAVA_HOME environment variable is not set.

In fact, most Windows users don't set `JAVA_HOME` at all, since it is not something done system-wide by any installer.

Solution? Let's add a fallback to use `AndroidSdk.JavaSdkPath`.

`AndroidSdk` from `xamarin-android-tools` has very reliable logic for finding Java on all platforms. However, we haven't been using it in E4K for locating Java, because it _implicitly_ requires the Android SDK (see class name) be installed in order to work. See where `AndroidSdkInfo` throws here: https://github.com/xamarin/xamarin-android-tools/blob/b159597b15e0f8e302e0aec9efbf7c913d063e33/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs#L23

Using it as a last resort will make things alot simpler for our Windows users. If they have Xamarin.Android installed from VS 2017, everything will "Just Work".