### PR TITLE
[build] fixup the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,7 @@ install:
   - source build/SetupCI.sh
 
 script: |
+  which java
+  java --version
+  echo $JAVA_HOME
   ./build.sh -t Travis -v diagnostic


### PR DESCRIPTION
Fixes: https://github.com/mono/Embeddinator-4000/issues/716

The beginning of this is troubleshooting Java 8 on TravisCI.