### PR TITLE
[build] changes to fix the build on Travis CI

### DIFF
--- a/.cake/MyGet.config
+++ b/.cake/MyGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="Cake MyGet Feed" value="https://www.myget.org/F/cake/api/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/.cake/packages.config
+++ b/.cake/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.23.0" />
+    <package id="Cake" version="0.31.0" />
 </packages>

--- a/binder/Utils/XamarinAndroid.cs
+++ b/binder/Utils/XamarinAndroid.cs
@@ -127,7 +127,7 @@ namespace Embeddinator
         {
             // If we are running on macOS, invoke java_home to figure out Java path.
             if (Platform.IsMacOS)
-                return Helpers.Invoke("/usr/libexec/java_home", null, null).StandardOutput.Trim();
+                return Helpers.Invoke("/usr/libexec/java_home", $"-v {JavaVersion}").StandardOutput.Trim();
     
             string home = Environment.GetEnvironmentVariable("JAVA_HOME");
             if (!string.IsNullOrEmpty(home))

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 #!mono .cake/Cake/Cake.exe
-#tool "nuget:?package=NUnit.ConsoleRunner"
+#tool "nuget:?package=NUnit.ConsoleRunner&version=3.6.1"
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");

--- a/build.ps1
+++ b/build.ps1
@@ -166,7 +166,7 @@ if(-Not $SkipToolPackageRestore.IsPresent) {
     }
 
     Write-Verbose -Message "Restoring tools from NuGet..."
-    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`" -configfile MyGet.config"
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
 
     if ($LASTEXITCODE -ne 0) {
         Throw "An error occured while restoring NuGet tools."

--- a/build.sh
+++ b/build.sh
@@ -80,7 +80,7 @@ if [ ! -f $PACKAGES_CONFIG_MD5 ] || [ "$( cat $PACKAGES_CONFIG_MD5 | sed 's/\r$/
     find . -type d ! -name . | xargs rm -rf
 fi
 
-mono "$NUGET_EXE" install -ExcludeVersion -configfile MyGet.config
+mono "$NUGET_EXE" install -ExcludeVersion
 if [ $? -ne 0 ]; then
     echo "Could not restore NuGet packages."
     exit 1

--- a/build/Tests.cake
+++ b/build/Tests.cake
@@ -182,7 +182,7 @@ string GetJavaSdkPath()
     }
     else if (FileExists("/usr/libexec/java_home"))
     {
-        javaHome = CaptureProcessOutput("/usr/libexec/java_home");
+        javaHome = CaptureProcessOutput("/usr/libexec/java_home", "-v 1.8");
     }
     else
     {

--- a/objcgen/Make.config
+++ b/objcgen/Make.config
@@ -1,14 +1,14 @@
 # Minimum Mono version
-MIN_MONO_VERSION=5.16.0.220
-MAX_MONO_VERSION=5.16.0.220
-MIN_MONO_URL=https://download.mono-project.com/archive/5.16.0/macos-10-universal/MonoFramework-MDK-5.16.0.220.macos10.xamarin.universal.pkg
+MIN_MONO_VERSION=5.16.0.221
+MAX_MONO_VERSION=5.16.0.221
+MIN_MONO_URL=https://download.visualstudio.microsoft.com/download/pr/46c7e581-4431-4247-9290-0d8a01e9d13a/46083944a2325576a03158d60d36a41e/monoframework-mdk-5.16.0.221.macos10.xamarin.universal.pkg
 
 # Minimum Xamarin.iOS version
-MIN_XI_VERSION=11.6.1.3
-MAX_XI_VERSION=11.6.1.3
-MIN_XI_URL=https://dl.xamarin.com/MonoTouch/Mac/xamarin.ios-11.6.1.3.pkg
+MIN_XI_VERSION=12.2.1.12
+MAX_XI_VERSION=12.2.1.12
+MIN_XI_URL=https://download.visualstudio.microsoft.com/download/pr/ae5c9ea8-ff17-448b-ae5f-24c69c2d2a9b/d9d62c813492e750e999699aa8904e40/xamarin.ios-12.2.1.12.pkg
 
 # Minimum Xamarin.Mac version
-MIN_XM_VERSION=4.0.0.215
-MAX_XM_VERSION=4.0.0.215
-MIN_XM_URL=https://dl.xamarin.com/XamarinforMac/Mac/xamarin.mac-4.0.0.215.pkg
+MIN_XM_VERSION=5.2.1.12
+MAX_XM_VERSION=5.2.1.12
+MIN_XM_URL=https://download.visualstudio.microsoft.com/download/pr/f9f9988e-d20f-4a3f-afb0-ac331c87013c/e3b67ed938dbfd32811529e6670301ff/xamarin.mac-5.2.1.12.pkg

--- a/objcgen/Make.config
+++ b/objcgen/Make.config
@@ -1,7 +1,7 @@
 # Minimum Mono version
-MIN_MONO_VERSION=5.4.1.7
-MAX_MONO_VERSION=5.4.1.7
-MIN_MONO_URL=https://download.mono-project.com/archive/5.4.1/macos-10-universal/MonoFramework-MDK-5.4.1.7.macos10.xamarin.universal.pkg
+MIN_MONO_VERSION=5.16.0.220
+MAX_MONO_VERSION=5.16.0.220
+MIN_MONO_URL=https://download.mono-project.com/archive/5.16.0/macos-10-universal/MonoFramework-MDK-5.16.0.220.macos10.xamarin.universal.pkg
 
 # Minimum Xamarin.iOS version
 MIN_XI_VERSION=11.6.1.3

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -285,6 +285,9 @@ namespace Embeddinator.ObjC
 			}
 		}
 
+		XcodeVersionCheck versionCheck = new XcodeVersionCheck ();
+		Version XcodeVersion => versionCheck.GetVersion (XcodeApp);
+
 		class BuildInfo
 		{
 			public string Sdk;
@@ -343,8 +346,14 @@ namespace Embeddinator.ObjC
 				case Platform.macOSFull:
 				case Platform.macOSModern:
 				case Platform.macOSSystem:
+					string[] macArchs = null;
+					if (Driver.CurrentEmbedder.XcodeVersion >= new Version (10, 0))
+						macArchs = new string[] { "x86_64" };
+					else
+						macArchs = new string[] { "i386", "x86_64" };
+
 					build_infos = new BuildInfo[] {
-					new BuildInfo { Sdk = "MacOSX", Architectures = new string [] { "i386", "x86_64" }, SdkName = "macosx", MinVersion = "10.7" },
+					new BuildInfo { Sdk = "MacOSX", Architectures = macArchs, SdkName = "macosx", MinVersion = "10.7" },
 				};
 					break;
 				case Platform.iOS:

--- a/tests/objc-cli/Makefile
+++ b/tests/objc-cli/Makefile
@@ -73,7 +73,7 @@ test-xctest-leaks: ../leaktest/bin/Debug/leaktest.exe $(MANAGED_DLL) debug/libma
 	mono --debug ../leaktest/bin/Debug/leaktest.exe `xcrun -f xctest` -XCTest All $(abspath libmanaged/Tests.xctest)
 
 libLeakCheckAtExit.dylib: leak-at-exit.c
-	clang -arch i386 -arch x86_64 -shared $< -o $@
+	clang -arch x86_64 -shared $< -o $@
 
 test-static: test-static-macos test-static-ios test-static-tvos test-static-watchos
 

--- a/tests/objcgentest/EmbedderTest.cs
+++ b/tests/objcgentest/EmbedderTest.cs
@@ -24,7 +24,7 @@ namespace DriverTest
 				valid = "armv7, armv7s, arm64, i386, x86_64";
 				break;
 			case Platform.macOS:
-				valid = "i386, x86_64";
+				valid = "x86_64";
 				break;
 			case Platform.tvOS:
 				valid = "arm64, x86_64";

--- a/tests/objcgentest/ManagedTest.cs
+++ b/tests/objcgentest/ManagedTest.cs
@@ -222,7 +222,7 @@ namespace ExecutionTests
 				case Platform.macOS:
 					Dlldir = "generic";
 					Dllname = "managed.dll";
-					Abi = "i386,x86_64";
+					Abi = "x86_64";
 					return;
 				case Platform.iOS:
 					Dlldir = "ios";


### PR DESCRIPTION
Context: https://travis-ci.org/mono/Embeddinator-4000/jobs/471012684
Context: https://travis-ci.org/mono/Embeddinator-4000/jobs/471026456
Context: https://travis-ci.org/mono/Embeddinator-4000/jobs/471037351

First issue we are hitting is a missing version of Cake on MyGet:

    Unable to find version '0.23.0' of package 'Cake'.
      https://www.myget.org/F/cake/api/v3/index.json: Package 'Cake.0.23.0' is not found on source 'https://www.myget.org/F/cake/api/v3/index.json'.

To fix this:

- Let's remove `MyGet.config` and just use NuGet
- Update Cake to 0.31, I recently used that version on another project

Next issue is that the build will not work using JDK 10:

    Compiling binding code...
        Invoking: /usr/libexec/java_home
            /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home
        Invoking: /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home/bin/javac
    ...
    Fatal Error: Unable to find package java.lang in classpath or bootclasspath

To fix this we should use the `-v 1.8` switch on every call to `java_home`.

Next issue is that we aren't specifying a version with the `#tool`
directive:

    The 'tool' directive is attempting to install the 'NUnit.ConsoleRunner' package
    without specifying a package version number.