### PR TITLE
mono-support.h:36:10: error: 'xamarin/xamarin.h' file not found

### DIFF
--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -437,6 +437,7 @@ namespace Embeddinator.ObjC
 			 */
 
 			foreach (var build_info in build_infos) {
+				lipo_files.Clear();
 				foreach (var arch in build_info.Architectures) {
 					var archOutputDirectory = Path.Combine (OutputDirectory, arch);
 					Directory.CreateDirectory (archOutputDirectory);
@@ -483,7 +484,7 @@ namespace Embeddinator.ObjC
 						case Platform.iOS:
 						case Platform.tvOS:
 						case Platform.watchOS:
-							common_options.Append ($"-I/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/SDKs/{build_info.XamariniOSSDK}/usr/include ");
+							common_options.Append ($"-I/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/SDKs/{build_info.XamariniOSSDK}/include ");
 							common_options.Append ("-DXAMARIN_IOS ");
 							break;
 						default:
@@ -524,7 +525,7 @@ namespace Embeddinator.ObjC
 							options.Append ($"-o ").Append (Utils.Quote (dynamic_ofile)).Append (" ");
 							lipo_files.Add (dynamic_ofile);
 							if (!string.IsNullOrEmpty (build_info.XamariniOSSDK)) {
-								options.Append ($"-L/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/SDKs/{build_info.XamariniOSSDK}/usr/lib ");
+								options.Append ($"-L/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/SDKs/{build_info.XamariniOSSDK}/lib ");
 								options.Append ("-lxamarin ");
 							}
 							else {

--- a/objcgen/embedder.cs
+++ b/objcgen/embedder.cs
@@ -478,7 +478,7 @@ namespace Embeddinator.ObjC
 						case Platform.macOSSystem:
 						case Platform.macOSModern:
 						case Platform.macOSFull:
-							common_options.Append ("-I/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/include ");
+							common_options.Append ("-I/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/SDKs/Xamarin.macOS.sdk/include ");
 							common_options.Append ("-DXAMARIN_MAC ");
 							break;
 						case Platform.iOS:


### PR DESCRIPTION
Path of "include" and "lib" directory for MonoTouch.*.sdk has been changed. 

Example: 
Old Path: /Library/Frameworks/Xamarin.iOS.framework/Versions/14.2.0.12/SDKs/MonoTouch.iphonesimulator.sdk/usr/include
New Path: /Library/Frameworks/Xamarin.iOS.framework/Versions/14.14.2.5/SDKs/MonoTouch.iphonesimulator.sdk/include

Path has been updated to resolve this issue.