### PR TITLE
VS 2019 Refresh

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,42 @@
+# https://aka.ms/yaml
+
+name: $(BuildID)
+
+trigger:
+- master
+
+variables:
+  Mono.Windows.Url: https://download.mono-project.com/archive/6.0.0/windows-installer/mono-6.0.0.319-gtksharp-2.12.45-win32-0.msi
+  SdkManager.Windows: 'C:\Program Files (x86)\Android\android-sdk\tools\bin\sdkmanager'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+jobs:
+
+- job: windows
+  pool:
+    name: Hosted VS2017
+    demands: msbuild
+  steps:
+  - powershell: |
+      echo y | & "$(SdkManager.Windows)" ndk-bundle
+    displayName: install Android NDK
+  - powershell: |
+      Invoke-WebRequest $(Mono.Windows.Url) -OutFile mono.msi -Verbose
+      Start-Process msiexec -Wait -ArgumentList '/i mono.msi /quiet /l*v mono.log'
+      Get-Content mono.log
+    displayName: install mono
+  - powershell: |
+      .\build.ps1 -t Jenkins -v diagnostic
+    displayName: build and test
+
+- job: mac
+  pool:
+    name: Hosted macOS
+    demands: msbuild
+  steps:
+  - bash: |
+      source build/SetupCI.sh
+    displayName: setup ci
+  - bash: |
+      ./build.sh -t Travis -v diagnostic
+    displayName: build and test

--- a/build.cake
+++ b/build.cake
@@ -34,7 +34,7 @@ Task("Build-Binder")
     .IsDependentOn("NuGet-Restore")
     .Does(() =>
     {
-        MSBuild("./build/projects/Embeddinator-4000.csproj", settings => settings.SetConfiguration(configuration));
+        MSBuild("./build/projects/Embeddinator-4000.csproj", MSBuildSettings());
     });
 
 Task("Generate-Project-Files")

--- a/build.ps1
+++ b/build.ps1
@@ -89,7 +89,7 @@ if(!$PSScriptRoot){
 $TOOLS_DIR = Join-Path $PSScriptRoot ".cake"
 $NUGET_EXE = Join-Path $PSScriptRoot ".cake/nuget.exe"
 $CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
-$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/v4.7.3/nuget.exe"
 $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
 $PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 

--- a/build.sh
+++ b/build.sh
@@ -67,7 +67,7 @@ fi
 # Download NuGet if it does not exist.
 if [ ! -f "$NUGET_EXE" ]; then
     echo "Downloading NuGet..."
-    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/v4.7.3/nuget.exe
     if [ $? -ne 0 ]; then
         echo "An error occured while downloading nuget.exe."
         exit 1

--- a/build/Tests.cake
+++ b/build/Tests.cake
@@ -11,8 +11,7 @@ Task("Build-Managed")
     .IsDependentOn("NuGet-Restore")
     .Does(() =>
     {
-        MSBuild("./tests/managed/generic/managed-generic.csproj", settings =>
-            settings.SetConfiguration(configuration));
+        MSBuild("./tests/managed/generic/managed-generic.csproj", MSBuildSettings());
     });
 
 Task("Build-Android")
@@ -20,8 +19,7 @@ Task("Build-Android")
     .IsDependentOn("NuGet-Restore")
     .Does(() =>
     {
-        MSBuild("./tests/managed/android/managed-android.csproj", settings =>
-            settings.SetConfiguration(configuration).SetPlatformTarget(PlatformTarget.MSIL));
+        MSBuild("./tests/managed/android/managed-android.csproj", MSBuildSettings().SetPlatformTarget(PlatformTarget.MSIL));
     });
 
 Task("Build-FSharp-Android")
@@ -29,8 +27,7 @@ Task("Build-FSharp-Android")
     .IsDependentOn("NuGet-Restore")
     .Does(() =>
     {
-        MSBuild("./tests/managed/fsharp-android/fsharp-android.fsproj", settings =>
-            settings.SetConfiguration(configuration).SetPlatformTarget(PlatformTarget.MSIL));
+        MSBuild("./tests/managed/fsharp-android/fsharp-android.fsproj", MSBuildSettings().SetPlatformTarget(PlatformTarget.MSIL));
     });
 
 Task("Build-FSharp-Generic")
@@ -38,8 +35,7 @@ Task("Build-FSharp-Generic")
     .IsDependentOn("NuGet-Restore")
     .Does(()=>
     {
-        MSBuild("./tests/managed/fsharp-generic/fsharp-generic.fsproj", settings =>
-            settings.SetConfiguration(configuration).SetPlatformTarget(PlatformTarget.MSIL));
+        MSBuild("./tests/managed/fsharp-generic/fsharp-generic.fsproj", MSBuildSettings().SetPlatformTarget(PlatformTarget.MSIL));
     });
 
 Task("Build-PCL")
@@ -47,8 +43,7 @@ Task("Build-PCL")
     .IsDependentOn("NuGet-Restore")
     .Does(() =>
     {
-        MSBuild("./tests/managed/pcl/managed-pcl.csproj", settings =>
-            settings.SetConfiguration(configuration).SetPlatformTarget(PlatformTarget.MSIL));
+        MSBuild("./tests/managed/pcl/managed-pcl.csproj", MSBuildSettings().SetPlatformTarget(PlatformTarget.MSIL));
     });
 
 Task("Build-NetStandard")
@@ -58,7 +53,7 @@ Task("Build-NetStandard")
     {
         var project = "./tests/managed/netstandard/managed-netstandard.csproj";
         DotNetCoreRestore(project);
-        MSBuild(project, settings => settings.SetConfiguration(configuration).SetPlatformTarget(PlatformTarget.MSIL));
+        MSBuild(project, MSBuildSettings().SetPlatformTarget(PlatformTarget.MSIL));
     });
 
 Task("Build-CSharp-Tests")
@@ -66,7 +61,7 @@ Task("Build-CSharp-Tests")
     .IsDependentOn("Build-Managed")
     .Does(() =>
     {
-        MSBuild("./tests/MonoEmbeddinator4000.Tests/MonoEmbeddinator4000.Tests.csproj", settings => settings.SetConfiguration(configuration));
+        MSBuild("./tests/MonoEmbeddinator4000.Tests/MonoEmbeddinator4000.Tests.csproj", MSBuildSettings());
     });
 
 Task("Run-CSharp-Tests")
@@ -108,9 +103,7 @@ Task("Build-C-Tests")
 
         // Execute the build files.
         if (IsRunningOnWindows())
-            MSBuild(mkDir + File("mk.sln"), settings =>
-                settings.SetConfiguration(configuration)
-                        .SetPlatformTarget(PlatformTarget.Win32));
+            MSBuild(mkDir + File("mk.sln"), MSBuildSettings().SetPlatformTarget(PlatformTarget.Win32));
         else
         {
             var envVars = new Dictionary<string, string> ();

--- a/build/Utils.cake
+++ b/build/Utils.cake
@@ -59,3 +59,41 @@ void Premake(string file, string args, string action)
         File("premake5.exe") : IsRunningOnMacOS() ? File("premake5-osx") : File("premake5-linux-64"));
     Exec(premakePath, $"--file={file} {args} {action}");
 }
+
+MSBuildSettings MSBuildSettings()
+{
+    var settings = new MSBuildSettings { Configuration = configuration };
+
+    if (IsRunningOnWindows())
+    {
+        // Find MSBuild for Visual Studio 2019 and newer
+        DirectoryPath vsLatest = VSWhereLatest();
+        FilePath msBuildPath = vsLatest?.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe");
+
+        // Find MSBuild for Visual Studio 2017
+        if (msBuildPath != null && !FileExists(msBuildPath))
+            msBuildPath = vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+
+        // Have we found MSBuild yet?
+        if (!FileExists(msBuildPath))
+        {
+            throw new Exception($"Failed to find MSBuild: {msBuildPath}");
+        }
+
+        Information("Building using MSBuild at " + msBuildPath);
+        settings.ToolPath = msBuildPath;
+
+        var java_home = Environment.GetEnvironmentVariable("JAVA_HOME_8_X64");
+        if (!string.IsNullOrEmpty(java_home))
+        {
+            Information("JAVA_HOME_8_X64 set: " + java_home);
+            settings = settings.WithProperty("JavaSdkDirectory", java_home);
+        }
+    }
+    else
+    {
+        settings.ToolPath = Context.Tools.Resolve("msbuild");
+    }
+
+    return settings;
+}

--- a/support/mono-support.h
+++ b/support/mono-support.h
@@ -89,7 +89,9 @@ typedef struct _GString GString;
 
 /* utils/mono-publib.h */
 typedef int32_t	mono_bool;
+#ifndef _WIN32
 typedef uint16_t mono_unichar2;
+#endif
 
 /* metadata/image.h */
 typedef struct _MonoAssembly MonoAssembly;


### PR DESCRIPTION
* Setup Azure DevOps for CI
  * Install Android NDK Bundle on Windows build agents
  * Workaround for `JAVA_HOME` on Windows build agents
* Support for Android NDK r19 and r20
* Updated Cake scripts to support VS 2019 on Windows
* Pin NuGet download URL to v4.7.3
* Bump to xamarin/xamarin-android-tools/master@294f447
  * Changes: https://github.com/xamarin/xamarin-android-tools/compare/4c00c22...294f447
* Fix for `mono-support.h` on Windows

Fixes: https://github.com/mono/Embeddinator-4000/issues/716
Fixes:

    c:\program files (x86)\mono\include\mono-2.0\mono\utils\mono-publib.h(94): error C2371: 'mono_unichar2': redefinition; different basic types [D:\a\1\s\tests\common\mk\common.Tests.vcxproj]