### PR TITLE
[objcgen] Fix shellcheck warning.

### DIFF
--- a/objcgen/thin-framework.sh
+++ b/objcgen/thin-framework.sh
@@ -67,7 +67,7 @@ while PLATFORM=$(/usr/libexec/PlistBuddy -c "Print :CFBundleSupportedPlatforms:$
 	if [[ $PLATFORM == *Simulator* ]]; then
 		/usr/libexec/PlistBuddy -c "Remove :CFBundleSupportedPlatforms:$C" "$OUT_FRAMEWORK/Info.plist"
 	else
-		let C++ || true
+		(( C++ ))
 	fi
 done
 


### PR DESCRIPTION
Fixes this warning:

    In thin-framework.sh line 70:
    		let C++ || true
                    ^------^ SC2219: Instead of 'let expr', prefer (( expr )) .

    For more information:
      https://www.shellcheck.net/wiki/SC2219 -- Instead of 'let expr', prefer (( ...
    make: *** [shellcheck] Error 1