### PR TITLE
Remove i386 default from objcgen

### DIFF
--- a/.cake/packages.config
+++ b/.cake/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.23.0" />
+    <package id="Cake" version="0.30.0" />
 </packages>

--- a/.cake/packages.config
+++ b/.cake/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.30.0" />
+    <package id="Cake" version="0.23.0" />
 </packages>

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -350,7 +350,7 @@ namespace Embeddinator.ObjC
 				case Platform.iOS:
 					build_infos = new BuildInfo[] {
 					new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: false), LinkerFlags = GetBitcodeFlag(defaultsToEnable: false) },
-					new BuildInfo { Sdk = "iPhoneSimulator", Architectures = new string [] { "x86_64" }, SdkName = "ios-simulator", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphonesimulator.sdk" },
+					new BuildInfo { Sdk = "iPhoneSimulator", Architectures = new string [] { "i386", "x86_64" }, SdkName = "ios-simulator", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphonesimulator.sdk" },
 				};
 					break;
 				case Platform.tvOS:
@@ -362,7 +362,7 @@ namespace Embeddinator.ObjC
 				case Platform.watchOS:
 					build_infos = new BuildInfo[] {
 					new BuildInfo { Sdk = "WatchOS", Architectures = new string [] { "armv7k" }, SdkName = "watchos", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchOS.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: true), LinkerFlags = GetBitcodeFlag(defaultsToEnable: true) },
-					new BuildInfo { Sdk = "WatchSimulator", Architectures = new string [] { "x86_64" }, SdkName = "watchos-simulator", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchSimulator.sdk" },
+					new BuildInfo { Sdk = "WatchSimulator", Architectures = new string [] { "i386" }, SdkName = "watchos-simulator", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchSimulator.sdk" },
 				};
 					break;
 				default:

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -285,6 +285,9 @@ namespace Embeddinator.ObjC
 			}
 		}
 
+		XcodeVersionCheck versionCheck = new XcodeVersionCheck ();
+		Version XcodeVersion => versionCheck.GetVersion (XcodeApp);
+
 		class BuildInfo
 		{
 			public string Sdk;
@@ -343,8 +346,14 @@ namespace Embeddinator.ObjC
 				case Platform.macOSFull:
 				case Platform.macOSModern:
 				case Platform.macOSSystem:
+					string[] macArchs = null;
+					if (Driver.CurrentEmbedder.XcodeVersion >= new Version (10, 0))
+						macArchs = new string[] { "x86_64" };
+					else
+						macArchs = new string[] { "i386", "x86_64" };
+
 					build_infos = new BuildInfo[] {
-					new BuildInfo { Sdk = "MacOSX", Architectures = new string [] { "x86_64" }, SdkName = "macosx", MinVersion = "10.7" },
+					new BuildInfo { Sdk = "MacOSX", Architectures = macArchs, SdkName = "macosx", MinVersion = "10.7" },
 				};
 					break;
 				case Platform.iOS:

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -344,13 +344,13 @@ namespace Embeddinator.ObjC
 				case Platform.macOSModern:
 				case Platform.macOSSystem:
 					build_infos = new BuildInfo[] {
-					new BuildInfo { Sdk = "MacOSX", Architectures = new string [] { "i386", "x86_64" }, SdkName = "macosx", MinVersion = "10.7" },
+					new BuildInfo { Sdk = "MacOSX", Architectures = new string [] { "x86_64" }, SdkName = "macosx", MinVersion = "10.7" },
 				};
 					break;
 				case Platform.iOS:
 					build_infos = new BuildInfo[] {
 					new BuildInfo { Sdk = "iPhoneOS", Architectures = new string [] { "armv7", "armv7s", "arm64" }, SdkName = "iphoneos", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphoneos.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: false), LinkerFlags = GetBitcodeFlag(defaultsToEnable: false) },
-					new BuildInfo { Sdk = "iPhoneSimulator", Architectures = new string [] { "i386", "x86_64" }, SdkName = "ios-simulator", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphonesimulator.sdk" },
+					new BuildInfo { Sdk = "iPhoneSimulator", Architectures = new string [] { "x86_64" }, SdkName = "ios-simulator", MinVersion = "8.0", XamariniOSSDK = "MonoTouch.iphonesimulator.sdk" },
 				};
 					break;
 				case Platform.tvOS:
@@ -362,7 +362,7 @@ namespace Embeddinator.ObjC
 				case Platform.watchOS:
 					build_infos = new BuildInfo[] {
 					new BuildInfo { Sdk = "WatchOS", Architectures = new string [] { "armv7k" }, SdkName = "watchos", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchOS.sdk", CompilerFlags = GetBitcodeFlag(defaultsToEnable: true), LinkerFlags = GetBitcodeFlag(defaultsToEnable: true) },
-					new BuildInfo { Sdk = "WatchSimulator", Architectures = new string [] { "i386" }, SdkName = "watchos-simulator", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchSimulator.sdk" },
+					new BuildInfo { Sdk = "WatchSimulator", Architectures = new string [] { "x86_64" }, SdkName = "watchos-simulator", MinVersion = "2.0", XamariniOSSDK = "Xamarin.WatchSimulator.sdk" },
 				};
 					break;
 				default:

--- a/objcgen/utils.cs
+++ b/objcgen/utils.cs
@@ -150,7 +150,7 @@ namespace Embeddinator.ObjC
 		{
 			string version_plist = GetXcodeVersionPath (xcode_path);
 			if (version_plist == null)
-				throw new InvalidOperationException ("Unable to find version information for xcode: " + xcode_path);
+				throw new InvalidOperationException ("Unable to find version information for Xcode: " + xcode_path);
 
 			return GetPListStringValue (version_plist, "CFBundleShortVersionString");
 		}

--- a/objcgen/utils.cs
+++ b/objcgen/utils.cs
@@ -135,4 +135,70 @@ namespace Embeddinator.ObjC
 			File.Copy (source, target, true);
 		}
 	}
+
+	class XcodeVersionCheck
+	{
+		Version version;
+		public Version GetVersion (string path)
+		{
+			if (version == null)
+				version = Version.Parse (GetXcodeVersion (path));
+			return version;
+		}
+
+		static string GetXcodeVersion (string xcode_path)
+		{
+			string version_plist = GetXcodeVersionPath (xcode_path);
+			if (version_plist == null)
+				throw new InvalidOperationException ("Unable to find version information for xcode: " + xcode_path);
+
+			return GetPListStringValue (version_plist, "CFBundleShortVersionString");
+		}
+
+		static string GetXcodeVersionPath (string xcode_path)
+		{
+			var version_plist = Path.Combine (xcode_path, "Contents/version.plist");
+			if (File.Exists (version_plist))
+				return version_plist;
+
+			version_plist = Path.Combine (xcode_path, "..", "version.plist");
+			if (File.Exists (version_plist))
+				return version_plist;
+
+			return null;
+		}
+
+		static string GetPListStringValue (string plist, string key)
+		{
+			var settings = new System.Xml.XmlReaderSettings ();
+			settings.DtdProcessing = System.Xml.DtdProcessing.Ignore;
+			var doc = new System.Xml.XmlDocument ();
+			using (var fs = new StringReader (ReadPListAsXml (plist))) {
+				using (var reader = System.Xml.XmlReader.Create (fs, settings)) {
+					doc.Load (reader);
+					return doc.DocumentElement.SelectSingleNode ($"//dict/key[text()='{key}']/following-sibling::string[1]/text()").Value;
+				}
+			}
+		}
+
+		public static string ReadPListAsXml (string path)
+		{
+			string tmpfile = null;
+			try {
+				tmpfile = Path.GetTempFileName ();
+				File.Copy (path, tmpfile, true);
+				using (var process = new System.Diagnostics.Process ()) {
+					process.StartInfo.FileName = "plutil";
+					process.StartInfo.Arguments = $"-convert xml1 {Utils.Quote (tmpfile)}";
+					process.Start ();
+					process.WaitForExit ();
+					return File.ReadAllText (tmpfile);
+				}
+			}
+			finally {
+				if (tmpfile != null)
+					File.Delete (tmpfile);
+			}
+		}
+	}
 }


### PR DESCRIPTION
i386 is no longer supported for macOS builds starting in Xcode 10. This also presumably applies to the various simulators, which I have changed as well.