### PR TITLE
[objcgen] fix error MM0073 when building with Xamarin.Mac 4.8 or later

### DIFF
--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -353,7 +353,7 @@ namespace Embeddinator.ObjC
 						macArchs = new string[] { "i386", "x86_64" };
 
 					build_infos = new BuildInfo[] {
-					new BuildInfo { Sdk = "MacOSX", Architectures = macArchs, SdkName = "macosx", MinVersion = "10.7" },
+					new BuildInfo { Sdk = "MacOSX", Architectures = macArchs, SdkName = "macosx", MinVersion = "10.9" },
 				};
 					break;
 				case Platform.iOS:


### PR DESCRIPTION
Xamarin.Mac 4.8 only supports macOS 10.9 (Mavericks) or higher.
fixes https://github.com/mono/Embeddinator-4000/issues/732